### PR TITLE
docs: improve navigation and architecture diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # KafClaw
-[![CI (Smoke+Fuzz+Go)](https://github.com/scalytics/KafClaw/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/scalytics/KafClaw/actions/workflows/ci.yml)
-[![Release](https://github.com/scalytics/KafClaw/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/scalytics/KafClaw/actions/workflows/release.yml)
-[![Pages](https://github.com/scalytics/KafClaw/actions/workflows/pages.yml/badge.svg?branch=main)](https://github.com/scalytics/KafClaw/actions/workflows/pages.yml)
+[![CI (Smoke+Fuzz+Go)](https://github.com/KafClaw/KafClaw/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/KafClaw/KafClaw/actions/workflows/ci.yml)
+[![Release](https://github.com/KafClaw/KafClaw/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/KafClaw/KafClaw/actions/workflows/release.yml)
+[![Pages](https://github.com/KafClaw/KafClaw/actions/workflows/pages.yml/badge.svg?branch=main)](https://github.com/KafClaw/KafClaw/actions/workflows/pages.yml)
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/KafClaw/KafClaw)](https://goreportcard.com/report/github.com/KafClaw/KafClaw)
 [![License](https://img.shields.io/github/license/KafClaw/KafClaw)](LICENSE)

--- a/docs/_includes/topnav.html
+++ b/docs/_includes/topnav.html
@@ -1,0 +1,40 @@
+<style>
+  .kc-topnav {
+    margin: 0 0 1rem;
+    padding: 0.7rem 0.9rem;
+    border: 1px solid #d4dcec;
+    border-radius: 10px;
+    background: #f7faff;
+    font-size: 0.92rem;
+  }
+  .kc-topnav .back {
+    border: 1px solid #c4d3ef;
+    border-radius: 7px;
+    background: #ffffff;
+    color: #17408f;
+    font-weight: 600;
+    padding: 0.2rem 0.55rem;
+    cursor: pointer;
+    margin-right: 0.6rem;
+  }
+  .kc-topnav a {
+    text-decoration: none;
+    font-weight: 600;
+    color: #17408f;
+    margin-right: 0.6rem;
+  }
+  .kc-topnav .sep {
+    color: #7a889f;
+    margin-right: 0.6rem;
+  }
+</style>
+<div class="kc-topnav">
+  <button type="button" class="back" onclick="if (window.history.length > 1) { window.history.back(); } else { window.location.href='{{ '/' | relative_url }}'; }">Back</button>
+  <a href="{{ '/' | relative_url }}">Home</a><span class="sep">|</span>
+  <a href="{{ '/getting-started' | relative_url }}">Get Started</a><span class="sep">|</span>
+  <a href="{{ '/manage-kafclaw' | relative_url }}">Manage</a><span class="sep">|</span>
+  <a href="{{ '/v2' | relative_url }}">v2 Docs</a><span class="sep">|</span>
+  <a href="{{ '/v2/architecture' | relative_url }}">Architecture</a><span class="sep">|</span>
+  <a href="{{ '/v2/admin-guide' | relative_url }}">Admin</a><span class="sep">|</span>
+  <a href="{{ '/v2/operations-guide' | relative_url }}">Operations</a>
+</div>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,7 @@
 # Getting Started
 
+{% include topnav.html %}
+
 This guide gets KafClaw from zero to a working setup, with focus on onboarding and workspace identity files.
 
 ## 1. Prerequisites

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,8 @@
   <img src="./assets/kafclaw.png" alt="KafClaw Logo" width="320" />
 </p>
 
+{% include topnav.html %}
+
 KafClaw is a Go-based agent runtime with three practical deployment modes:
 
 - `local`: personal assistant on one machine

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,5 +1,7 @@
 # Operations and Maintenance
 
+{% include topnav.html %}
+
 Operational runbook for keeping KafClaw healthy in dev and production-like setups.
 
 ## Daily Checks

--- a/docs/manage-kafclaw.md
+++ b/docs/manage-kafclaw.md
@@ -1,5 +1,7 @@
 # KafClaw Management Guide
 
+{% include topnav.html %}
+
 Operator-focused guide for managing KafClaw from CLI and runtime endpoints.
 
 ## 1. Core Command Surface

--- a/docs/v2/architecture-detailed.md
+++ b/docs/v2/architecture-detailed.md
@@ -1,5 +1,7 @@
 # KafClaw System Architecture — Detailed Reference
 
+{% include topnav.html %}
+
 > For the quick overview, see [architecture.md](./architecture.md).
 > See also: [FR-009 System Architecture](../requirements/FR-009-system-architecture.md), [FR-013 Package Design](../requirements/FR-013-package-design.md), [FR-018 Interface Contracts](../requirements/FR-018-interface-contracts.md)
 
@@ -27,20 +29,55 @@
 
 KafClaw is a personal AI assistant framework written in Go with an Electron desktop frontend. It connects messaging channels (WhatsApp, local network, web UI) to LLM providers through an asynchronous message bus, with a tool registry for filesystem/shell/web operations, a 6-layer semantic memory system, policy-based authorization, multi-agent collaboration via Kafka, and a cron-based job scheduler.
 
-```
-WhatsApp --+
-CLI -------+                                    +-- Filesystem Tools
-Web UI ----+-- Message Bus -- Agent Loop -- LLM +-- Shell Execution
-Scheduler -+       |              |              +-- Web Search
-                   |              |              +-- Memory (remember/recall)
-                   |         Context Builder
-                   |         +-- Soul Files (AGENTS.md, SOUL.md, ...)
-                   |         +-- Working Memory (per-user scratchpad)
-                   |         +-- Observations (compressed history)
-                   |         +-- RAG Injection (vector search)
-                   |         +-- Tool + Skill definitions
-                   |
-               Timeline DB (SQLite)
+<div style="overflow:auto;border:1px solid #d4dcec;border-radius:10px;padding:10px;background:#fbfdff;">
+  <svg viewBox="0 0 1120 340" role="img" aria-label="KafClaw detailed architecture overview diagram" style="min-width:900px;max-width:100%;height:auto;">
+    <defs>
+      <marker id="arrowB" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+        <polygon points="0 0, 9 3.5, 0 7" fill="#2e5cab"></polygon>
+      </marker>
+    </defs>
+    <rect x="400" y="28" width="320" height="70" rx="10" fill="#eaf1ff" stroke="#9bb5e6"></rect>
+    <text x="560" y="56" text-anchor="middle" font-size="17" font-weight="700" fill="#1f3f84">Message Bus</text>
+    <text x="560" y="76" text-anchor="middle" font-size="12" fill="#355d9c">decouples channels from agent loop</text>
+
+    <rect x="400" y="120" width="320" height="72" rx="10" fill="#ffffff" stroke="#d4dcec"></rect>
+    <text x="560" y="148" text-anchor="middle" font-size="16" font-weight="700" fill="#24344d">Agent Loop + Context Builder</text>
+    <text x="560" y="168" text-anchor="middle" font-size="12" fill="#4e5c73">soul files • memory • skills • tool calls</text>
+
+    <rect x="90" y="44" width="230" height="148" rx="10" fill="#ffffff" stroke="#d4dcec"></rect>
+    <text x="205" y="68" text-anchor="middle" font-size="14" font-weight="700" fill="#24344d">Ingress Channels</text>
+    <text x="205" y="92" text-anchor="middle" font-size="12" fill="#4e5c73">WhatsApp / CLI / Web</text>
+    <text x="205" y="112" text-anchor="middle" font-size="12" fill="#4e5c73">Slack / Teams bridge</text>
+    <text x="205" y="132" text-anchor="middle" font-size="12" fill="#4e5c73">Scheduler jobs</text>
+    <text x="205" y="152" text-anchor="middle" font-size="12" fill="#4e5c73">Group traces/tasks</text>
+
+    <rect x="800" y="44" width="230" height="148" rx="10" fill="#ffffff" stroke="#d4dcec"></rect>
+    <text x="915" y="68" text-anchor="middle" font-size="14" font-weight="700" fill="#24344d">Execution Plane</text>
+    <text x="915" y="92" text-anchor="middle" font-size="12" fill="#4e5c73">Provider (LLM)</text>
+    <text x="915" y="112" text-anchor="middle" font-size="12" fill="#4e5c73">Tools (fs/shell/web)</text>
+    <text x="915" y="132" text-anchor="middle" font-size="12" fill="#4e5c73">Memory (RAG/observer)</text>
+    <text x="915" y="152" text-anchor="middle" font-size="12" fill="#4e5c73">Group + Orchestrator</text>
+
+    <rect x="320" y="226" width="480" height="82" rx="10" fill="#f4f8ff" stroke="#c8d6f1"></rect>
+    <text x="560" y="249" text-anchor="middle" font-size="14" font-weight="700" fill="#214483">Timeline DB (SQLite)</text>
+    <text x="560" y="269" text-anchor="middle" font-size="12" fill="#4e5c73">events • traces • tasks • approvals • memory chunks</text>
+    <text x="560" y="287" text-anchor="middle" font-size="12" fill="#4e5c73">settings • roster • topic metadata</text>
+
+    <line x1="320" y1="92" x2="400" y2="62" stroke="#2e5cab" stroke-width="2.2" marker-end="url(#arrowB)"></line>
+    <line x1="720" y1="62" x2="800" y2="92" stroke="#2e5cab" stroke-width="2.2" marker-end="url(#arrowB)"></line>
+    <line x1="560" y1="98" x2="560" y2="120" stroke="#2e5cab" stroke-width="2.2" marker-end="url(#arrowB)"></line>
+    <line x1="560" y1="192" x2="560" y2="226" stroke="#2e5cab" stroke-width="2.2" marker-end="url(#arrowB)"></line>
+  </svg>
+</div>
+
+Mermaid source (GitHub code view renders this; GitHub Pages may require a Mermaid JS include depending on your theme setup):
+
+```mermaid
+flowchart LR
+  IN["Ingress Channels<br/>WhatsApp / CLI / Web / Slack / Teams / Scheduler"] --> MB["Message Bus"]
+  MB --> AG["Agent Loop + Context Builder"]
+  AG --> EX["Execution Plane<br/>Provider + Tools + Memory + Group"]
+  AG --> DB["Timeline DB (SQLite)<br/>events + traces + tasks + approvals + memory"]
 ```
 
 ### Design Principles

--- a/docs/v2/architecture.md
+++ b/docs/v2/architecture.md
@@ -1,5 +1,7 @@
 # KafClaw Architecture — Overview
 
+{% include topnav.html %}
+
 A quick reference for the KafClaw system architecture. For the comprehensive deep-dive, see [architecture-detailed.md](./architecture-detailed.md).
 
 > See also: [FR-009 System Architecture](../requirements/FR-009-system-architecture.md), [FR-013 Package Design](../requirements/FR-013-package-design.md)
@@ -52,25 +54,56 @@ LLM abstraction supporting OpenAI-compatible APIs:
 
 ## System Diagram
 
-```
-WhatsApp ---+
-CLI --------+                                 +-- Filesystem Tools
-Web UI -----+-- Message Bus -- Agent Loop -- LLM +-- Shell Execution
-Scheduler --+       |              |              +-- Web Search
-                    |              |              +-- Memory (remember/recall)
-                    |         Context Builder
-                    |         +-- Soul Files (AGENTS.md, SOUL.md, ...)
-                    |         +-- Working Memory (per-user scratchpad)
-                    |         +-- Observations (compressed history)
-                    |         +-- RAG Injection (vector search)
-                    |         +-- Tool + Skill definitions
-                    |
-                Timeline DB (SQLite)
-                +-- Event log
-                +-- Memory chunks (embeddings)
-                +-- Settings, tasks, approvals
-                +-- Group roster, skill channels
-                +-- Orchestrator hierarchy
+<div style="overflow:auto;border:1px solid #d4dcec;border-radius:10px;padding:10px;background:#fbfdff;">
+  <svg viewBox="0 0 1120 360" role="img" aria-label="KafClaw system diagram" style="min-width:900px;max-width:100%;height:auto;">
+    <defs>
+      <marker id="arrowA" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+        <polygon points="0 0, 9 3.5, 0 7" fill="#2e5cab"></polygon>
+      </marker>
+    </defs>
+    <rect x="410" y="40" width="300" height="64" rx="10" fill="#eaf1ff" stroke="#9bb5e6"></rect>
+    <text x="560" y="65" text-anchor="middle" font-size="18" font-weight="700" fill="#1f3f84">Message Bus</text>
+    <text x="560" y="84" text-anchor="middle" font-size="12" fill="#355d9c">Inbound / Outbound decoupling</text>
+
+    <rect x="410" y="130" width="300" height="70" rx="10" fill="#ffffff" stroke="#d4dcec"></rect>
+    <text x="560" y="157" text-anchor="middle" font-size="16" font-weight="700" fill="#24344d">Agent Loop</text>
+    <text x="560" y="176" text-anchor="middle" font-size="12" fill="#4e5c73">LLM orchestration + tool loop</text>
+
+    <rect x="120" y="48" width="190" height="140" rx="10" fill="#ffffff" stroke="#d4dcec"></rect>
+    <text x="215" y="72" text-anchor="middle" font-size="14" font-weight="700" fill="#24344d">Channels</text>
+    <text x="215" y="96" text-anchor="middle" font-size="12" fill="#4e5c73">WhatsApp</text>
+    <text x="215" y="116" text-anchor="middle" font-size="12" fill="#4e5c73">CLI / Web UI</text>
+    <text x="215" y="136" text-anchor="middle" font-size="12" fill="#4e5c73">Slack / Teams</text>
+    <text x="215" y="156" text-anchor="middle" font-size="12" fill="#4e5c73">Scheduler</text>
+
+    <rect x="790" y="48" width="220" height="152" rx="10" fill="#ffffff" stroke="#d4dcec"></rect>
+    <text x="900" y="72" text-anchor="middle" font-size="14" font-weight="700" fill="#24344d">Tools + Memory</text>
+    <text x="900" y="96" text-anchor="middle" font-size="12" fill="#4e5c73">Filesystem / Shell</text>
+    <text x="900" y="116" text-anchor="middle" font-size="12" fill="#4e5c73">Web / Recall</text>
+    <text x="900" y="136" text-anchor="middle" font-size="12" fill="#4e5c73">Working Memory</text>
+    <text x="900" y="156" text-anchor="middle" font-size="12" fill="#4e5c73">Observer + RAG</text>
+    <text x="900" y="176" text-anchor="middle" font-size="12" fill="#4e5c73">Group / Skills</text>
+
+    <rect x="345" y="235" width="430" height="88" rx="10" fill="#f4f8ff" stroke="#c8d6f1"></rect>
+    <text x="560" y="258" text-anchor="middle" font-size="14" font-weight="700" fill="#214483">Timeline DB (SQLite)</text>
+    <text x="560" y="278" text-anchor="middle" font-size="12" fill="#4e5c73">Events • Tasks • Approvals • Memory chunks</text>
+    <text x="560" y="297" text-anchor="middle" font-size="12" fill="#4e5c73">Group roster • Topics • Settings</text>
+
+    <line x1="310" y1="98" x2="410" y2="72" stroke="#2e5cab" stroke-width="2.2" marker-end="url(#arrowA)"></line>
+    <line x1="710" y1="72" x2="790" y2="98" stroke="#2e5cab" stroke-width="2.2" marker-end="url(#arrowA)"></line>
+    <line x1="560" y1="104" x2="560" y2="130" stroke="#2e5cab" stroke-width="2.2" marker-end="url(#arrowA)"></line>
+    <line x1="560" y1="200" x2="560" y2="235" stroke="#2e5cab" stroke-width="2.2" marker-end="url(#arrowA)"></line>
+  </svg>
+</div>
+
+Mermaid source (GitHub code view renders this; GitHub Pages may require a Mermaid JS include depending on your theme setup):
+
+```mermaid
+flowchart LR
+  CH["Channels<br/>WhatsApp / CLI / Web / Slack / Teams / Scheduler"] --> MB["Message Bus"]
+  MB --> AL["Agent Loop"]
+  AL --> TM["Tools + Memory<br/>Filesystem / Shell / Web / RAG"]
+  AL --> DB["Timeline DB (SQLite)<br/>events + tasks + approvals + memory"]
 ```
 
 ## Design Principles

--- a/docs/v2/index.md
+++ b/docs/v2/index.md
@@ -1,5 +1,7 @@
 # KafClaw Documentation (v2)
 
+{% include topnav.html %}
+
 Primary v2 reference set for KafClaw.
 
 ## Quick Links


### PR DESCRIPTION
## Summary
Improves docs usability and architecture clarity across `docs/` and aligns README links.

### What changed
- Added shared top navigation with **Back** + main doc area links (`docs/_includes/topnav.html`)
- Added nav include to key docs pages (home, getting started, manage, maintenance, v2 index, architecture docs)
- Upgraded architecture docs with rendered **SVG system diagrams** and Mermaid source fallback:
  - `docs/v2/architecture.md`
  - `docs/v2/architecture-detailed.md`
- Updated README badge links to point to upstream `github.com/KafClaw/KafClaw`

## Why
- Easier navigation between major docs areas
- Better architecture readability on GitHub Pages (SVG always renders)
- Mermaid source kept for environments that support native Mermaid rendering
- README metadata now points to canonical upstream project
