### PR TITLE
docs: close sweep gaps and enforce chat auth token

### DIFF
--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,180 @@
+---
+layout: default
+title: KafClaw Architecture
+---
+
+<style>
+  :root {
+    --bg: #f5f7fb;
+    --panel: #ffffff;
+    --ink: #172338;
+    --muted: #4e5c73;
+    --line: #d7dfea;
+    --primary: #0f5fff;
+    --accent: #17b890;
+  }
+  .kc-arch-wrap {
+    margin: 0 auto;
+    max-width: 1100px;
+    color: var(--ink);
+    font-family: "Avenir Next", "Segoe UI", "Helvetica Neue", sans-serif;
+  }
+  .kc-arch-hero {
+    background: linear-gradient(125deg, #0f5fff 0%, #1342a6 55%, #0f2a6b 100%);
+    color: #fff;
+    border-radius: 14px;
+    padding: 28px;
+    box-shadow: 0 14px 36px rgba(17, 43, 101, 0.28);
+  }
+  .kc-arch-hero h1 {
+    margin: 0 0 8px;
+    font-size: 2rem;
+    line-height: 1.2;
+  }
+  .kc-arch-hero p {
+    margin: 0;
+    font-size: 1.05rem;
+    opacity: 0.95;
+  }
+  .kc-grid {
+    display: grid;
+    gap: 16px;
+    margin-top: 20px;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+  }
+  .kc-card {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 16px;
+    box-shadow: 0 8px 22px rgba(26, 43, 80, 0.08);
+  }
+  .kc-card h2 {
+    margin: 0 0 10px;
+    font-size: 1.05rem;
+  }
+  .kc-card p,
+  .kc-card li {
+    color: var(--muted);
+  }
+  .kc-kafka { grid-column: span 12; }
+  .kc-agent { grid-column: span 6; }
+  .kc-support { grid-column: span 4; }
+  .kc-flow { grid-column: span 12; }
+  .kc-chip {
+    display: inline-block;
+    margin: 3px 6px 3px 0;
+    padding: 4px 10px;
+    border-radius: 999px;
+    border: 1px solid #bdd0ff;
+    background: #eef3ff;
+    color: #163a86;
+    font-size: 0.82rem;
+    font-weight: 600;
+  }
+  .kc-flow svg {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+  .kc-note {
+    margin-top: 12px;
+    padding: 10px 12px;
+    border-left: 4px solid var(--accent);
+    background: #e9faf5;
+    color: #17584a;
+    border-radius: 8px;
+  }
+  @media (max-width: 900px) {
+    .kc-agent, .kc-support { grid-column: span 12; }
+  }
+</style>
+
+<div class="kc-arch-wrap">
+  <div class="kc-arch-hero">
+    <h1>KafClaw Architecture</h1>
+    <p>Kafka-native coordination for local assistants, peer groups, and hierarchical multi-agent systems.</p>
+  </div>
+
+  <div class="kc-grid">
+    <section class="kc-card kc-kafka">
+      <h2>Kafka Backbone</h2>
+      <p>All collaboration flows through typed envelopes over Kafka topics, enabling traceability and reliable routing across agents.</p>
+      <span class="kc-chip">announce</span>
+      <span class="kc-chip">request</span>
+      <span class="kc-chip">response</span>
+      <span class="kc-chip">trace</span>
+      <span class="kc-chip">memory</span>
+      <span class="kc-chip">audit</span>
+      <span class="kc-chip">orchestrator</span>
+      <span class="kc-chip">skill channels</span>
+    </section>
+
+    <section class="kc-card kc-agent">
+      <h2>Full Agent Runtime (Go)</h2>
+      <ul>
+        <li>Agent loop with provider abstraction</li>
+        <li>Tool framework (filesystem, shell, memory, web)</li>
+        <li>Policy engine for safe execution</li>
+        <li>Timeline DB (SQLite) for events and traces</li>
+      </ul>
+    </section>
+
+    <section class="kc-card kc-agent">
+      <h2>Lightweight Agents (Any Language)</h2>
+      <ul>
+        <li>Use only Kafka + JSON envelope schema</li>
+        <li>Join group topics and skill channels</li>
+        <li>Participate without SDK lock-in</li>
+        <li>Suitable for scripts, services, and bridges</li>
+      </ul>
+    </section>
+
+    <section class="kc-card kc-support">
+      <h2>Channels</h2>
+      <p>WhatsApp, Telegram, CLI, and Web UI connect users and operators to the agent network.</p>
+    </section>
+
+    <section class="kc-card kc-support">
+      <h2>Shared Memory</h2>
+      <p>Persistent memory and ephemeral context allow agents to reuse and route knowledge over time.</p>
+    </section>
+
+    <section class="kc-card kc-support">
+      <h2>Orchestration</h2>
+      <p>Hierarchy + zones define who can see what and how delegation is safely performed.</p>
+    </section>
+
+    <section class="kc-card kc-flow">
+      <h2>System Flow</h2>
+      <svg viewBox="0 0 1080 320" role="img" aria-label="KafClaw architecture flow diagram">
+        <defs>
+          <marker id="arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto">
+            <polygon points="0,0 10,4 0,8" fill="#335ea8"></polygon>
+          </marker>
+        </defs>
+        <rect x="390" y="20" width="300" height="70" rx="10" fill="#eaf1ff" stroke="#8ea9df"></rect>
+        <text x="540" y="48" text-anchor="middle" font-size="18" font-weight="700" fill="#173b87">Apache Kafka</text>
+        <text x="540" y="69" text-anchor="middle" font-size="12" fill="#335ea8">control • tasks • memory • orchestrator • skills</text>
+
+        <rect x="110" y="140" width="270" height="120" rx="10" fill="#ffffff" stroke="#cfd9ea"></rect>
+        <text x="245" y="168" text-anchor="middle" font-size="16" font-weight="700" fill="#1e2c43">Agent A (Full Runtime)</text>
+        <text x="245" y="192" text-anchor="middle" font-size="12" fill="#465a77">Loop • Tools • Timeline • Policy</text>
+        <text x="245" y="212" text-anchor="middle" font-size="12" fill="#465a77">Memory • Provider • Channels</text>
+
+        <rect x="700" y="140" width="270" height="120" rx="10" fill="#ffffff" stroke="#cfd9ea"></rect>
+        <text x="835" y="168" text-anchor="middle" font-size="16" font-weight="700" fill="#1e2c43">Agent B (Any Language)</text>
+        <text x="835" y="192" text-anchor="middle" font-size="12" fill="#465a77">Kafka Producer / Consumer</text>
+        <text x="835" y="212" text-anchor="middle" font-size="12" fill="#465a77">JSON Envelopes + Skill Topics</text>
+
+        <line x1="245" y1="140" x2="455" y2="90" stroke="#335ea8" stroke-width="2.5" marker-end="url(#arrow)"></line>
+        <line x1="835" y1="140" x2="625" y2="90" stroke="#335ea8" stroke-width="2.5" marker-end="url(#arrow)"></line>
+        <line x1="500" y1="260" x2="580" y2="260" stroke="#17b890" stroke-width="3"></line>
+        <text x="540" y="282" text-anchor="middle" font-size="12" fill="#26705e">request/response + trace + memory exchange</text>
+      </svg>
+      <div class="kc-note">
+        KafClaw supports both full-featured Go agents and lightweight non-Go agents in the same collaboration fabric.
+      </div>
+    </section>
+  </div>
+</div>

--- a/docs/concepts/how-agents-work.md
+++ b/docs/concepts/how-agents-work.md
@@ -1,0 +1,55 @@
+# How Agents Work
+
+This page describes the live runtime path from message input to response output.
+
+## Runtime Flow
+
+1. Inbound message enters via a channel (CLI, Web UI, WhatsApp, Slack, Teams, etc.)
+2. Message is published to the internal bus
+3. Agent loop consumes inbound event
+4. Context builder assembles system prompt:
+   - runtime identity block
+   - workspace identity files (`AGENTS.md`, `SOUL.md`, `USER.md`, `TOOLS.md`, `IDENTITY.md`)
+   - `memory/MEMORY.md` (if present)
+   - tool summary and system-repo skills (if available)
+5. Model responds, optionally issuing tool calls
+6. Tool policy evaluates requested calls
+7. Tool results are fed back into loop (up to configured iteration limit)
+8. Final response is stored, indexed, and published as outbound message
+
+## Default Tool Registration
+
+The loop registers these tools by default:
+
+- `read_file`
+- `write_file`
+- `edit_file`
+- `list_dir`
+- `resolve_path`
+- `exec`
+- `sessions_spawn`
+- `subagents`
+- `agents_list`
+
+When memory service is enabled, it also registers:
+
+- `remember`
+- `recall`
+
+## Group and Orchestrator Identity
+
+When group mode is enabled:
+
+- agent identity is built from runtime + workspace files
+- capabilities are exported from active tool registry
+- onboarding/announce messages publish identity to group control topics
+- roster and timeline persist identity snapshots
+
+## Auto-Scaffold and Startup Behavior
+
+At gateway startup:
+
+- if workspace identity files are missing, scaffold runs automatically (non-destructive)
+- if memory service is enabled, soul files are indexed in background
+
+This makes headless and container setups self-healing for missing baseline files.

--- a/docs/concepts/runtime-tools.md
+++ b/docs/concepts/runtime-tools.md
@@ -1,0 +1,40 @@
+# Runtime Tools and Capabilities
+
+This is the runtime-accurate tool view for current Go agent loop behavior.
+
+## Why This Page Exists
+
+`TOOLS.md` is part of the prompt and guidance, but tools become real capabilities only when registered in the loop.
+
+## Currently Registered by Default
+
+- `read_file`
+- `write_file`
+- `edit_file`
+- `list_dir`
+- `resolve_path`
+- `exec`
+- `sessions_spawn`
+- `subagents`
+- `agents_list`
+
+Conditional:
+
+- `remember` (memory service required)
+- `recall` (memory service required)
+
+## Capability Export to Group
+
+Group identity announcements use registered tool names as capability list.
+If registration changes, group-visible capabilities change automatically.
+
+## Tool Safety Model
+
+- Tools may declare risk tiers: read-only, write, high-risk
+- Shell execution has workspace restrictions and guardrails
+- Write tools are work-repo scoped through repo path getters
+
+For operational policy and hardening, see:
+
+- `docs/v2/security-risks.md`
+- `docs/v2/admin-guide.md`

--- a/docs/concepts/soul-identity-tools.md
+++ b/docs/concepts/soul-identity-tools.md
@@ -1,0 +1,67 @@
+# Soul and Identity Files
+
+KafClaw agents are shaped by a workspace-level file set scaffolded during onboarding.
+
+## The File Set
+
+Onboarding and workspace scaffold use this canonical order:
+
+1. `AGENTS.md`
+2. `SOUL.md`
+3. `USER.md`
+4. `TOOLS.md`
+5. `IDENTITY.md`
+
+These files are embedded templates in the codebase and can be overwritten with `kafclaw onboard --force`.
+
+## How Runtime Uses These Files
+
+### 1. System prompt construction
+
+At runtime, the context builder loads all files above from the workspace and appends them to the system prompt.
+
+- Missing files are skipped
+- Existing files are included as-is
+- Order is stable and shared with indexing/scaffolding
+
+### 2. Group identity announcement
+
+When joining a Kafka group, identity metadata is derived as follows:
+
+- `SoulSummary`: first paragraph from `SOUL.md` (heading lines are ignored)
+- `Capabilities`: names of currently registered tools
+- `Channels`: starts with `cli` (then channel-specific fields may be added by gateway setup)
+
+This identity is announced in group onboarding and roster messages.
+
+### 3. Memory indexing
+
+If memory is enabled, all identity files are chunked and indexed as `source=soul:<filename>`.
+Soul entries are treated as permanent memory (not pruned by TTL lifecycle).
+
+## Practical Authoring Guidance
+
+### `SOUL.md`
+
+Put stable values and behavior traits in the first paragraph if you want group peers to see them in `SoulSummary`.
+
+### `AGENTS.md`
+
+Use for operational behavior and working rules (tool usage patterns, action policy, collaboration style).
+
+### `TOOLS.md`
+
+Treat this as human-readable guidance for tool intent and conventions. It does not dynamically register tools by itself.
+
+### `IDENTITY.md`
+
+Use for architecture role, capabilities narrative, and deployment context.
+
+### `USER.md`
+
+Use for owner/user profile, preferences, timezone, and project context.
+
+## Important Distinction
+
+`TOOLS.md` describes tools, but actual capabilities in runtime come from tool registration in Go code.
+If docs and runtime diverge, runtime registration is source of truth.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,30 +10,75 @@ KafClaw is a Go-based agent runtime with three practical deployment modes:
 - `local-kafka`: local runtime connected to Kafka/group orchestration
 - `remote`: headless gateway reachable over network (token required)
 
+## Ecosystem
+
+- **KafScale** ([`@kafscale`](https://github.com/kafscale), [kafscale.io](https://kafscale.io)): Kafka-compatible and S3-compatible data plane used for durable event transport and large artifact flows in agent systems.
+- **GitClaw** (in this KafClaw repository): agentic, self-hosted GitHub replacement focused on autonomous repository workflows and automation.
+- **KafClaw**: runtime and coordination layer for local, Kafka-connected, and remote/headless agents.
+
+## Why KafClaw
+
+KafClaw gives teams an enterprise-ready way to run and coordinate autonomous agents over Apache Kafka.
+Instead of locking agents to one model, one language, or one SDK, it uses a typed Kafka message protocol so any runtime that can read and write JSON envelopes can participate.
+
+What this enables in practice:
+
+- Reliable multi-agent collaboration with correlation IDs, timestamps, and trace-friendly envelopes
+- Group and hierarchy orchestration with role boundaries and scoped visibility
+- Shared memory and skill routing so agents can reuse knowledge across sessions
+- Flexible deployment from a single local assistant to a Kafka-connected production gateway
+
+In short: Kafka is the backbone, and KafClaw is the coordination layer that keeps heterogeneous agents working together safely and observably.
+
 ## Start Here
 
 - [Getting Started](./getting-started.md) - install, onboard, first run
+- [Manage KafClaw](./manage-kafclaw.md) - operator runbook for CLI, health checks, group and bridge operations
 - [Operations and Maintenance](./maintenance.md) - runbook for updates, checks, backups, troubleshooting
+- [Architecture Visual (HTML)](./architecture.html) - system overview diagram and component map
 
-## Core References (v2)
+## Agent Concepts
+
+- [How Agents Work](./concepts/how-agents-work.md) - end-to-end runtime flow from inbound message to outbound response
+- [Soul and Identity Files](./concepts/soul-identity-tools.md) - what `AGENTS.md`, `SOUL.md`, `USER.md`, `TOOLS.md`, `IDENTITY.md` do
+- [Runtime Tools and Capabilities](./concepts/runtime-tools.md) - actual tools registered by the Go runtime
+
+## Integrations
+
+- [Slack and Teams Bridge](./v2/slack-teams-bridge.md)
+- [WhatsApp Setup](./v2/whatsapp-setup.md)
+- [WhatsApp Onboarding](./v2/whatsapp-onboarding.md)
+
+## Operations and Admin
+
+- [Admin Guide](./v2/admin-guide.md)
+- [Operations Guide](./v2/operations-guide.md)
+- [Docker Deployment](./v2/docker-deployment.md)
+- [Release Guide](./v2/release.md)
+
+## Architecture and Security
+
+- [Architecture Overview](./v2/architecture.md)
+- [Detailed Architecture](./v2/architecture-detailed.md)
+- [Timeline Architecture](./v2/architecture-timeline.md)
+- [Security Risks](./v2/security-risks.md)
+- [Subagents Threat Model](./v2/subagents-threat-model.md)
+
+## Full v2 Reference Set
 
 - [v2 Index](./v2/index.md)
 - [User Manual](./v2/user-manual.md)
-- [Operations Guide](./v2/operations-guide.md)
-- [Admin Guide](./v2/admin-guide.md)
-- [Architecture Overview](./v2/architecture.md)
-- [Detailed Architecture](./v2/architecture-detailed.md)
-- [Security Risks](./v2/security-risks.md)
-- [Release Guide](./v2/release.md)
 
 ## Security Baseline
 
 - Default bind is loopback: `127.0.0.1`
-- Remote mode requires auth token
+- Remote/headless mode should use auth token for dashboard API
+- When `gateway.authToken` is set, both dashboard API and `POST /chat` require bearer auth (dashboard keeps `/api/v1/status` open for health checks)
 - Use `kafclaw doctor` for diagnostics
 - Use `kafclaw doctor --fix` for env merge and permissions hygiene
 
 ## Repository Docs Areas
 
-- `docs/v2/` - primary product and operations docs
+- `docs/concepts/` - runtime behavior and core mental models
+- `docs/v2/` - full product and operations reference set
 - `docs/security/` - security audits and roadmap

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -25,7 +25,8 @@ For env hygiene and permissions:
   - group/orchestrator: on
 - `remote`
   - bind: typically `0.0.0.0` or specific LAN IP
-  - auth token: required
+  - dashboard auth token: strongly recommended
+  - with auth token configured, both dashboard API and `POST /chat` require bearer auth
 
 If you intentionally run remote, do not force loopback defaults.
 
@@ -106,7 +107,8 @@ Then restart runtime/service.
   - check `gateway.host`
   - check firewall ports `18790`, `18791`
 - Remote mode blocked:
-  - ensure auth token exists
+  - ensure dashboard auth token exists
+  - verify token is sent to both dashboard API and `/chat` calls
 - Kafka group issues:
   - verify brokers and group config
   - use `kafclaw kshark` for diagnostics

--- a/docs/manage-kafclaw.md
+++ b/docs/manage-kafclaw.md
@@ -1,0 +1,284 @@
+# KafClaw Management Guide
+
+Operator-focused guide for managing KafClaw from CLI and runtime endpoints.
+
+## 1. Core Command Surface
+
+| Command | Purpose |
+|--------|---------|
+| `kafclaw onboard` | Initialize config and scaffold workspace identity files |
+| `kafclaw gateway` | Run full gateway (API, dashboard, channels, memory, group/orchestrator when enabled) |
+| `kafclaw status` | Quick operational status: config, providers, channels, pairing, policy diagnostics |
+| `kafclaw doctor` | Run setup and config diagnostics |
+| `kafclaw config` | Low-level dotted-path config read/write/unset |
+| `kafclaw configure` | Guided updates for selected settings (currently subagent allowlist) |
+| `kafclaw group` | Join/leave/status/members for Kafka collaboration group |
+| `kafclaw kshark` | Kafka connectivity and protocol diagnostics |
+| `kafclaw agent -m` | Single-shot direct CLI interaction with agent loop |
+| `kafclaw pairing` | Approve/deny pending Slack/Teams sender pairings |
+| `kafclaw whatsapp-setup` | Configure WhatsApp auth and initial lists |
+| `kafclaw whatsapp-auth` | Approve/deny/list WhatsApp JIDs |
+| `kafclaw install` | Install binary to `/usr/local/bin` |
+| `kafclaw version` | Print build version |
+
+## 2. First-Time Operator Runbook
+
+```bash
+./kafclaw onboard
+./kafclaw status
+./kafclaw doctor
+./kafclaw gateway
+```
+
+Then verify:
+
+- API: `http://127.0.0.1:18790`
+- Dashboard: `http://127.0.0.1:18791`
+
+## 3. Onboarding and Modes
+
+### Interactive
+
+```bash
+./kafclaw onboard
+```
+
+### Non-interactive examples
+
+```bash
+./kafclaw onboard --non-interactive --profile local --llm skip
+./kafclaw onboard --non-interactive --profile local-kafka --kafka-brokers localhost:9092 --group-name kafclaw --agent-id agent-local --role worker --llm skip
+./kafclaw onboard --non-interactive --profile remote --llm openai-compatible --llm-api-base http://localhost:11434/v1 --llm-model llama3.1:8b
+```
+
+Mode effects applied by onboarding:
+
+| Mode | Gateway Host | Group | Orchestrator | Auth Token |
+|------|--------------|-------|--------------|------------|
+| `local` | `127.0.0.1` | off | off | none |
+| `local-kafka` | `127.0.0.1` | on | on | none |
+| `remote` | `0.0.0.0` | off | off | generated/required |
+
+Onboarding also scaffolds workspace files:
+
+- `AGENTS.md`
+- `SOUL.md`
+- `USER.md`
+- `TOOLS.md`
+- `IDENTITY.md`
+
+Use `--force` to overwrite existing config and scaffold files.
+
+## 4. Daily Health Checks
+
+### Status snapshot
+
+```bash
+./kafclaw status
+```
+
+Highlights include:
+
+- config + API key presence
+- WhatsApp session/QR state
+- Slack/Teams account diagnostics and policy warnings
+- pending pairing counts from timeline
+
+### Doctor checks
+
+```bash
+./kafclaw doctor
+./kafclaw doctor --fix
+./kafclaw doctor --generate-gateway-token
+```
+
+`doctor` returns non-zero when failing checks exist.
+
+## 5. Config Management
+
+### Low-level config edits
+
+```bash
+./kafclaw config get gateway.host
+./kafclaw config set gateway.host 127.0.0.1
+./kafclaw config unset channels.slack.accounts
+```
+
+### Guided update path
+
+```bash
+./kafclaw configure
+./kafclaw configure --subagents-allow-agents agent-main,agent-research --non-interactive
+./kafclaw configure --clear-subagents-allow-agents --non-interactive
+```
+
+### LLM provider and token management
+
+Interactive (recommended):
+
+```bash
+./kafclaw onboard
+```
+
+Provider setup options in onboarding:
+
+- `cli-token` (prompts for token; OpenRouter-style OpenAI-compatible flow)
+- `openai-compatible` (prompts for API base, optional token, model)
+- `skip` (retain current settings)
+
+Direct config edits:
+
+```bash
+./kafclaw config get providers.openai.apiBase
+./kafclaw config set providers.openai.apiBase "https://openrouter.ai/api/v1"
+./kafclaw config set providers.openai.apiKey "<token>"
+./kafclaw config set model.name "anthropic/claude-sonnet-4-5"
+```
+
+## 6. Group Collaboration Operations
+
+```bash
+./kafclaw group join mygroup
+./kafclaw group status
+./kafclaw group members
+./kafclaw group leave
+```
+
+Notes:
+
+- Group state is persisted in timeline settings (`group_name`, `group_active`)
+- `group status` also prints resolved topic names and LFS health
+- `group members` reads roster snapshots from timeline DB
+
+### Configure Kafka broker connection (examples)
+
+Using onboarding profile:
+
+```bash
+./kafclaw onboard --non-interactive --profile local-kafka --kafka-brokers "broker1:9092,broker2:9092" --group-name kafclaw --agent-id agent-ops --role worker --llm skip
+```
+
+Using direct config commands:
+
+```bash
+./kafclaw config set group.enabled true
+./kafclaw config set group.groupName "kafclaw"
+./kafclaw config set group.kafkaBrokers "broker1:9092,broker2:9092"
+./kafclaw config set group.consumerGroup "kafclaw-workers"
+./kafclaw config set group.agentId "agent-ops"
+```
+
+Using KafScale proxy style settings:
+
+```bash
+./kafclaw config set group.lfsProxyUrl "https://your-kafscale-endpoint"
+./kafclaw config set group.lfsProxyApiKey "<kafscale-api-key>"
+```
+
+Verification:
+
+```bash
+./kafclaw group join kafclaw
+./kafclaw group status
+./kafclaw kshark --auto --yes
+```
+
+## 7. Kafka Diagnostics with KShark
+
+Auto-config from current KafClaw group config:
+
+```bash
+./kafclaw kshark --auto --yes
+```
+
+Using explicit properties:
+
+```bash
+./kafclaw kshark --props ./client.properties --topic group.mygroup.requests --group mygroup-workers --yes
+```
+
+Useful options:
+
+- `--json <file>` export report
+- `--diag` include traceroute/MTU diagnostics
+- `--preset` for predefined connection templates
+
+## 8. Channel Auth and Pairing
+
+### Pairing queue (Slack/Teams)
+
+```bash
+./kafclaw pairing pending
+./kafclaw pairing approve slack ABC123
+./kafclaw pairing deny msteams XYZ999
+```
+
+### WhatsApp auth flow
+
+```bash
+./kafclaw whatsapp-setup
+./kafclaw whatsapp-auth --list
+./kafclaw whatsapp-auth --approve "+123456789@s.whatsapp.net"
+./kafclaw whatsapp-auth --deny "+123456789@s.whatsapp.net"
+```
+
+## 9. Channel Bridge (`cmd/channelbridge`)
+
+Build and run:
+
+```bash
+go build -o /tmp/channelbridge ./cmd/channelbridge
+/tmp/channelbridge
+```
+
+Default bind: `:18888` (set via `CHANNEL_BRIDGE_ADDR`).
+
+Key endpoints:
+
+- `GET /healthz`
+- `GET /status`
+- `POST /slack/events`
+- `POST /slack/commands`
+- `POST /slack/interactions`
+- `POST /teams/messages`
+
+Core env vars:
+
+- `KAFCLAW_BASE_URL` (default `http://127.0.0.1:18791`)
+- `KAFCLAW_SLACK_INBOUND_TOKEN`
+- `KAFCLAW_MSTEAMS_INBOUND_TOKEN`
+- `SLACK_SIGNING_SECRET`
+- `MSTEAMS_INBOUND_BEARER`
+- `CHANNEL_BRIDGE_STATE` (bridge state file path)
+
+## 10. State and Paths
+
+Core runtime files:
+
+- Config: `~/.kafclaw/config.json`
+- Env: `~/.config/kafclaw/env`
+- Timeline DB: `~/.kafclaw/timeline.db`
+- WhatsApp session: `~/.kafclaw/whatsapp.db`
+- WhatsApp QR image: `~/.kafclaw/whatsapp-qr.png`
+- Subagent state: `~/.kafclaw/subagents/`
+
+## 11. Incident Shortcuts
+
+### Gateway will not start
+
+1. `./kafclaw doctor`
+2. Confirm API key/provider config
+3. Check timeline DB permissions and disk
+4. Re-run `./kafclaw onboard` (or `--force` if needed)
+
+### Kafka/group issues
+
+1. `./kafclaw group status`
+2. `./kafclaw kshark --auto --yes`
+3. Verify brokers/auth and LFS proxy settings
+
+### Channel ingress issues
+
+1. `./kafclaw status` for account diagnostics
+2. Check `pairing pending`
+3. If using bridge, check `GET /status` on channel bridge

--- a/docs/manage-kafclaw.md
+++ b/docs/manage-kafclaw.md
@@ -262,7 +262,32 @@ Core runtime files:
 - WhatsApp QR image: `~/.kafclaw/whatsapp-qr.png`
 - Subagent state: `~/.kafclaw/subagents/`
 
-## 11. Incident Shortcuts
+## 11. Client Auth Token Distribution
+
+This section applies to **direct HTTP clients** that call KafClaw API endpoints.
+For Slack/Teams/WhatsApp users, authentication is handled by provider bridge + pairing/allowlist controls, not by manually passing the gateway bearer token.
+
+When `KAFCLAW_GATEWAY_AUTH_TOKEN` (or `gateway.authToken`) is set, direct clients do not auto-receive tokens.
+Operators must distribute tokens out-of-band (secure chat, secret manager, deployment env injection, etc.).
+
+Operator token sources:
+
+- `~/.kafclaw/config.json` (`gateway.authToken`)
+- `~/.config/kafclaw/env` (if managed there)
+- `./kafclaw doctor --generate-gateway-token` (rotate/create)
+
+Client request header:
+
+```http
+Authorization: Bearer <token>
+```
+
+Validation endpoint:
+
+- `POST /api/v1/auth/verify` checks a provided bearer token
+- it validates tokens; it does not mint or return a token
+
+## 12. Incident Shortcuts
 
 ### Gateway will not start
 

--- a/docs/v2/admin-guide.md
+++ b/docs/v2/admin-guide.md
@@ -128,11 +128,48 @@ Operational notes:
 | `Host` | `127.0.0.1` | `KAFCLAW_GATEWAY_HOST` | Bind address |
 | `Port` | `18790` | `KAFCLAW_GATEWAY_PORT` | API port |
 | `DashboardPort` | `18791` | `KAFCLAW_GATEWAY_DASHBOARD_PORT` | Dashboard port |
-| `AuthToken` | *(empty)* | `KAFCLAW_GATEWAY_AUTH_TOKEN` | Required for headless mode |
+| `AuthToken` | *(empty)* | `KAFCLAW_GATEWAY_AUTH_TOKEN` | Dashboard API bearer token (except `/api/v1/status`) |
 | `TLSCert` | *(empty)* | — | Optional TLS certificate path |
 | `TLSKey` | *(empty)* | — | Optional TLS private key path |
 
-**LAN access:** The default `Host: 127.0.0.1` only accepts local connections. To expose the gateway on your network, set `Host` to `0.0.0.0` (all interfaces) or a specific LAN IP, and set `AuthToken` to secure it. Use `make run-headless` for the recommended configuration. The gateway serves plain HTTP — do not use `https://` in the browser unless TLS is configured.
+**LAN access:** The default `Host: 127.0.0.1` only accepts local connections. To expose the gateway on your network, set `Host` to `0.0.0.0` (all interfaces) or a specific LAN IP, and set `AuthToken`. Use `make run-headless` for the recommended configuration. The gateway serves plain HTTP — do not use `https://` in the browser unless TLS is configured.
+
+**Auth scope:** `AuthToken` is enforced on dashboard API routes on port `18791` (excluding `/api/v1/status` and CORS preflight), and on API server `POST /chat` on port `18790`.
+
+### Group Configuration
+
+| Field | Default | Env Var | Description |
+|-------|---------|---------|-------------|
+| `Enabled` | `false` | `KAFCLAW_GROUP_ENABLED` | Enable Kafka group collaboration |
+| `GroupName` | *(empty)* | `KAFCLAW_GROUP_GROUP_NAME` | Group topic namespace |
+| `KafkaBrokers` | *(empty)* | `KAFCLAW_GROUP_KAFKA_BROKERS` | Broker list (`host:port,...`) |
+| `ConsumerGroup` | *(auto)* | `KAFCLAW_GROUP_KAFKA_CONSUMER_GROUP` | Kafka consumer group id |
+| `AgentID` | *(hostname-derived)* | `KAFCLAW_GROUP_AGENT_ID` | Agent identity used in group protocol |
+| `LFSProxyURL` | `http://localhost:8080` | `KAFCLAW_GROUP_KAFSCALE_LFS_PROXY_URL` | KafScale LFS/proxy endpoint |
+| `LFSProxyAPIKey` | *(empty)* | `KAFCLAW_GROUP_KAFSCALE_LFS_PROXY_API_KEY` | Proxy auth key |
+| `PollIntervalMs` | `2000` | `KAFCLAW_GROUP_POLL_INTERVAL_MS` | Poll cadence for group operations |
+| `OnboardMode` | `open` | `KAFCLAW_GROUP_ONBOARD_MODE` | Group onboarding mode (`open` or `gated`) |
+| `MaxDelegationDepth` | `3` | `KAFCLAW_GROUP_MAX_DELEGATION_DEPTH` | Delegation depth guardrail |
+
+### Orchestrator Configuration
+
+| Field | Default | Env Var | Description |
+|-------|---------|---------|-------------|
+| `Enabled` | `false` | `KAFCLAW_ORCHESTRATOR_ENABLED` | Enable orchestrator layer |
+| `Role` | `worker` | `KAFCLAW_ORCHESTRATOR_ROLE` | `orchestrator`, `worker`, or `observer` |
+| `ZoneID` | *(empty)* | `KAFCLAW_ORCHESTRATOR_ZONE_ID` | Zone assignment |
+| `ParentID` | *(empty)* | `KAFCLAW_ORCHESTRATOR_PARENT_ID` | Parent agent for hierarchy |
+| `Endpoint` | *(empty)* | `KAFCLAW_ORCHESTRATOR_ENDPOINT` | This agent's reachable API endpoint |
+
+### Scheduler Configuration
+
+| Field | Default | Env Var | Description |
+|-------|---------|---------|-------------|
+| `Enabled` | `false` | `KAFCLAW_SCHEDULER_ENABLED` | Enable scheduler loop |
+| `TickInterval` | `60s` | `KAFCLAW_SCHEDULER_TICK_INTERVAL` | Tick cadence |
+| `MaxConcLLM` | `3` | `KAFCLAW_SCHEDULER_MAX_CONC_LLM` | Concurrency for LLM category jobs |
+| `MaxConcShell` | `1` | `KAFCLAW_SCHEDULER_MAX_CONC_SHELL` | Concurrency for shell category jobs |
+| `MaxConcDefault` | `5` | `KAFCLAW_SCHEDULER_MAX_CONC_DEFAULT` | Concurrency for default category jobs |
 
 ### Tools Configuration
 

--- a/docs/v2/architecture-detailed.md
+++ b/docs/v2/architecture-detailed.md
@@ -556,7 +556,8 @@ Destructive deletion, VCS deletion, disk destruction, device redirection, permis
 ### 9.3 Network Security
 
 - Default bind: 127.0.0.1
-- Headless: 0.0.0.0 with mandatory auth token
+- Headless: 0.0.0.0 with dashboard API auth token (`/api/v1/status` excluded)
+- `POST /chat` on port `18790` also enforces bearer auth when `KAFCLAW_GATEWAY_AUTH_TOKEN` is configured
 - TLS: optional cert/key
 - Electron: sandbox, context isolation, no node integration in renderer
 
@@ -576,7 +577,7 @@ Destructive deletion, VCS deletion, disk destruction, device redirection, permis
 |------|---------|-------------|
 | Standalone | `make run` | Local binary, no Kafka, localhost only (binds 127.0.0.1) |
 | Full | `make run-full` | + Kafka + orchestrator (binds 127.0.0.1) |
-| Headless | `make run-headless` | Binds 0.0.0.0, requires `KAFCLAW_GATEWAY_AUTH_TOKEN` |
+| Headless | `make run-headless` | Binds 0.0.0.0, dashboard API + `/chat` protected by `KAFCLAW_GATEWAY_AUTH_TOKEN` |
 | Remote | `make electron-start-remote` | Electron UI connects to headless server |
 | Docker | `make docker-up` | Container deployment |
 
@@ -588,7 +589,7 @@ To expose the gateway on your LAN (e.g., running on a Jetson Nano, accessing fro
 
 ```bash
 export KAFCLAW_GATEWAY_AUTH_TOKEN=mysecrettoken
-make run-headless    # binds 0.0.0.0, requires auth token
+make run-headless    # binds 0.0.0.0, dashboard API auth enabled
 ```
 
 Then access from another machine: `http://<server-ip>:18791/` (note: **http**, not https — the gateway serves plain HTTP unless TLS is configured via `tlsCert`/`tlsKey`).

--- a/docs/v2/index.md
+++ b/docs/v2/index.md
@@ -6,7 +6,11 @@ Primary v2 reference set for KafClaw.
 
 - [Docs Home](../index.md)
 - [Getting Started](../getting-started.md)
+- [Manage KafClaw](../manage-kafclaw.md)
 - [Operations and Maintenance](../maintenance.md)
+- [How Agents Work](../concepts/how-agents-work.md)
+- [Soul and Identity Files](../concepts/soul-identity-tools.md)
+- [Runtime Tools and Capabilities](../concepts/runtime-tools.md)
 
 ## Guides
 

--- a/docs/v2/operations-guide.md
+++ b/docs/v2/operations-guide.md
@@ -150,7 +150,7 @@ kafclaw install      # copies to /usr/local/bin
 |------|---------|-------------|---------------|-------------|
 | Standalone | `make run` | `127.0.0.1` | No | Local binary, no Kafka/orchestrator |
 | Full | `make run-full` | `127.0.0.1` | No | + Kafka group + orchestrator |
-| Headless | `make run-headless` | `0.0.0.0` | Yes | LAN/cloud accessible, no GUI |
+| Headless | `make run-headless` | `0.0.0.0` | Dashboard API: Yes | LAN/cloud accessible, no GUI |
 | Remote | `make electron-start-remote` | N/A | N/A | Electron UI connects to headless server |
 
 ### LAN / Remote Access
@@ -170,6 +170,11 @@ Then access from another machine:
 http://<server-ip>:18791/          # Dashboard
 http://<server-ip>:18790/chat      # API
 ```
+
+Important auth scope note:
+
+- `gateway.authToken` protects dashboard API routes on port `18791` (except `/api/v1/status`).
+- `gateway.authToken` also protects `POST /chat` on port `18790`.
 
 **Common pitfalls:**
 - **Wrong protocol:** The gateway serves plain `http://`. Using `https://` in the browser will fail silently unless TLS is configured (`tlsCert`/`tlsKey` in gateway config).

--- a/docs/v2/operations-guide.md
+++ b/docs/v2/operations-guide.md
@@ -370,6 +370,12 @@ Delivery worker polls every 5 seconds, retries up to 5 times with exponential ba
 |--------|------|-------------|
 | POST | `/chat?message=...&session=...` | Process message via agent loop |
 
+Auth note:
+
+- For direct HTTP clients: if `gateway.authToken` is configured, clients must send `Authorization: Bearer <token>` on `/chat`.
+- For Slack/Teams/WhatsApp provider users: auth is enforced through provider bridge + channel access controls (not manual gateway bearer tokens).
+- Direct clients obtain this token out-of-band from the operator; the API does not issue tokens.
+
 ### Port 18791 — Dashboard API
 
 **Status and Auth:**
@@ -378,6 +384,8 @@ Delivery worker polls every 5 seconds, retries up to 5 times with exponential ba
 |--------|------|-------------|
 | GET | `/api/v1/status` | Health, version, uptime, mode |
 | POST | `/api/v1/auth/verify` | Bearer token validation |
+
+`/api/v1/auth/verify` validates a supplied token and auth requirement state; it does not return or mint a token.
 
 **Timeline and Traces:**
 

--- a/docs/v2/slack-teams-bridge.md
+++ b/docs/v2/slack-teams-bridge.md
@@ -87,6 +87,11 @@ Probe endpoints:
 - `GET /slack/probe` validates Slack token with `auth.test`
 - `GET /teams/probe` validates Teams bot token flow and returns decoded bot/graph claims plus diagnostics (audience, expiry, scopes/roles), permission coverage, tenant/app identity checks, and live Graph capability checks (`users`, `teams`, `channels`, `organization`)
 
+Outbound endpoints:
+
+- `POST /slack/outbound`
+- `POST /teams/outbound`
+
 Socket mode ingress:
 
 - If `SLACK_APP_TOKEN` is set, the bridge also consumes Slack Events API, slash commands, and interactions via Socket Mode.

--- a/docs/v2/user-manual.md
+++ b/docs/v2/user-manual.md
@@ -124,6 +124,7 @@ kafclaw gateway
 
 - Ports: 18790 (API), 18791 (dashboard)
 - Runs until Ctrl+C. Handles graceful shutdown of all subsystems.
+- If `gateway.authToken` is set, dashboard API routes require bearer auth (except `/api/v1/status` and CORS preflight), and `POST /chat` on port `18790` also requires bearer auth.
 
 ### 3.2 `agent`
 
@@ -217,8 +218,13 @@ kafclaw configure --clear-subagents-allow-agents --non-interactive
 Kafka diagnostics helper.
 
 ```bash
-kafclaw kshark --broker localhost:9092 --test-connection
+kafclaw kshark --auto --yes
+kafclaw kshark --props ./client.properties --topic group.mygroup.requests --group mygroup-workers --yes
 ```
+
+Use either:
+- `--auto` (derive Kafka settings from current KafClaw group config), or
+- `--props` (explicit Kafka client properties file).
 
 ### 3.10 `whatsapp-setup`
 
@@ -246,9 +252,19 @@ Group collaboration management (requires Kafka).
 
 ```bash
 kafclaw group status
-kafclaw group join
+kafclaw group join mygroup
 kafclaw group leave
 kafclaw group members
+```
+
+### 3.13 `pairing`
+
+Manage pending Slack/Teams sender pairings.
+
+```bash
+kafclaw pairing pending
+kafclaw pairing approve slack ABC123
+kafclaw pairing deny msteams XYZ999
 ```
 
 ---

--- a/internal/cli/gateway.go
+++ b/internal/cli/gateway.go
@@ -567,20 +567,20 @@ func runGatewayMain(cmd *cobra.Command, args []string) {
 
 	// Start Local HTTP Server for Local Network access
 	// Start Local HTTP Server for Local Network access (API)
-		go func() {
-			mux := http.NewServeMux()
-			mux.HandleFunc("/chat", func(w http.ResponseWriter, r *http.Request) {
-				if cfg.Gateway.AuthToken != "" {
-					token := strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
-					if token != cfg.Gateway.AuthToken {
-						http.Error(w, "unauthorized", http.StatusUnauthorized)
-						return
-					}
-				}
-				if r.Method != http.MethodPost {
-					http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	go func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/chat", func(w http.ResponseWriter, r *http.Request) {
+			if cfg.Gateway.AuthToken != "" {
+				token := strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+				if token != cfg.Gateway.AuthToken {
+					http.Error(w, "unauthorized", http.StatusUnauthorized)
 					return
 				}
+			}
+			if r.Method != http.MethodPost {
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
 			msg := r.URL.Query().Get("message")
 			if msg == "" {
 				http.Error(w, "Missing message parameter", http.StatusBadRequest)


### PR DESCRIPTION
## Summary

Found a security bug in `internal/cli/gateway.go` during `docs/` creation and fixed it as part of this docs sweep.

### Security fix included
- `POST /chat` on port `18790` was reachable without bearer auth when `KAFCLAW_GATEWAY_AUTH_TOKEN` was configured.
- Fixed by enforcing bearer token validation on `/chat` whenever `gateway.authToken` is set.

### Regression coverage
- Added test: `TestRunGatewayChatAuthEnforcedWhenTokenConfigured` in `internal/cli/gateway_run_test.go`
- Verifies:
  - no token => `401`
  - wrong token => `401`
  - correct token => non-`401`
- `go test ./internal/cli/...` passes.

## Docs improvements delivered in same pass

- Added/updated first-class operator docs:
  - `docs/manage-kafclaw.md`
  - `docs/getting-started.md`
  - `docs/index.md`
  - `docs/v2/user-manual.md`
  - `docs/v2/admin-guide.md`
  - `docs/v2/operations-guide.md`
  - `docs/v2/slack-teams-bridge.md`
  - `docs/v2/architecture-detailed.md`
  - `docs/maintenance.md`
- Added architecture/concepts pages:
  - `docs/architecture.html`
  - `docs/concepts/how-agents-work.md`
  - `docs/concepts/soul-identity-tools.md`
  - `docs/concepts/runtime-tools.md`
- Added explicit docs for:
  - `doctor`, `configure`, `pairing`, `kshark --auto/--props`
  - interactive LLM provider/token setup (`onboard`)
  - Kafka broker connection examples (onboard + direct config + verification)
