### PR TITLE
Add Skill management, 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Run tests
         run: go test ./...
 
+      - name: Security check gate
+        run: go run ./cmd/kafclaw security check
+
       - name: Run race detector
         run: go test -race ./...
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,10 @@ jobs:
           go-version: "1.24.13"
           cache-dependency-path: go.sum
 
+      - name: Validate bundled skills artifacts
+        shell: bash
+        run: bash scripts/check_bundled_skills.sh
+
       - name: Build hardened binary
         shell: bash
         env:
@@ -174,9 +178,11 @@ jobs:
           set -euo pipefail
           BIN_NAME="kafclaw-${{ matrix.artifact_suffix }}${{ matrix.ext }}"
           BUNDLE_DIR="dist/kafclaw-${{ matrix.artifact_suffix }}-bundle"
-          mkdir -p "$BUNDLE_DIR/bin" "$BUNDLE_DIR/systemd" "$BUNDLE_DIR/env"
+          mkdir -p "$BUNDLE_DIR/bin" "$BUNDLE_DIR/systemd" "$BUNDLE_DIR/env" "$BUNDLE_DIR/skills" "$BUNDLE_DIR/docs/skills"
 
           cp "dist/${BIN_NAME}" "$BUNDLE_DIR/bin/kafclaw"
+          cp -R skills/. "$BUNDLE_DIR/skills/"
+          cp -R docs/skills/. "$BUNDLE_DIR/docs/skills/"
 
           cat > "$BUNDLE_DIR/systemd/kafclaw.service" <<'UNIT'
           [Unit]
@@ -226,6 +232,10 @@ jobs:
           chmod +x "$BUNDLE_DIR/install.sh"
 
           tar -C dist -czf "dist/kafclaw-${{ matrix.artifact_suffix }}-bundle.tar.gz" "kafclaw-${{ matrix.artifact_suffix }}-bundle"
+
+          if [[ "${{ matrix.goarch }}" == "amd64" ]]; then
+            tar -czf "dist/kafclaw-skills-bundle.tar.gz" skills docs/skills
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ NPM_MIN_VERSION := 11
 HOST_GOMODCACHE := $(shell go env GOMODCACHE)
 HOST_GOCACHE := $(shell go env GOCACHE)
 
-.PHONY: help check bootstrap build run rerun test vet race commit-check test-smoke test-critical test-fuzz code-ql test-classification test-subagents-e2e install \
+.PHONY: help check bootstrap build run rerun test vet race commit-check test-smoke test-critical test-fuzz code-ql test-classification test-subagents-e2e check-bundled-skills install \
 	release release-major release-minor release-patch dist-go \
 	docker-build docker-up docker-down docker-logs \
 	run-standalone run-full run-headless \
@@ -110,6 +110,9 @@ race: ## Run race-enabled tests across all packages
 
 test-smoke: ## Run fast critical-path smoke tests (bug-finding first)
 	bash scripts/test_smoke.sh
+
+check-bundled-skills: ## Validate that bundled skills/docs artifacts exist
+	bash scripts/check_bundled_skills.sh
 
 test-critical: ## Enforce 100% coverage on critical logic
 	bash scripts/check_critical_coverage.sh

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ NPM_MIN_VERSION := 11
 HOST_GOMODCACHE := $(shell go env GOMODCACHE)
 HOST_GOCACHE := $(shell go env GOCACHE)
 
-.PHONY: help check bootstrap build run rerun test vet race commit-check test-smoke test-critical test-fuzz code-ql test-classification test-subagents-e2e check-bundled-skills install \
+.PHONY: help check bootstrap build run rerun test vet race fmt-check commit-check test-smoke test-critical test-fuzz code-ql test-classification test-subagents-e2e check-bundled-skills install \
 	release release-major release-minor release-patch dist-go \
 	docker-build docker-up docker-down docker-logs \
 	run-standalone run-full run-headless \
@@ -108,6 +108,14 @@ vet: ## Run go vet across all packages
 race: ## Run race-enabled tests across all packages
 	go test -race ./...
 
+fmt-check: ## Verify Go files are gofmt-formatted
+	@unformatted="$$(gofmt -l .)"; \
+	if [ -n "$$unformatted" ]; then \
+		echo "The following files are not gofmt-formatted:"; \
+		echo "$$unformatted"; \
+		exit 1; \
+	fi
+
 test-smoke: ## Run fast critical-path smoke tests (bug-finding first)
 	bash scripts/test_smoke.sh
 
@@ -123,7 +131,7 @@ test-fuzz: ## Run fuzz tests for critical guard logic
 code-ql: ## Run local CodeQL (Go + JS/TS + Actions) and emit SARIF under .tmp/codeql/
 	bash scripts/codeql_local.sh
 
-commit-check: check vet race test-fuzz code-ql ## Run pre-commit quality gates (vet, race, fuzz, CodeQL)
+commit-check: check fmt-check vet race test-fuzz code-ql ## Run pre-commit quality gates (fmt, vet, race, fuzz, CodeQL)
 	@echo "commit-check completed."
 
 test-classification: ## Run internal/external message classification E2E test (verbose)

--- a/docs/architecture-security/security-for-ops.md
+++ b/docs/architecture-security/security-for-ops.md
@@ -94,6 +94,21 @@ Test restore regularly on a clean host.
 ./kafclaw status
 ./kafclaw doctor
 ./kafclaw doctor --fix
+./kafclaw security check
+./kafclaw security audit --deep
+./kafclaw security fix --yes
 ```
 
 Use these as part of daily operations and after any security-relevant change.
+
+## 9. Skills and OAuth Security Notes
+
+- Prefer `skills.scope=selected` for least-privilege skill exposure.
+- Use `skills.runtimeIsolation=auto` (or `strict` when container runtime is guaranteed).
+- When using `strict`, `kafclaw security check` validates that `docker`/`podman` is actually usable by the current operator user.
+- OAuth skill tokens are encrypted at rest with local tomb-key management by default (`~/.config/kafclaw/tomb.rr`), with optional keyring/file backends.
+- `doctor --fix` moves sensitive env keys into tomb-managed encrypted storage and scrubs them from `~/.config/kafclaw/env`.
+- Security events and install decisions are chained into immutable-style audit logs under `~/.kafclaw/skills/audit/`.
+- For deployment-specific skill operations and remediations, refer to:
+  - [Skills](../skills/index.md)
+  - [KafClaw Management Guide](../operations-admin/manage-kafclaw.md)

--- a/docs/skills/channel-onboarding.md
+++ b/docs/skills/channel-onboarding.md
@@ -1,0 +1,48 @@
+---
+title: channel-onboarding
+parent: Skills
+nav_order: 1
+---
+
+# channel-onboarding
+
+Guides setup and verification for Slack, Teams, and WhatsApp channel integrations.
+
+## Default State
+
+- Bundled with KafClaw
+- Enabled by default
+
+## What It Does
+
+- Validates channel prerequisites and required config fields.
+- Guides first-time onboarding for Slack, Teams, and WhatsApp.
+- Produces concrete remediation steps when checks fail.
+
+## Install / Enable
+
+Already bundled and enabled by default. To ensure the skills system is active:
+
+```bash
+kafclaw skills enable
+```
+
+## Usage
+
+- Run onboarding:
+
+```bash
+kafclaw onboard
+```
+
+- Run diagnostics:
+
+```bash
+kafclaw doctor
+```
+
+## Troubleshooting
+
+- If channels do not respond, check channel `enabled` flags and required tokens in config.
+- If onboarding is skipped, rerun with `kafclaw onboard --skip-skills=false`.
+- If diagnostics report missing prerequisites, follow the command hints from `doctor`.

--- a/docs/skills/gh-issues.md
+++ b/docs/skills/gh-issues.md
@@ -1,0 +1,39 @@
+---
+title: gh-issues
+parent: Skills
+nav_order: 5
+---
+
+# gh-issues
+
+Run issue-driven engineering loops with controlled PR lifecycle.
+
+## Default State
+
+- Bundled with KafClaw
+- Disabled by default
+
+## What It Does
+
+- Selects and executes issue work by priority/label.
+- Drives implementation, PR updates, and review follow-up.
+- Keeps explicit approval gates for merge and high-risk operations.
+
+## Install / Enable
+
+No external install needed (bundled skill). Enable it:
+
+```bash
+kafclaw skills enable-skill gh-issues
+```
+
+## Usage
+
+- Use when running backlog-driven work and shipping issues end-to-end.
+- Works best with `github` skill enabled for full repository operations.
+
+## Troubleshooting
+
+- If issue selection is noisy, tighten labels/milestones before execution.
+- If PR actions fail, verify GitHub auth and repository permissions.
+- If merge actions are blocked, confirm approval workflow requirements.

--- a/docs/skills/github.md
+++ b/docs/skills/github.md
@@ -1,0 +1,39 @@
+---
+title: github
+parent: Skills
+nav_order: 4
+---
+
+# github
+
+Operate GitHub issues, pull requests, and checks safely.
+
+## Default State
+
+- Bundled with KafClaw
+- Disabled by default
+
+## What It Does
+
+- Supports issue/PR/check/release workflows with controlled safety gates.
+- Encourages minimal, auditable changes with clear status reporting.
+- Applies approval expectations before merge/release/destructive actions.
+
+## Install / Enable
+
+No external install needed (bundled skill). Enable it:
+
+```bash
+kafclaw skills enable-skill github
+```
+
+## Usage
+
+- Use for repo triage, PR follow-up, and CI signal interpretation.
+- Pair with `gh-issues` for issue-driven execution loops.
+
+## Troubleshooting
+
+- If GitHub actions fail, verify `gh auth status`.
+- If operations are blocked, check your policy/approval settings.
+- If API calls are rate-limited, retry with reduced query scope.

--- a/docs/skills/google-cli.md
+++ b/docs/skills/google-cli.md
@@ -1,0 +1,60 @@
+---
+title: google-cli
+parent: Skills
+nav_order: 7
+---
+
+# google-cli
+
+Install and validate the Google Cloud CLI (`gcloud`) for cloud/operator workflows.
+
+## Default State
+
+- Bundled with KafClaw
+- Disabled by default
+
+## Check
+
+```bash
+kafclaw skills prereq check google-cli
+```
+
+## Install Plan
+
+```bash
+kafclaw skills prereq install google-cli --dry-run
+```
+
+## Install
+
+```bash
+kafclaw skills prereq install google-cli --yes
+```
+
+The installer uses Go-native OS routines (APT on Linux, Homebrew on macOS).
+
+## Enable Skill
+
+```bash
+kafclaw skills enable-skill google-cli
+```
+
+## Usage
+
+- Verify auth status:
+
+```bash
+gcloud auth list
+```
+
+- Verify active project:
+
+```bash
+gcloud config get-value project
+```
+
+## Troubleshooting
+
+- If install fails on Linux, run package metadata update and retry.
+- If `gcloud` is not found after install, ensure your shell `PATH` includes the install location.
+- If auth fails in headless environments, use device/browser-based auth flow from Google CLI.

--- a/docs/skills/google-workspace.md
+++ b/docs/skills/google-workspace.md
@@ -36,7 +36,7 @@ kafclaw skills auth start google-workspace \
   --client-id '<client-id>' \
   --client-secret '<client-secret>' \
   --redirect-uri 'http://localhost:53682/callback' \
-  --scopes 'openid,email,profile,https://www.googleapis.com/auth/gmail.readonly'
+  --access 'mail,calendar,drive'
 ```
 
 ## Complete
@@ -54,6 +54,8 @@ kafclaw skills auth complete google-workspace \
 - Agent read-only tool:
   - `google_workspace_read` with `operation=gmail_list_messages|calendar_list_events|drive_list_files`
   - include Gmail/Calendar/Drive read scopes during `auth start` for the operation you need.
+- Configure capability defaults (used by `skills auth start` when `--scopes` is omitted):
+  - `kafclaw configure --google-workspace-read mail,calendar`
 
 ## Troubleshooting
 

--- a/docs/skills/google-workspace.md
+++ b/docs/skills/google-workspace.md
@@ -51,6 +51,9 @@ kafclaw skills auth complete google-workspace \
 - Start flow, open returned URL in a browser, approve scopes, and paste callback URL.
 - Keep scopes minimal and aligned with tenant policy.
 - OAuth flow start/complete events are recorded in chained security audit logs (see [Skills](./index.md)).
+- Agent read-only tool:
+  - `google_workspace_read` with `operation=gmail_list_messages|calendar_list_events|drive_list_files`
+  - include Gmail/Calendar/Drive read scopes during `auth start` for the operation you need.
 
 ## Troubleshooting
 

--- a/docs/skills/google-workspace.md
+++ b/docs/skills/google-workspace.md
@@ -1,0 +1,59 @@
+---
+title: google-workspace
+parent: Skills
+nav_order: 8
+---
+
+# google-workspace
+
+Headless OAuth flow for Google Workspace integrations.
+
+## Default State
+
+- Bundled with KafClaw
+- Disabled by default
+
+## What It Does
+
+- Supports headless OAuth enrollment for Google Workspace APIs.
+- Stores token state securely for runtime use by the local agent.
+- Enables policy-gated Google Workspace operations after enrollment.
+
+For key backend options and storage/security posture, see [Skills](./index.md).
+
+## Install / Enable
+
+No external install needed (bundled skill). Enable it:
+
+```bash
+kafclaw skills enable-skill google-workspace
+```
+
+## Start
+
+```bash
+kafclaw skills auth start google-workspace \
+  --client-id '<client-id>' \
+  --client-secret '<client-secret>' \
+  --redirect-uri 'http://localhost:53682/callback' \
+  --scopes 'openid,email,profile,https://www.googleapis.com/auth/gmail.readonly'
+```
+
+## Complete
+
+```bash
+kafclaw skills auth complete google-workspace \
+  --callback-url 'http://localhost:53682/callback?code=...&state=...'
+```
+
+## Usage
+
+- Start flow, open returned URL in a browser, approve scopes, and paste callback URL.
+- Keep scopes minimal and aligned with tenant policy.
+- OAuth flow start/complete events are recorded in chained security audit logs (see [Skills](./index.md)).
+
+## Troubleshooting
+
+- If `state mismatch` appears, restart the flow and use the latest callback.
+- If token exchange fails, validate client ID/secret, redirect URI, and consent scopes.
+- If skill doctor warns about missing token, rerun `auth start` + `auth complete`.

--- a/docs/skills/incident-comms.md
+++ b/docs/skills/incident-comms.md
@@ -1,0 +1,39 @@
+---
+title: incident-comms
+parent: Skills
+nav_order: 10
+---
+
+# incident-comms
+
+Generate and send standardized incident communications.
+
+## Default State
+
+- Bundled with KafClaw
+- Disabled by default
+
+## What It Does
+
+- Builds structured incident updates (impact, scope, timeline, next update).
+- Adapts message shape for enabled channels.
+- Enforces explicit approval before outbound send actions.
+
+## Install / Enable
+
+No external install needed (bundled skill). Enable it:
+
+```bash
+kafclaw skills enable-skill incident-comms
+```
+
+## Usage
+
+- Use for first alert, periodic updates, and resolution notices.
+- Keep a fixed update cadence and include next expected update time.
+
+## Troubleshooting
+
+- If sends are blocked, check approval policy and channel enablement.
+- If channel formatting is inconsistent, use a shared incident template.
+- If channels are not ready, run onboarding/doctor before incident publishing.

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -104,6 +104,11 @@ kafclaw security fix --yes
 - `kafclaw skills auth start <provider> ...`
 - `kafclaw skills auth complete <provider> --callback-url ...`
 
+Agent tool names for OAuth-enrolled read-only access:
+
+- `google_workspace_read` (`gmail_list_messages`, `calendar_list_events`, `drive_list_files`)
+- `m365_read` (`mail_list_messages`, `calendar_list_events`, `onedrive_list_children`)
+
 ## Remediation
 
 - Missing `node`: install Node.js and rerun `kafclaw skills enable`

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -68,10 +68,22 @@ kafclaw configure --non-interactive --skills-scope selected
 kafclaw onboard --accept-risk --non-interactive --skip-skills=false --install-clawhub --skills-node-major 20
 ```
 
+- Optional during onboarding: preselect provider capabilities:
+
+```bash
+kafclaw onboard --accept-risk --non-interactive --skip-skills --google-workspace-read mail,drive --m365-read calendar
+```
+
 - Configure can manage global and per-skill toggles:
 
 ```bash
 kafclaw configure --non-interactive --skills-enabled-set --skills-enabled=true --skills-node-manager npm --enable-skill github --disable-skill weather
+```
+
+- Configure OAuth capability presets for provider skills:
+
+```bash
+kafclaw configure --non-interactive --google-workspace-read mail,calendar --m365-read mail,files
 ```
 
 - Doctor validates skills prerequisites/runtime readiness:
@@ -103,6 +115,7 @@ kafclaw security fix --yes
 - `kafclaw skills prereq install <name> --dry-run|--yes`
 - `kafclaw skills auth start <provider> ...`
 - `kafclaw skills auth complete <provider> --callback-url ...`
+- `kafclaw skills auth start <provider> --access mail,calendar,...` (scope presets)
 
 Agent tool names for OAuth-enrolled read-only access:
 

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -1,0 +1,143 @@
+---
+title: Skills
+nav_order: 6
+has_children: true
+---
+
+# Skills
+
+Operator and security notes for bundled and external skills.
+
+For deep security posture and operational commands, see:
+
+- [Security for Operators](../architecture-security/security-for-ops.md)
+- [KafClaw Management Guide](../operations-admin/manage-kafclaw.md)
+
+## Bundled Skills
+
+- `channel-onboarding` (default enabled)
+- `session-logs`
+- `summarize`
+- `github`
+- `gh-issues`
+- `weather`
+- `google-cli`
+- `google-workspace`
+- `m365`
+- `incident-comms`
+- `skill-creator`
+
+## Prerequisites
+
+- Node.js (`node` and `npm` in `PATH`)
+- `clawhub` CLI for external installs/updates
+
+```bash
+npm install -g --ignore-scripts clawhub
+```
+
+## Bootstrap
+
+```bash
+kafclaw skills enable --install-clawhub
+```
+
+This command enables skills, creates secure runtime directories, ensures `.nvmrc`, and validates tooling.
+
+## Runtime Policy and Scope
+
+- Skills scope:
+  - `skills.scope=selected` (recommended default): only explicitly enabled skills are available.
+  - `skills.scope=all`: all skills are considered enabled.
+- Runtime isolation:
+  - `skills.runtimeIsolation=auto` (default): use container isolation when available, otherwise host policy mode.
+  - `skills.runtimeIsolation=strict`: require container isolation (`docker`/`podman`), fail if unavailable.
+  - `skills.runtimeIsolation=host`: host execution with policy enforcement only.
+
+Configure examples:
+
+```bash
+kafclaw configure --non-interactive --skills-scope selected
+```
+
+## Lifecycle (Onboard / Configure / Doctor)
+
+- Onboarding can bootstrap skills automatically:
+
+```bash
+kafclaw onboard --accept-risk --non-interactive --skip-skills=false --install-clawhub --skills-node-major 20
+```
+
+- Configure can manage global and per-skill toggles:
+
+```bash
+kafclaw configure --non-interactive --skills-enabled-set --skills-enabled=true --skills-node-manager npm --enable-skill github --disable-skill weather
+```
+
+- Doctor validates skills prerequisites/runtime readiness:
+
+```bash
+kafclaw doctor
+```
+
+- Security command surface (recommended for ongoing checks):
+
+```bash
+kafclaw security check
+kafclaw security audit --deep
+kafclaw security fix --yes
+```
+
+## Commands
+
+- `kafclaw skills list`
+- `kafclaw skills status`
+- `kafclaw skills enable`
+- `kafclaw skills disable`
+- `kafclaw skills enable-skill <name>`
+- `kafclaw skills disable-skill <name>`
+- `kafclaw skills verify <path-or-url>`
+- `kafclaw skills install <slug-or-url>`
+- `kafclaw skills update [name]`
+- `kafclaw skills prereq check <name>`
+- `kafclaw skills prereq install <name> --dry-run|--yes`
+- `kafclaw skills auth start <provider> ...`
+- `kafclaw skills auth complete <provider> --callback-url ...`
+
+## Remediation
+
+- Missing `node`: install Node.js and rerun `kafclaw skills enable`
+- Missing `clawhub`: `npm install -g --ignore-scripts clawhub`
+- Blocked external installs: set `skills.externalInstalls=true`
+- Blocked domain: update `skills.linkPolicy` allow/deny configuration
+- Skill-specific setup errors: run `kafclaw doctor` and fix reported prerequisites/tokens
+
+## OAuth Secret Storage
+
+- OAuth pending and token blobs are encrypted at rest.
+- OAuth blobs and tomb-stored env secrets both use AES-GCM and the same tomb-managed master key material.
+- OAuth runtime files are stored under `~/.kafclaw/skills/tools/auth/<provider>/<profile>/` as `pending.json` and `token.json`; they are written encrypted (not plaintext secret JSON files).
+- Master key backend supports local-native tomb key (default) and fallbacks:
+  - `KAFCLAW_OAUTH_KEY_BACKEND=local|auto|keyring|file`
+  - Local default path: `~/.config/kafclaw/tomb.rr` (0600)
+  - Optional override: `KAFCLAW_OAUTH_TOMB_FILE=/custom/path/tomb.rr`
+  - Optional explicit key: `KAFCLAW_OAUTH_MASTER_KEY`
+- `kafclaw doctor --fix` also syncs sensitive env keys into tomb-managed encrypted storage (`env_tomb_sync` check).
+- After successful tomb sync, `doctor --fix` scrubs sensitive keys from `~/.config/kafclaw/env` (`env_sensitive_scrub` check). Runtime then loads them from tomb into process env.
+- For provider-specific enrollment flows, use:
+  - [google-workspace](./google-workspace.md)
+  - [m365](./m365.md)
+
+## External Source Pinning
+
+- External skill install sources can be pinned with `#sha256=<64-hex>`:
+  - `kafclaw skills install 'https://example.org/skills/demo.zip#sha256=<digest>'`
+- Install/update fails if the installed package hash does not match the pin.
+- `kafclaw security check` reports hash-pinning coverage for installed external skills.
+
+## ClawHub State
+
+- `clawhub:<slug>` installs are staged in quarantine, verified, then installed.
+- ClawHub state/metadata is synchronized under skills runtime tools state.
+- Security events and install decisions are recorded as chained JSONL audit logs in `~/.kafclaw/skills/audit/`.
+- See [KafClaw Management Guide](../operations-admin/manage-kafclaw.md) for operations workflow.

--- a/docs/skills/m365.md
+++ b/docs/skills/m365.md
@@ -37,7 +37,7 @@ kafclaw skills auth start m365 \
   --client-secret '<client-secret>' \
   --redirect-uri 'http://localhost:53682/callback' \
   --tenant-id '<tenant-or-common>' \
-  --scopes 'openid,offline_access,User.Read'
+  --access 'mail,calendar,files'
 ```
 
 ## Complete
@@ -55,6 +55,8 @@ kafclaw skills auth complete m365 \
 - Agent read-only tool:
   - `m365_read` with `operation=mail_list_messages|calendar_list_events|onedrive_list_children`
   - include `Mail.Read` / `Calendars.Read` / `Files.Read` scopes during `auth start` for the operation you need.
+- Configure capability defaults (used by `skills auth start` when `--scopes` is omitted):
+  - `kafclaw configure --m365-read mail,files`
 
 ## Troubleshooting
 

--- a/docs/skills/m365.md
+++ b/docs/skills/m365.md
@@ -52,6 +52,9 @@ kafclaw skills auth complete m365 \
 - Start flow, sign in, approve scopes, then paste callback URL to complete enrollment.
 - Prefer tenant-specific app registration and least-privilege scopes.
 - OAuth flow start/complete events are recorded in chained security audit logs (see [Skills](./index.md)).
+- Agent read-only tool:
+  - `m365_read` with `operation=mail_list_messages|calendar_list_events|onedrive_list_children`
+  - include `Mail.Read` / `Calendars.Read` / `Files.Read` scopes during `auth start` for the operation you need.
 
 ## Troubleshooting
 

--- a/docs/skills/m365.md
+++ b/docs/skills/m365.md
@@ -1,0 +1,60 @@
+---
+title: m365
+parent: Skills
+nav_order: 9
+---
+
+# m365
+
+Headless OAuth flow for Microsoft 365 integrations.
+
+## Default State
+
+- Bundled with KafClaw
+- Disabled by default
+
+## What It Does
+
+- Supports headless OAuth enrollment for Microsoft 365/Graph APIs.
+- Stores token state securely for runtime use by the local agent.
+- Enables policy-gated Outlook/Calendar/Drive/Teams operations.
+
+For key backend options and storage/security posture, see [Skills](./index.md).
+
+## Install / Enable
+
+No external install needed (bundled skill). Enable it:
+
+```bash
+kafclaw skills enable-skill m365
+```
+
+## Start
+
+```bash
+kafclaw skills auth start m365 \
+  --client-id '<client-id>' \
+  --client-secret '<client-secret>' \
+  --redirect-uri 'http://localhost:53682/callback' \
+  --tenant-id '<tenant-or-common>' \
+  --scopes 'openid,offline_access,User.Read'
+```
+
+## Complete
+
+```bash
+kafclaw skills auth complete m365 \
+  --callback-url 'http://localhost:53682/callback?code=...&state=...'
+```
+
+## Usage
+
+- Start flow, sign in, approve scopes, then paste callback URL to complete enrollment.
+- Prefer tenant-specific app registration and least-privilege scopes.
+- OAuth flow start/complete events are recorded in chained security audit logs (see [Skills](./index.md)).
+
+## Troubleshooting
+
+- If token exchange fails, verify tenant ID, redirect URI, and Graph app permissions.
+- If callback parsing fails, pass the full URL including query string.
+- If you rotate app credentials, re-enroll token state with a new start/complete flow.

--- a/docs/skills/session-logs.md
+++ b/docs/skills/session-logs.md
@@ -1,0 +1,39 @@
+---
+title: session-logs
+parent: Skills
+nav_order: 2
+---
+
+# session-logs
+
+Analyze session logs to explain failures, regressions, and behavior drift.
+
+## Default State
+
+- Bundled with KafClaw
+- Disabled by default
+
+## What It Does
+
+- Reads local session/task traces and extracts key failure points.
+- Summarizes timeline, repeated errors, and likely root causes.
+- Produces remediation-focused summaries for operators.
+
+## Install / Enable
+
+No external install needed (bundled skill). Enable it:
+
+```bash
+kafclaw skills enable-skill session-logs
+```
+
+## Usage
+
+- Use when investigating unstable behavior across prior runs.
+- Pair with `kafclaw doctor` output to correlate config/runtime issues.
+
+## Troubleshooting
+
+- If no useful data appears, verify session logs exist in your runtime workspace.
+- If output may contain secrets, redact before sharing externally.
+- If skill appears disabled, confirm with `kafclaw skills list`.

--- a/docs/skills/skill-creator.md
+++ b/docs/skills/skill-creator.md
@@ -1,0 +1,39 @@
+---
+title: skill-creator
+parent: Skills
+nav_order: 11
+---
+
+# skill-creator
+
+Create and maintain KafClaw skills with consistent structure and safety requirements.
+
+## Default State
+
+- Bundled with KafClaw
+- Disabled by default
+
+## What It Does
+
+- Provides a workflow for creating and improving skill definitions.
+- Enforces structure (`SKILL.md`, clear workflows, explicit safety gates).
+- Ensures operator docs are added for each shipped skill.
+
+## Install / Enable
+
+No external install needed (bundled skill). Enable it:
+
+```bash
+kafclaw skills enable-skill skill-creator
+```
+
+## Usage
+
+- Use when introducing a new skill or hardening an existing one.
+- Require docs update in `/docs/skills` as part of completion criteria.
+
+## Troubleshooting
+
+- If a new skill is not discovered, verify folder path and `SKILL.md` frontmatter.
+- If execution is blocked, verify policy settings (`skills.enabled`, source toggles, link policy).
+- If rollout is risky, gate with verify/install first and keep update rollback path.

--- a/docs/skills/summarize.md
+++ b/docs/skills/summarize.md
@@ -1,0 +1,39 @@
+---
+title: summarize
+parent: Skills
+nav_order: 3
+---
+
+# summarize
+
+Produce concise summaries of long technical artifacts.
+
+## Default State
+
+- Bundled with KafClaw
+- Disabled by default
+
+## What It Does
+
+- Compresses large logs, docs, and threads into actionable summaries.
+- Preserves technical decisions, risks, and next actions.
+- Avoids speculation by calling out unknowns explicitly.
+
+## Install / Enable
+
+No external install needed (bundled skill). Enable it:
+
+```bash
+kafclaw skills enable-skill summarize
+```
+
+## Usage
+
+- Use for long incident timelines, pull request discussions, and diagnostics output.
+- Request output in structured form (findings, risks, actions).
+
+## Troubleshooting
+
+- If summaries miss context, narrow the scope to a specific file set.
+- If summaries are too broad, provide the audience and objective first.
+- If skill appears unavailable, verify global skills are enabled.

--- a/docs/skills/weather.md
+++ b/docs/skills/weather.md
@@ -1,0 +1,39 @@
+---
+title: weather
+parent: Skills
+nav_order: 6
+---
+
+# weather
+
+Provide weather and short forecast responses.
+
+## Default State
+
+- Bundled with KafClaw
+- Disabled by default
+
+## What It Does
+
+- Resolves location-based current weather and short forecasts.
+- Returns concise forecast windows with units and timing context.
+- Handles ambiguous location requests with follow-up clarification.
+
+## Install / Enable
+
+No external install needed (bundled skill). Enable it:
+
+```bash
+kafclaw skills enable-skill weather
+```
+
+## Usage
+
+- Use for quick weather lookups used in planning or incident operations.
+- Provide explicit location format when possible (`City, Country/State`).
+
+## Troubleshooting
+
+- If location is ambiguous, include region/country in your query.
+- If data looks stale, re-run query with explicit date/time window.
+- If skill is not selectable, verify `skills.enabled=true`.

--- a/go.mod
+++ b/go.mod
@@ -19,11 +19,14 @@ require (
 )
 
 require (
+	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/beeper/argo-go v1.1.2 // indirect
 	github.com/coder/websocket v1.8.14 // indirect
+	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/elliotchance/orderedmap/v3 v3.1.0 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.15.9 // indirect
@@ -39,6 +42,7 @@ require (
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
+	github.com/zalando/go-keyring v0.2.6 // indirect
 	go.mau.fi/libsignal v0.2.1 // indirect
 	go.mau.fi/util v0.9.5 // indirect
 	golang.org/x/crypto v0.47.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+al.essio.dev/pkg/shellescape v1.5.1 h1:86HrALUujYS/h+GtqoB26SBEdkWfmMI6FubjXlsXyho=
+al.essio.dev/pkg/shellescape v1.5.1/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
@@ -12,6 +14,8 @@ github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
+github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
@@ -23,6 +27,8 @@ github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
@@ -86,6 +92,8 @@ github.com/xdg-go/scram v1.1.2/go.mod h1:RT/sEzTbU5y00aCK8UOx6R7YryM0iF1N2MOmC3k
 github.com/xdg-go/stringprep v1.0.4 h1:XLI/Ng3O1Atzq0oBs3TWm+5ZVgkq2aqdlvP9JtoZ6c8=
 github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=
+github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
 go.mau.fi/libsignal v0.2.1 h1:vRZG4EzTn70XY6Oh/pVKrQGuMHBkAWlGRC22/85m9L0=
 go.mau.fi/libsignal v0.2.1/go.mod h1:iVvjrHyfQqWajOUaMEsIfo3IqgVMrhWcPiiEzk7NgoU=
 go.mau.fi/util v0.9.5 h1:7AoWPCIZJGv4jvtFEuCe3GhAbI7uF9ckIooaXvwlIR4=

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -200,6 +200,8 @@ func (l *Loop) registerDefaultTools() {
 	l.registry.Register(tools.NewSessionsSpawnTool(l.spawnSubagentFromTool))
 	l.registry.Register(tools.NewSubagentsTool(l.listSubagentsForTool, l.killSubagentForTool, l.steerSubagentForTool))
 	l.registry.Register(tools.NewAgentsListTool(l.listSubagentAgentsForTool))
+	l.registry.Register(tools.NewGoogleWorkspaceReadTool())
+	l.registry.Register(tools.NewM365ReadTool())
 }
 
 // Run starts the agent loop, processing messages from the bus.

--- a/internal/cli/configure.go
+++ b/internal/cli/configure.go
@@ -12,6 +12,11 @@ import (
 var configureSubagentsAllowAgents string
 var configureClearSubagentsAllowAgents bool
 var configureNonInteractive bool
+var configureSkillsEnabled bool
+var configureSkillsNodeManager string
+var configureSkillsScope string
+var configureEnableSkills []string
+var configureDisableSkills []string
 
 var configureCmd = &cobra.Command{
 	Use:   "configure",
@@ -22,7 +27,13 @@ var configureCmd = &cobra.Command{
 func init() {
 	configureCmd.Flags().StringVar(&configureSubagentsAllowAgents, "subagents-allow-agents", "", "Comma-separated agent IDs allowed for sessions_spawn agentId (use '*' for any)")
 	configureCmd.Flags().BoolVar(&configureClearSubagentsAllowAgents, "clear-subagents-allow-agents", false, "Clear subagent allowlist (default behavior: current agent only)")
+	configureCmd.Flags().BoolVar(&configureSkillsEnabled, "skills-enabled", false, "Enable or disable global skills system (with --skills-enabled-set)")
+	configureCmd.Flags().StringVar(&configureSkillsNodeManager, "skills-node-manager", "", "Set skills node manager (npm|pnpm|bun)")
+	configureCmd.Flags().StringVar(&configureSkillsScope, "skills-scope", "", "Set skills scope (all|selected)")
+	configureCmd.Flags().StringSliceVar(&configureEnableSkills, "enable-skill", nil, "Enable one or more skills (repeatable)")
+	configureCmd.Flags().StringSliceVar(&configureDisableSkills, "disable-skill", nil, "Disable one or more skills (repeatable)")
 	configureCmd.Flags().BoolVar(&configureNonInteractive, "non-interactive", false, "Apply flags only and skip prompts")
+	configureCmd.Flags().Bool("skills-enabled-set", false, "Apply --skills-enabled value")
 	rootCmd.AddCommand(configureCmd)
 }
 
@@ -59,6 +70,46 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 	}
 
 	cfg.Tools.Subagents.AllowAgents = updatedAllowAgents
+
+	if cmd.Flags().Changed("skills-enabled-set") {
+		cfg.Skills.Enabled = configureSkillsEnabled
+	}
+	if strings.TrimSpace(configureSkillsNodeManager) != "" {
+		val := strings.ToLower(strings.TrimSpace(configureSkillsNodeManager))
+		switch val {
+		case "npm", "pnpm", "bun":
+			cfg.Skills.NodeManager = val
+		default:
+			return fmt.Errorf("invalid --skills-node-manager: %s (expected npm|pnpm|bun)", val)
+		}
+	}
+	if strings.TrimSpace(configureSkillsScope) != "" {
+		scope := strings.ToLower(strings.TrimSpace(configureSkillsScope))
+		switch scope {
+		case "all", "selected":
+			cfg.Skills.Scope = scope
+		default:
+			return fmt.Errorf("invalid --skills-scope: %s (expected all|selected)", scope)
+		}
+	}
+	if cfg.Skills.Entries == nil {
+		cfg.Skills.Entries = map[string]config.SkillEntryConfig{}
+	}
+	for _, name := range configureEnableSkills {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		cfg.Skills.Entries[name] = config.SkillEntryConfig{Enabled: true}
+	}
+	for _, name := range configureDisableSkills {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		cfg.Skills.Entries[name] = config.SkillEntryConfig{Enabled: false}
+	}
+
 	if err := config.Save(cfg); err != nil {
 		return fmt.Errorf("save config: %w", err)
 	}
@@ -68,6 +119,9 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 		state = strings.Join(cfg.Tools.Subagents.AllowAgents, ",")
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Updated tools.subagents.allowAgents: %s\n", state)
+	fmt.Fprintf(cmd.OutOrStdout(), "Updated skills.enabled: %v\n", cfg.Skills.Enabled)
+	fmt.Fprintf(cmd.OutOrStdout(), "Updated skills.nodeManager: %s\n", cfg.Skills.NodeManager)
+	fmt.Fprintf(cmd.OutOrStdout(), "Updated skills.scope: %s\n", cfg.Skills.Scope)
 	return nil
 }
 

--- a/internal/cli/configure.go
+++ b/internal/cli/configure.go
@@ -17,6 +17,8 @@ var configureSkillsNodeManager string
 var configureSkillsScope string
 var configureEnableSkills []string
 var configureDisableSkills []string
+var configureGoogleWorkspaceRead string
+var configureM365Read string
 
 var configureCmd = &cobra.Command{
 	Use:   "configure",
@@ -32,6 +34,8 @@ func init() {
 	configureCmd.Flags().StringVar(&configureSkillsScope, "skills-scope", "", "Set skills scope (all|selected)")
 	configureCmd.Flags().StringSliceVar(&configureEnableSkills, "enable-skill", nil, "Enable one or more skills (repeatable)")
 	configureCmd.Flags().StringSliceVar(&configureDisableSkills, "disable-skill", nil, "Disable one or more skills (repeatable)")
+	configureCmd.Flags().StringVar(&configureGoogleWorkspaceRead, "google-workspace-read", "", "Set google-workspace capabilities (mail,calendar,drive,all)")
+	configureCmd.Flags().StringVar(&configureM365Read, "m365-read", "", "Set m365 capabilities (mail,calendar,files,all)")
 	configureCmd.Flags().BoolVar(&configureNonInteractive, "non-interactive", false, "Apply flags only and skip prompts")
 	configureCmd.Flags().Bool("skills-enabled-set", false, "Apply --skills-enabled value")
 	rootCmd.AddCommand(configureCmd)
@@ -100,14 +104,43 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 		if name == "" {
 			continue
 		}
-		cfg.Skills.Entries[name] = config.SkillEntryConfig{Enabled: true}
+		entry := cfg.Skills.Entries[name]
+		entry.Enabled = true
+		cfg.Skills.Entries[name] = entry
 	}
 	for _, name := range configureDisableSkills {
 		name = strings.TrimSpace(name)
 		if name == "" {
 			continue
 		}
-		cfg.Skills.Entries[name] = config.SkillEntryConfig{Enabled: false}
+		entry := cfg.Skills.Entries[name]
+		entry.Enabled = false
+		cfg.Skills.Entries[name] = entry
+	}
+
+	if strings.TrimSpace(configureGoogleWorkspaceRead) != "" {
+		caps, err := parseCapabilitySelection(configureGoogleWorkspaceRead, map[string]struct{}{
+			"mail": {}, "calendar": {}, "drive": {}, "all": {},
+		})
+		if err != nil {
+			return fmt.Errorf("invalid --google-workspace-read: %w", err)
+		}
+		entry := cfg.Skills.Entries["google-workspace"]
+		entry.Enabled = true
+		entry.Capabilities = caps
+		cfg.Skills.Entries["google-workspace"] = entry
+	}
+	if strings.TrimSpace(configureM365Read) != "" {
+		caps, err := parseCapabilitySelection(configureM365Read, map[string]struct{}{
+			"mail": {}, "calendar": {}, "files": {}, "all": {},
+		})
+		if err != nil {
+			return fmt.Errorf("invalid --m365-read: %w", err)
+		}
+		entry := cfg.Skills.Entries["m365"]
+		entry.Enabled = true
+		entry.Capabilities = caps
+		cfg.Skills.Entries["m365"] = entry
 	}
 
 	if err := config.Save(cfg); err != nil {
@@ -123,6 +156,33 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(cmd.OutOrStdout(), "Updated skills.nodeManager: %s\n", cfg.Skills.NodeManager)
 	fmt.Fprintf(cmd.OutOrStdout(), "Updated skills.scope: %s\n", cfg.Skills.Scope)
 	return nil
+}
+
+func parseCapabilitySelection(raw string, allowed map[string]struct{}) ([]string, error) {
+	parts := parseCSVList(raw)
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("expected comma-separated capability list")
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		v := strings.ToLower(strings.TrimSpace(p))
+		if v == "" {
+			continue
+		}
+		if _, ok := allowed[v]; !ok {
+			return nil, fmt.Errorf("unsupported capability %q", v)
+		}
+		if _, dup := seen[v]; dup {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no valid capabilities provided")
+	}
+	return out, nil
 }
 
 func parseCSVList(raw string) []string {

--- a/internal/cli/configure_test.go
+++ b/internal/cli/configure_test.go
@@ -38,6 +38,8 @@ func TestConfigureSkillsFlags(t *testing.T) {
 		"--skills-node-manager=pnpm",
 		"--enable-skill=github",
 		"--disable-skill=weather",
+		"--google-workspace-read=mail,calendar",
+		"--m365-read=files",
 	); err != nil {
 		t.Fatalf("configure skills flags failed: %v", err)
 	}
@@ -77,5 +79,22 @@ func TestConfigureSkillsFlags(t *testing.T) {
 	}
 	if v, _ := weather["enabled"].(bool); v {
 		t.Fatalf("expected weather enabled override false")
+	}
+	gws, ok := entries["google-workspace"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected google-workspace entry override")
+	}
+	if v, _ := gws["enabled"].(bool); !v {
+		t.Fatalf("expected google-workspace enabled override true")
+	}
+	if caps, ok := gws["capabilities"].([]any); !ok || len(caps) != 2 {
+		t.Fatalf("expected google-workspace capabilities [mail calendar], got %#v", gws["capabilities"])
+	}
+	m365, ok := entries["m365"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected m365 entry override")
+	}
+	if caps, ok := m365["capabilities"].([]any); !ok || len(caps) != 1 {
+		t.Fatalf("expected m365 capabilities [files], got %#v", m365["capabilities"])
 	}
 }

--- a/internal/cli/configure_test.go
+++ b/internal/cli/configure_test.go
@@ -1,6 +1,9 @@
 package cli
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -10,5 +13,69 @@ func TestParseCSVList(t *testing.T) {
 	want := []string{"agent-a", "agent-b", "*"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected parse result: got=%v want=%v", got, want)
+	}
+}
+
+func TestConfigureSkillsFlags(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgDir := filepath.Join(tmpDir, ".kafclaw")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(`{"skills":{"enabled":false,"nodeManager":"npm","entries":{}}}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	_ = os.Setenv("HOME", tmpDir)
+
+	if _, err := runRootCommand(t,
+		"configure",
+		"--non-interactive",
+		"--skills-enabled-set",
+		"--skills-enabled=true",
+		"--skills-node-manager=pnpm",
+		"--enable-skill=github",
+		"--disable-skill=weather",
+	); err != nil {
+		t.Fatalf("configure skills flags failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(cfgDir, "config.json"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	skills, ok := cfg["skills"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing skills section")
+	}
+	if enabled, _ := skills["enabled"].(bool); !enabled {
+		t.Fatalf("expected skills enabled true, got %#v", skills["enabled"])
+	}
+	if nm, _ := skills["nodeManager"].(string); nm != "pnpm" {
+		t.Fatalf("expected skills.nodeManager pnpm, got %q", nm)
+	}
+	entries, ok := skills["entries"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected skills.entries object")
+	}
+	gh, ok := entries["github"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected github entry override")
+	}
+	if v, _ := gh["enabled"].(bool); !v {
+		t.Fatalf("expected github enabled override true")
+	}
+	weather, ok := entries["weather"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected weather entry override")
+	}
+	if v, _ := weather["enabled"].(bool); v {
+		t.Fatalf("expected weather enabled override false")
 	}
 }

--- a/internal/cli/onboard.go
+++ b/internal/cli/onboard.go
@@ -2,20 +2,23 @@ package cli
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/KafClaw/KafClaw/internal/config"
 	"github.com/KafClaw/KafClaw/internal/identity"
 	"github.com/KafClaw/KafClaw/internal/onboarding"
+	skillruntime "github.com/KafClaw/KafClaw/internal/skills"
 	"github.com/spf13/cobra"
 )
 
 var onboardCmd = &cobra.Command{
 	Use:   "onboard",
 	Short: "Initialize configuration and scaffold workspace",
-	Run:   runOnboard,
+	RunE:  runOnboard,
 }
 
 var onboardForce bool
@@ -43,10 +46,33 @@ var onboardSubModel string
 var onboardSubThinking string
 var onboardSubAllowAgents string
 var onboardNonInteractive bool
+var onboardAcceptRisk bool
+var onboardJSON bool
+var onboardSkipSkills bool
+var onboardInstallClawhub bool
+var onboardSkillsNodeMajor string
+
+type onboardingSkillsSummary struct {
+	Enabled      bool     `json:"enabled"`
+	StateDirsOK  bool     `json:"stateDirsOk"`
+	NodeFound    bool     `json:"nodeFound"`
+	ClawhubFound bool     `json:"clawhubFound"`
+	Remediation  []string `json:"remediation,omitempty"`
+	Warnings     []string `json:"warnings,omitempty"`
+}
+
+type onboardingSummary struct {
+	ConfigPath string                  `json:"configPath"`
+	Workspace  string                  `json:"workspace"`
+	WorkRepo   string                  `json:"workRepo"`
+	Skills     onboardingSkillsSummary `json:"skills"`
+}
 
 func init() {
 	onboardCmd.Flags().BoolVarP(&onboardForce, "force", "f", false, "Overwrite existing config and soul files")
 	onboardCmd.Flags().BoolVar(&onboardNonInteractive, "non-interactive", false, "Run onboarding without prompts")
+	onboardCmd.Flags().BoolVar(&onboardAcceptRisk, "accept-risk", false, "Acknowledge risk for non-interactive onboarding")
+	onboardCmd.Flags().BoolVar(&onboardJSON, "json", false, "Output onboarding summary as JSON")
 	onboardCmd.Flags().StringVar(&onboardProfile, "profile", "", "Preset profile: local | local-kafka | remote")
 	onboardCmd.Flags().StringVar(&onboardMode, "mode", "", "Runtime mode: local | local-kafka | remote")
 	onboardCmd.Flags().StringVar(&onboardLLMPreset, "llm", "", "LLM setup: cli-token | openai-compatible | skip")
@@ -65,6 +91,9 @@ func init() {
 	onboardCmd.Flags().StringVar(&onboardSubAllowAgents, "subagents-allow-agents", "", "Comma-separated agent IDs allowed for sessions_spawn agentId (use '*' for any)")
 	onboardCmd.Flags().StringVar(&onboardSubModel, "subagents-model", "", "Default model for spawned subagents")
 	onboardCmd.Flags().StringVar(&onboardSubThinking, "subagents-thinking", "", "Default thinking level for spawned subagents")
+	onboardCmd.Flags().BoolVar(&onboardSkipSkills, "skip-skills", false, "Skip skills bootstrap")
+	onboardCmd.Flags().BoolVar(&onboardInstallClawhub, "install-clawhub", true, "Install clawhub via npm if missing during skills bootstrap")
+	onboardCmd.Flags().StringVar(&onboardSkillsNodeMajor, "skills-node-major", "20", "Node major version to pin in .nvmrc for skills")
 	onboardCmd.Flags().BoolVar(&onboardSystemd, "systemd", false, "Install systemd service + override + env file (Linux)")
 	onboardCmd.Flags().StringVar(&onboardServiceUser, "service-user", "kafclaw", "Service user for systemd setup")
 	onboardCmd.Flags().StringVar(&onboardServiceBinary, "service-binary", "/usr/local/bin/kafclaw", "kafclaw binary path for systemd ExecStart")
@@ -74,11 +103,14 @@ func init() {
 	rootCmd.AddCommand(onboardCmd)
 }
 
-func runOnboard(cmd *cobra.Command, args []string) {
+func runOnboard(cmd *cobra.Command, args []string) error {
+	if onboardNonInteractive && !onboardAcceptRisk {
+		return fmt.Errorf("non-interactive onboarding requires --accept-risk")
+	}
+
 	printHeader("🚀 KafClaw Onboard")
 	fmt.Println("Initializing KafClaw...")
 
-	// 1. Config file
 	cfgPath, _ := config.ConfigPath()
 
 	if _, err := os.Stat(cfgPath); err == nil && !onboardForce {
@@ -93,7 +125,6 @@ func runOnboard(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	// 2. Load config (with expanded paths) for scaffolding
 	cfg, err := config.Load()
 	if err != nil {
 		fmt.Printf("Config warning: %v (using defaults)\n", err)
@@ -102,7 +133,6 @@ func runOnboard(cmd *cobra.Command, args []string) {
 		cfg = config.DefaultConfig()
 	}
 
-	// 2.1 Guided mode/provider onboarding
 	if err := onboarding.RunProfileWizard(cfg, cmd.InOrStdin(), cmd.OutOrStdout(), onboarding.WizardParams{
 		Profile:          onboardProfile,
 		Mode:             onboardMode,
@@ -125,7 +155,7 @@ func runOnboard(cmd *cobra.Command, args []string) {
 		NonInteractive:   onboardNonInteractive,
 	}); err != nil {
 		fmt.Printf("Onboarding wizard error: %v\n", err)
-		return
+		return nil
 	}
 
 	fmt.Fprintln(cmd.OutOrStdout(), onboarding.BuildProfileSummary(cfg))
@@ -134,20 +164,19 @@ func runOnboard(cmd *cobra.Command, args []string) {
 		ok, err := onboarding.ConfirmApply(confirmReader, cmd.OutOrStdout())
 		if err != nil {
 			fmt.Printf("Onboarding confirmation error: %v\n", err)
-			return
+			return nil
 		}
 		if !ok {
 			fmt.Println("Onboarding aborted before writing config.")
-			return
+			return nil
 		}
 	}
 	if err := config.Save(cfg); err != nil {
 		fmt.Printf("Error saving configured onboarding profile: %v\n", err)
-		return
+		return nil
 	}
 	fmt.Printf("Updated configuration at: %s\n", cfgPath)
 
-	// 3. Scaffold workspace soul files
 	fmt.Printf("\nWorkspace: %s\n", cfg.Paths.Workspace)
 	result, err := identity.ScaffoldWorkspace(cfg.Paths.Workspace, onboardForce)
 	if err != nil {
@@ -164,7 +193,6 @@ func runOnboard(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	// 4. Ensure work repo directories
 	if warn, err := config.EnsureWorkRepo(cfg.Paths.WorkRepoPath); err != nil {
 		fmt.Printf("Work repo error: %v\n", err)
 	} else {
@@ -174,15 +202,78 @@ func runOnboard(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	skillsSummary := onboardingSkillsSummary{
+		Enabled:      cfg.Skills.Enabled,
+		NodeFound:    skillruntime.HasBinary("node"),
+		ClawhubFound: skillruntime.HasBinary("clawhub"),
+	}
+	if onboardSkipSkills {
+		fmt.Println("\nSkills bootstrap: skipped (--skip-skills)")
+	} else {
+		enableSkills := onboardNonInteractive
+		if !onboardNonInteractive {
+			fmt.Print("\nEnable skills now? [Y/n]: ")
+			confirmReader := bufio.NewReader(cmd.InOrStdin())
+			line, _ := confirmReader.ReadString('\n')
+			answer := strings.TrimSpace(strings.ToLower(line))
+			enableSkills = answer == "" || answer == "y" || answer == "yes"
+		}
+		if enableSkills {
+			cfg.Skills.Enabled = true
+			skillsSummary.Enabled = true
+			if cfg.Skills.NodeManager == "" {
+				cfg.Skills.NodeManager = "npm"
+			}
+			if err := config.Save(cfg); err != nil {
+				fmt.Printf("Skills bootstrap warning: failed saving config: %v\n", err)
+				skillsSummary.Warnings = append(skillsSummary.Warnings, err.Error())
+			}
+			if _, err := skillruntime.EnsureStateDirs(); err != nil {
+				fmt.Printf("Skills bootstrap warning: failed creating secure dirs: %v\n", err)
+				skillsSummary.Warnings = append(skillsSummary.Warnings, err.Error())
+			} else {
+				skillsSummary.StateDirsOK = true
+			}
+			if _, err := skillruntime.EnsureNVMRC(cfg.Paths.WorkRepoPath, onboardSkillsNodeMajor); err != nil {
+				fmt.Printf("Skills bootstrap warning: failed writing .nvmrc: %v\n", err)
+				skillsSummary.Warnings = append(skillsSummary.Warnings, err.Error())
+			}
+			skillsSummary.NodeFound = skillruntime.HasBinary("node")
+			if !skillsSummary.NodeFound {
+				fmt.Println("Skills bootstrap warning: node not found in PATH; install Node.js and run 'kafclaw skills enable'.")
+				skillsSummary.Remediation = append(skillsSummary.Remediation, "Install Node.js and rerun `kafclaw skills enable`.")
+			} else if err := skillruntime.EnsureClawhub(onboardInstallClawhub); err != nil {
+				fmt.Printf("Skills bootstrap warning: %v\n", err)
+				skillsSummary.Warnings = append(skillsSummary.Warnings, err.Error())
+				skillsSummary.Remediation = append(skillsSummary.Remediation, "Install clawhub (`npm install -g --ignore-scripts clawhub`) or rerun with --install-clawhub.")
+			}
+			skillsSummary.ClawhubFound = skillruntime.HasBinary("clawhub")
+			fmt.Println("Skills bootstrap complete. Use 'kafclaw skills list' to inspect status.")
+		} else {
+			fmt.Println("\nSkills bootstrap: not enabled")
+		}
+	}
+
 	fmt.Println("\nNext steps:")
 	fmt.Println("1. Review ~/.kafclaw/config.json and ~/.config/kafclaw/env.")
 	fmt.Println("2. Customize soul files in your workspace (SOUL.md, USER.md, etc.)")
 	fmt.Println("3. Run 'kafclaw agent -m \"hello\"' to test.")
 
+	if onboardJSON {
+		summary := onboardingSummary{
+			ConfigPath: cfgPath,
+			Workspace:  cfg.Paths.Workspace,
+			WorkRepo:   cfg.Paths.WorkRepoPath,
+			Skills:     skillsSummary,
+		}
+		data, _ := json.MarshalIndent(summary, "", "  ")
+		fmt.Fprintln(cmd.OutOrStdout(), string(data))
+	}
+
 	if onboardSystemd {
 		if runtime.GOOS != "linux" {
 			fmt.Println("\nSystemd setup is only supported on Linux.")
-			return
+			return nil
 		}
 		result, err := onboarding.SetupSystemdGateway(onboarding.SetupOptions{
 			ServiceUser: onboardServiceUser,
@@ -194,7 +285,7 @@ func runOnboard(cmd *cobra.Command, args []string) {
 		})
 		if err != nil {
 			fmt.Printf("\nSystemd setup failed: %v\n", err)
-			return
+			return nil
 		}
 
 		fmt.Println("\nSystemd setup complete:")
@@ -206,4 +297,5 @@ func runOnboard(cmd *cobra.Command, args []string) {
 		fmt.Printf("  + Env file: %s\n", result.EnvPath)
 		fmt.Println("  Next (as root): systemctl daemon-reload && systemctl enable --now kafclaw-gateway.service")
 	}
+	return nil
 }

--- a/internal/cli/onboard_test.go
+++ b/internal/cli/onboard_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOnboardNonInteractiveRequiresAcceptRisk(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	_ = os.Setenv("HOME", tmpDir)
+
+	_, err := runRootCommand(t, "onboard", "--non-interactive", "--skip-skills")
+	if err == nil {
+		t.Fatal("expected onboard to fail without --accept-risk in non-interactive mode")
+	}
+}
+
+func TestOnboardJSONSummary(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	_ = os.Setenv("HOME", tmpDir)
+
+	out, err := runRootCommand(t, "onboard", "--non-interactive", "--accept-risk", "--skip-skills", "--json")
+	if err != nil {
+		t.Fatalf("onboard failed: %v", err)
+	}
+	if !strings.Contains(out, "\"configPath\"") || !strings.Contains(out, "\"skills\"") {
+		t.Fatalf("expected onboarding JSON summary in output, got %q", out)
+	}
+}
+
+func TestOnboardSkillsBootstrapPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	origPath := os.Getenv("PATH")
+	defer os.Setenv("HOME", origHome)
+	defer os.Setenv("PATH", origPath)
+	_ = os.Setenv("HOME", tmpDir)
+
+	bin := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	for _, name := range []string{"node", "clawhub"} {
+		script := filepath.Join(bin, name)
+		if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	_ = os.Setenv("PATH", bin+string(os.PathListSeparator)+origPath)
+
+	out, err := runRootCommand(t, "onboard", "--non-interactive", "--accept-risk", "--skip-skills=false", "--json")
+	if err != nil {
+		t.Fatalf("onboard failed: %v", err)
+	}
+	if !strings.Contains(out, "\"enabled\": true") && !strings.Contains(out, "\"enabled\":true") {
+		t.Fatalf("expected skills enabled in onboarding output, got %q", out)
+	}
+}

--- a/internal/cli/security.go
+++ b/internal/cli/security.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/KafClaw/KafClaw/internal/cliconfig"
+	"github.com/spf13/cobra"
+)
+
+var securityJSON bool
+var securityAuditDeep bool
+var securityFixYes bool
+
+var securityCmd = &cobra.Command{
+	Use:   "security",
+	Short: "Run security checks, deep audits, and safe remediations",
+}
+
+var securityCheckCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Run fast security checks",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		report, err := cliconfig.RunSecurityCheck()
+		if err != nil {
+			return formatSecurityError("CHECK_FAILED", err, "rerun with `kafclaw security check --json` for details")
+		}
+		return printSecurityReport(cmd, report)
+	},
+}
+
+var securityAuditCmd = &cobra.Command{
+	Use:   "audit",
+	Short: "Run security audit (optionally deep)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		report, err := cliconfig.RunSecurityAudit(cliconfig.SecurityAuditOptions{Deep: securityAuditDeep})
+		if err != nil {
+			return formatSecurityError("AUDIT_FAILED", err, "rerun with `kafclaw security audit --deep --json`")
+		}
+		return printSecurityReport(cmd, report)
+	},
+}
+
+var securityFixCmd = &cobra.Command{
+	Use:   "fix",
+	Short: "Apply safe security remediations",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		report, err := cliconfig.RunSecurityFix(cliconfig.SecurityFixOptions{Yes: securityFixYes})
+		if err != nil {
+			return formatSecurityError("FIX_FAILED", err, "rerun with `kafclaw security fix --yes` to confirm remediation")
+		}
+		return printSecurityReport(cmd, report)
+	},
+}
+
+func init() {
+	securityCmd.AddCommand(securityCheckCmd)
+	securityCmd.AddCommand(securityAuditCmd)
+	securityCmd.AddCommand(securityFixCmd)
+
+	securityCheckCmd.Flags().BoolVar(&securityJSON, "json", false, "Output JSON")
+	securityAuditCmd.Flags().BoolVar(&securityJSON, "json", false, "Output JSON")
+	securityAuditCmd.Flags().BoolVar(&securityAuditDeep, "deep", false, "Run deep audit (verifies installed skills)")
+	securityFixCmd.Flags().BoolVar(&securityJSON, "json", false, "Output JSON")
+	securityFixCmd.Flags().BoolVar(&securityFixYes, "yes", false, "Confirm applying security remediations")
+
+	rootCmd.AddCommand(securityCmd)
+}
+
+func printSecurityReport(cmd *cobra.Command, report cliconfig.SecurityReport) error {
+	if securityJSON {
+		fmt.Fprintln(cmd.OutOrStdout(), cliconfig.MarshalSecurityReport(report))
+	} else {
+		failures := 0
+		for _, check := range report.Checks {
+			symbol := "PASS"
+			if check.Status == cliconfig.SecurityWarn {
+				symbol = "WARN"
+			}
+			if check.Status == cliconfig.SecurityFail {
+				symbol = "FAIL"
+				failures++
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "[%s] %s: %s\n", symbol, check.Name, check.Message)
+		}
+		if failures > 0 {
+			return fmt.Errorf("security reported %d failing check(s)", failures)
+		}
+	}
+	if report.HasFailures() {
+		return fmt.Errorf("security reported failing checks")
+	}
+	return nil
+}
+
+func formatSecurityError(code string, err error, remediation string) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("[%s] %v. remediation: %s", strings.ToUpper(strings.TrimSpace(code)), err, remediation)
+}

--- a/internal/cli/security_test.go
+++ b/internal/cli/security_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSecurityCheckCommand(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	_ = os.Setenv("HOME", tmpDir)
+
+	out, err := runRootCommand(t, "security", "check")
+	if err != nil && !strings.Contains(out, "[FAIL]") {
+		t.Fatalf("security check failed unexpectedly: %v", err)
+	}
+	if !strings.Contains(out, "doctor:") {
+		t.Fatalf("expected doctor-derived checks in output, got %q", out)
+	}
+}
+
+func TestSecurityFixRequiresYes(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	_ = os.Setenv("HOME", tmpDir)
+
+	_, err := runRootCommand(t, "security", "fix")
+	if err == nil {
+		t.Fatal("expected security fix to require --yes")
+	}
+}
+
+func TestSecurityFixAppliesSkillPolicyDefaults(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgDir := filepath.Join(tmpDir, ".kafclaw")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	cfg := `{
+	  "skills": {
+	    "enabled": true,
+	    "linkPolicy": {
+	      "mode": "allowlist",
+	      "allowDomains": [],
+	      "allowHttp": true,
+	      "maxLinksPerSkill": 0
+	    }
+	  }
+	}`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	_ = os.Setenv("HOME", tmpDir)
+
+	_, _ = runRootCommand(t, "security", "fix", "--yes")
+
+	data, err := os.ReadFile(filepath.Join(cfgDir, "config.json"))
+	if err != nil {
+		t.Fatalf("read config after fix: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, `"allowHttp": false`) && !strings.Contains(text, `"allowHttp":false`) {
+		t.Fatalf("expected allowHttp=false after fix, got: %s", text)
+	}
+	if !strings.Contains(text, "clawhub.ai") {
+		t.Fatalf("expected default allow domain after fix, got: %s", text)
+	}
+}

--- a/internal/cli/skills.go
+++ b/internal/cli/skills.go
@@ -1,0 +1,632 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+	"github.com/KafClaw/KafClaw/internal/skills"
+	"github.com/spf13/cobra"
+)
+
+var (
+	skillsListJSON         bool
+	skillsStatusJSON       bool
+	skillsEnableInstallHub bool
+	skillsEnableNodeMajor  string
+	skillsVerifyJSON       bool
+	skillsInstallJSON      bool
+	skillsUpdateJSON       bool
+	skillsApproveWarnings  bool
+	skillsPrereqDryRun     bool
+	skillsPrereqJSON       bool
+	skillsPrereqYes        bool
+	skillsAuthProfile      string
+	skillsAuthClientID     string
+	skillsAuthClientSecret string
+	skillsAuthRedirectURI  string
+	skillsAuthScopes       string
+	skillsAuthTenantID     string
+	skillsAuthCode         string
+	skillsAuthState        string
+	skillsAuthCallbackURL  string
+	skillsAuthJSON         bool
+	skillsExecJSON         bool
+)
+
+var skillsCmd = &cobra.Command{
+	Use:   "skills",
+	Short: "Manage bundled and external skills",
+}
+
+var skillsPrereqCmd = &cobra.Command{
+	Use:   "prereq",
+	Short: "Check/install skill prerequisites",
+}
+
+var skillsAuthCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Headless auth flows for skills",
+}
+
+type skillListRow struct {
+	Name       string   `json:"name"`
+	Source     string   `json:"source"`
+	Enabled    bool     `json:"enabled"`
+	Configured bool     `json:"configured"`
+	Eligible   bool     `json:"eligible"`
+	Missing    []string `json:"missing,omitempty"`
+}
+
+type skillsStatusPayload struct {
+	SkillsEnabled    bool           `json:"skillsEnabled"`
+	Scope            string         `json:"scope"`
+	RuntimeIsolation string         `json:"runtimeIsolation"`
+	NodeFound        bool           `json:"nodeFound"`
+	ClawhubFound     bool           `json:"clawhubFound"`
+	Rows             []skillListRow `json:"rows"`
+}
+
+var skillsEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable the skills system and bootstrap prerequisites",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Load()
+		if err != nil {
+			return formatSkillError("CONFIG_LOAD_FAILED", err, "check ~/.kafclaw/config.json")
+		}
+		cfg.Skills.Enabled = true
+		if cfg.Skills.NodeManager == "" {
+			cfg.Skills.NodeManager = "npm"
+		}
+		if err := config.Save(cfg); err != nil {
+			return formatSkillError("CONFIG_SAVE_FAILED", err, "verify write permissions for ~/.kafclaw")
+		}
+		if _, err := skills.EnsureStateDirs(); err != nil {
+			return formatSkillError("STATE_DIRS_FAILED", err, "check permissions on ~/.kafclaw/skills")
+		}
+		if _, err := skills.EnsureNVMRC(cfg.Paths.WorkRepoPath, skillsEnableNodeMajor); err != nil {
+			return formatSkillError("NVMRC_WRITE_FAILED", err, "check work repo path permissions")
+		}
+		if !skills.HasBinary("node") {
+			return formatSkillError("NODE_MISSING", fmt.Errorf("node not found in PATH"), "install Node.js, then rerun `kafclaw skills enable`")
+		}
+		if err := skills.EnsureClawhub(skillsEnableInstallHub); err != nil {
+			return formatSkillError("CLAWHUB_BOOTSTRAP_FAILED", err, "install clawhub (`npm install -g --ignore-scripts clawhub`) or rerun with --install-clawhub=false")
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "Skills system enabled.")
+		return nil
+	},
+}
+
+var skillsDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable the skills system",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Load()
+		if err != nil {
+			return formatSkillError("CONFIG_LOAD_FAILED", err, "check ~/.kafclaw/config.json")
+		}
+		cfg.Skills.Enabled = false
+		if err := config.Save(cfg); err != nil {
+			return formatSkillError("CONFIG_SAVE_FAILED", err, "verify write permissions for ~/.kafclaw")
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "Skills system disabled.")
+		return nil
+	},
+}
+
+var skillsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List bundled and configured skills",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Load()
+		if err != nil {
+			return formatSkillError("CONFIG_LOAD_FAILED", err, "check ~/.kafclaw/config.json")
+		}
+		payload := buildSkillsStatus(cfg)
+
+		if skillsListJSON {
+			data, _ := json.MarshalIndent(payload, "", "  ")
+			fmt.Fprintln(cmd.OutOrStdout(), string(data))
+			return nil
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Skills enabled: %v\n", payload.SkillsEnabled)
+		fmt.Fprintln(cmd.OutOrStdout(), "Columns: name | source | state | eligible | missing")
+		for _, row := range payload.Rows {
+			state := "disabled"
+			if row.Enabled {
+				state = "enabled"
+			}
+			eligible := "yes"
+			if !row.Eligible {
+				eligible = "no"
+			}
+			missing := "-"
+			if len(row.Missing) > 0 {
+				missing = strings.Join(row.Missing, ", ")
+			}
+			override := ""
+			if row.Configured {
+				override = " [override]"
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "- %s | %s | %s%s | %s | %s\n", row.Name, row.Source, state, override, eligible, missing)
+		}
+		return nil
+	},
+}
+
+var skillsStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show skills readiness summary",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Load()
+		if err != nil {
+			return formatSkillError("CONFIG_LOAD_FAILED", err, "check ~/.kafclaw/config.json")
+		}
+		payload := buildSkillsStatus(cfg)
+		if skillsStatusJSON {
+			data, _ := json.MarshalIndent(payload, "", "  ")
+			fmt.Fprintln(cmd.OutOrStdout(), string(data))
+			return nil
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Skills enabled: %v\n", payload.SkillsEnabled)
+		fmt.Fprintf(cmd.OutOrStdout(), "Scope: %s\n", payload.Scope)
+		fmt.Fprintf(cmd.OutOrStdout(), "Runtime isolation: %s\n", payload.RuntimeIsolation)
+		fmt.Fprintf(cmd.OutOrStdout(), "Node found: %v\n", payload.NodeFound)
+		fmt.Fprintf(cmd.OutOrStdout(), "Clawhub found: %v\n", payload.ClawhubFound)
+		ready := 0
+		for _, row := range payload.Rows {
+			if row.Eligible {
+				ready++
+			}
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Eligible skills: %d/%d\n", ready, len(payload.Rows))
+		return nil
+	},
+}
+
+var skillsEnableSkillCmd = &cobra.Command{
+	Use:   "enable-skill <name>",
+	Short: "Enable one skill by name",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := strings.TrimSpace(args[0])
+		if name == "" {
+			return formatSkillError("SKILL_NAME_REQUIRED", fmt.Errorf("skill name is required"), "provide a non-empty skill name")
+		}
+		if err := setSkillEnabled(name, true); err != nil {
+			return formatSkillError("SKILL_ENABLE_FAILED", err, "check config write permissions")
+		}
+		if name == "google-cli" {
+			check, err := skills.CheckPrerequisite("google-cli")
+			if err == nil && !check.Installed {
+				fmt.Fprintln(cmd.OutOrStdout(), "Prerequisite missing: google-cli (gcloud). Run: kafclaw skills prereq install google-cli --yes")
+			}
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Skill enabled: %s\n", name)
+		return nil
+	},
+}
+
+var skillsDisableSkillCmd = &cobra.Command{
+	Use:   "disable-skill <name>",
+	Short: "Disable one skill by name",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := strings.TrimSpace(args[0])
+		if name == "" {
+			return formatSkillError("SKILL_NAME_REQUIRED", fmt.Errorf("skill name is required"), "provide a non-empty skill name")
+		}
+		if err := setSkillEnabled(name, false); err != nil {
+			return formatSkillError("SKILL_DISABLE_FAILED", err, "check config write permissions")
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Skill disabled: %s\n", name)
+		return nil
+	},
+}
+
+var skillsVerifyCmd = &cobra.Command{
+	Use:   "verify <path-or-url>",
+	Short: "Verify a skill package/source before install",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		target := strings.TrimSpace(args[0])
+		if target == "" {
+			return formatSkillError("TARGET_REQUIRED", fmt.Errorf("target is required"), "pass a skill path, URL, or slug")
+		}
+		cfg, err := config.Load()
+		if err != nil {
+			return formatSkillError("CONFIG_LOAD_FAILED", err, "check ~/.kafclaw/config.json")
+		}
+		report, err := skills.VerifySkillSource(cfg, target)
+		if err != nil {
+			return formatSkillError("VERIFY_FAILED", err, "run `kafclaw skills verify --json <target>` for detailed findings")
+		}
+		if skillsVerifyJSON {
+			data, _ := json.MarshalIndent(report, "", "  ")
+			fmt.Fprintln(cmd.OutOrStdout(), string(data))
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "Skill: %s\n", report.SkillName)
+			fmt.Fprintf(cmd.OutOrStdout(), "Source: %s (%s)\n", report.ResolvedTarget, report.SourceType)
+			fmt.Fprintf(cmd.OutOrStdout(), "Files: %d, Links: %d\n", report.FileCount, report.LinkCount)
+			for _, f := range report.Findings {
+				if f.File != "" {
+					fmt.Fprintf(cmd.OutOrStdout(), "- [%s] %s (%s) in %s\n", f.Severity, f.Code, f.Message, f.File)
+				} else {
+					fmt.Fprintf(cmd.OutOrStdout(), "- [%s] %s (%s)\n", f.Severity, f.Code, f.Message)
+				}
+			}
+			if len(report.Findings) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No findings.")
+			}
+		}
+		if !report.OK {
+			return formatSkillError("VERIFY_CRITICAL", fmt.Errorf("verification failed with %d critical finding(s)", report.CriticalCount()), "fix critical findings before install/update")
+		}
+		return nil
+	},
+}
+
+var skillsInstallCmd = &cobra.Command{
+	Use:   "install <slug-or-url>",
+	Short: "Install a skill from clawhub slug or URL",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		target := strings.TrimSpace(args[0])
+		cfg, err := config.Load()
+		if err != nil {
+			return formatSkillError("CONFIG_LOAD_FAILED", err, "check ~/.kafclaw/config.json")
+		}
+		res, err := skills.InstallSkill(cfg, target, skillsApproveWarnings)
+		if err != nil {
+			return formatSkillError("INSTALL_FAILED", err, "run `kafclaw skills verify <target>` and retry with --approve-warnings if intended")
+		}
+		if skillsInstallJSON {
+			data, _ := json.MarshalIndent(res, "", "  ")
+			fmt.Fprintln(cmd.OutOrStdout(), string(data))
+			return nil
+		}
+		action := "Installed"
+		if res.Updated {
+			action = "Updated"
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s skill: %s\n", action, res.Name)
+		fmt.Fprintf(cmd.OutOrStdout(), "Path: %s\n", res.InstallPath)
+		if res.WarningCount > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "Warnings: %d (approved)\n", res.WarningCount)
+		}
+		return nil
+	},
+}
+
+var skillsUpdateCmd = &cobra.Command{
+	Use:   "update [name]",
+	Short: "Update one skill or all skills",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var name string
+		if len(args) > 0 {
+			name = strings.TrimSpace(args[0])
+		}
+		cfg, err := config.Load()
+		if err != nil {
+			return formatSkillError("CONFIG_LOAD_FAILED", err, "check ~/.kafclaw/config.json")
+		}
+		results, err := skills.UpdateSkills(cfg, name, skillsApproveWarnings)
+		if err != nil {
+			return formatSkillError("UPDATE_FAILED", err, "run `kafclaw skills list` and verify installed skill metadata")
+		}
+		if skillsUpdateJSON {
+			data, _ := json.MarshalIndent(results, "", "  ")
+			fmt.Fprintln(cmd.OutOrStdout(), string(data))
+			return nil
+		}
+		for _, res := range results {
+			fmt.Fprintf(cmd.OutOrStdout(), "Updated skill: %s (%s)\n", res.Name, res.InstallPath)
+		}
+		return nil
+	},
+}
+
+var skillsPrereqCheckCmd = &cobra.Command{
+	Use:   "check <name>",
+	Short: "Check if a prerequisite is installed",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := skills.CheckPrerequisite(args[0])
+		if err != nil {
+			return formatSkillError("PREREQ_CHECK_FAILED", err, "use one of the supported names (e.g. google-cli)")
+		}
+		if skillsPrereqJSON {
+			data, _ := json.MarshalIndent(res, "", "  ")
+			fmt.Fprintln(cmd.OutOrStdout(), string(data))
+			return nil
+		}
+		state := "missing"
+		if res.Installed {
+			state = "installed"
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", res.Name, state)
+		return nil
+	},
+}
+
+var skillsPrereqInstallCmd = &cobra.Command{
+	Use:   "install <name>",
+	Short: "Install a prerequisite using Go-native routines",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !skillsPrereqDryRun && !skillsPrereqYes {
+			return formatSkillError("PREREQ_CONFIRM_REQUIRED", fmt.Errorf("prerequisite installs require explicit confirmation"), "pass --yes (or use --dry-run)")
+		}
+		res, err := skills.InstallPrerequisite(args[0], skillsPrereqDryRun)
+		if err != nil {
+			return formatSkillError("PREREQ_INSTALL_FAILED", err, "rerun with --dry-run first to review install steps")
+		}
+		if skillsPrereqJSON {
+			data, _ := json.MarshalIndent(res, "", "  ")
+			fmt.Fprintln(cmd.OutOrStdout(), string(data))
+			return nil
+		}
+		if skillsPrereqDryRun {
+			fmt.Fprintf(cmd.OutOrStdout(), "Dry-run install plan for %s:\n", res.Name)
+			for _, m := range res.Messages {
+				fmt.Fprintf(cmd.OutOrStdout(), "- %s\n", m)
+			}
+			return nil
+		}
+		state := "missing"
+		if res.Installed {
+			state = "installed"
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", res.Name, state)
+		return nil
+	},
+}
+
+var skillsAuthStartCmd = &cobra.Command{
+	Use:   "start <provider>",
+	Short: "Start headless OAuth flow for provider (google-workspace|m365)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		input := skills.OAuthStartInput{
+			Provider:     skills.OAuthProvider(strings.TrimSpace(args[0])),
+			Profile:      skillsAuthProfile,
+			ClientID:     skillsAuthClientID,
+			ClientSecret: skillsAuthClientSecret,
+			RedirectURI:  skillsAuthRedirectURI,
+			Scopes:       strings.Split(strings.TrimSpace(skillsAuthScopes), ","),
+			TenantID:     skillsAuthTenantID,
+		}
+		res, err := skills.StartOAuthFlow(input)
+		if err != nil {
+			return formatSkillError("AUTH_START_FAILED", err, "validate client-id/client-secret/redirect-uri and try again")
+		}
+		if skillsAuthJSON {
+			data, _ := json.MarshalIndent(res, "", "  ")
+			fmt.Fprintln(cmd.OutOrStdout(), string(data))
+			return nil
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Provider: %s\n", res.Provider)
+		fmt.Fprintf(cmd.OutOrStdout(), "Profile: %s\n", res.Profile)
+		fmt.Fprintf(cmd.OutOrStdout(), "State: %s\n", res.State)
+		fmt.Fprintln(cmd.OutOrStdout(), "Open this URL, authenticate, then run `kafclaw skills auth complete ...` with code + state:")
+		fmt.Fprintln(cmd.OutOrStdout(), res.AuthorizeURL)
+		return nil
+	},
+}
+
+var skillsAuthCompleteCmd = &cobra.Command{
+	Use:   "complete <provider>",
+	Short: "Complete headless OAuth flow and store tokens securely",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		code := strings.TrimSpace(skillsAuthCode)
+		state := strings.TrimSpace(skillsAuthState)
+		if strings.TrimSpace(skillsAuthCallbackURL) != "" {
+			parsedCode, parsedState, err := skills.ParseOAuthCallbackURL(skillsAuthCallbackURL)
+			if err != nil {
+				return formatSkillError("AUTH_CALLBACK_PARSE_FAILED", err, "pass --code and --state directly if callback URL parsing fails")
+			}
+			if code == "" {
+				code = parsedCode
+			}
+			if state == "" {
+				state = parsedState
+			}
+		}
+		res, err := skills.CompleteOAuthFlow(skills.OAuthCompleteInput{
+			Provider: skills.OAuthProvider(strings.TrimSpace(args[0])),
+			Profile:  skillsAuthProfile,
+			Code:     code,
+			State:    state,
+		})
+		if err != nil {
+			return formatSkillError("AUTH_COMPLETE_FAILED", err, "ensure state matches `skills auth start` output")
+		}
+		if skillsAuthJSON {
+			data, _ := json.MarshalIndent(res, "", "  ")
+			fmt.Fprintln(cmd.OutOrStdout(), string(data))
+			return nil
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Token stored for %s/%s\n", res.Provider, res.Profile)
+		fmt.Fprintf(cmd.OutOrStdout(), "Path: %s\n", res.TokenPath)
+		if !res.ExpiresAt.IsZero() {
+			fmt.Fprintf(cmd.OutOrStdout(), "Expires: %s\n", res.ExpiresAt.Format(time.RFC3339))
+		}
+		return nil
+	},
+}
+
+var skillsExecCmd = &cobra.Command{
+	Use:   "exec <skill> <command> [args...]",
+	Short: "Execute an installed skill command with runtime policy enforcement",
+	Args:  cobra.MinimumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Load()
+		if err != nil {
+			return formatSkillError("CONFIG_LOAD_FAILED", err, "check ~/.kafclaw/config.json")
+		}
+		res, err := skills.ExecuteSkillCommand(cfg, strings.TrimSpace(args[0]), append([]string{}, args[1:]...))
+		if skillsExecJSON {
+			data, _ := json.MarshalIndent(res, "", "  ")
+			fmt.Fprintln(cmd.OutOrStdout(), string(data))
+		}
+		if res != nil && !skillsExecJSON {
+			if res.Stdout != "" {
+				fmt.Fprint(cmd.OutOrStdout(), res.Stdout)
+				if !strings.HasSuffix(res.Stdout, "\n") {
+					fmt.Fprintln(cmd.OutOrStdout())
+				}
+			}
+			if res.Stderr != "" {
+				fmt.Fprint(cmd.OutOrStdout(), res.Stderr)
+				if !strings.HasSuffix(res.Stderr, "\n") {
+					fmt.Fprintln(cmd.OutOrStdout())
+				}
+			}
+			if res.OutputTruncated {
+				fmt.Fprintln(cmd.OutOrStdout(), "[output truncated by policy]")
+			}
+		}
+		if err != nil {
+			return formatSkillError("EXEC_FAILED", err, "check SKILL-POLICY.json and command allow/deny rules")
+		}
+		return nil
+	},
+}
+
+func init() {
+	skillsCmd.AddCommand(skillsEnableCmd)
+	skillsCmd.AddCommand(skillsDisableCmd)
+	skillsCmd.AddCommand(skillsListCmd)
+	skillsCmd.AddCommand(skillsStatusCmd)
+	skillsCmd.AddCommand(skillsEnableSkillCmd)
+	skillsCmd.AddCommand(skillsDisableSkillCmd)
+	skillsCmd.AddCommand(skillsVerifyCmd)
+	skillsCmd.AddCommand(skillsInstallCmd)
+	skillsCmd.AddCommand(skillsUpdateCmd)
+	skillsCmd.AddCommand(skillsPrereqCmd)
+	skillsCmd.AddCommand(skillsAuthCmd)
+	skillsCmd.AddCommand(skillsExecCmd)
+
+	skillsPrereqCmd.AddCommand(skillsPrereqCheckCmd)
+	skillsPrereqCmd.AddCommand(skillsPrereqInstallCmd)
+	skillsAuthCmd.AddCommand(skillsAuthStartCmd)
+	skillsAuthCmd.AddCommand(skillsAuthCompleteCmd)
+
+	skillsListCmd.Flags().BoolVar(&skillsListJSON, "json", false, "Output JSON")
+	skillsStatusCmd.Flags().BoolVar(&skillsStatusJSON, "json", false, "Output JSON")
+	skillsEnableCmd.Flags().BoolVar(&skillsEnableInstallHub, "install-clawhub", true, "Install clawhub via npm if missing")
+	skillsEnableCmd.Flags().StringVar(&skillsEnableNodeMajor, "node-major", "20", "Node major version to pin in .nvmrc when missing")
+	skillsVerifyCmd.Flags().BoolVar(&skillsVerifyJSON, "json", false, "Output JSON")
+	skillsInstallCmd.Flags().BoolVar(&skillsInstallJSON, "json", false, "Output JSON")
+	skillsUpdateCmd.Flags().BoolVar(&skillsUpdateJSON, "json", false, "Output JSON")
+	skillsInstallCmd.Flags().BoolVar(&skillsApproveWarnings, "approve-warnings", false, "Allow install when verify emits warnings")
+	skillsUpdateCmd.Flags().BoolVar(&skillsApproveWarnings, "approve-warnings", false, "Allow update when verify emits warnings")
+	skillsPrereqInstallCmd.Flags().BoolVar(&skillsPrereqDryRun, "dry-run", false, "Show install plan without running commands")
+	skillsPrereqInstallCmd.Flags().BoolVar(&skillsPrereqYes, "yes", false, "Confirm running install routine")
+	skillsPrereqCheckCmd.Flags().BoolVar(&skillsPrereqJSON, "json", false, "Output JSON")
+	skillsPrereqInstallCmd.Flags().BoolVar(&skillsPrereqJSON, "json", false, "Output JSON")
+	skillsAuthStartCmd.Flags().StringVar(&skillsAuthProfile, "profile", "default", "Credential profile name")
+	skillsAuthStartCmd.Flags().StringVar(&skillsAuthClientID, "client-id", "", "OAuth client ID")
+	skillsAuthStartCmd.Flags().StringVar(&skillsAuthClientSecret, "client-secret", "", "OAuth client secret")
+	skillsAuthStartCmd.Flags().StringVar(&skillsAuthRedirectURI, "redirect-uri", "http://localhost:53682/callback", "OAuth redirect URI")
+	skillsAuthStartCmd.Flags().StringVar(&skillsAuthScopes, "scopes", "", "Comma-separated OAuth scopes")
+	skillsAuthStartCmd.Flags().StringVar(&skillsAuthTenantID, "tenant-id", "", "M365 tenant ID (optional, defaults common)")
+	skillsAuthStartCmd.Flags().BoolVar(&skillsAuthJSON, "json", false, "Output JSON")
+	skillsAuthCompleteCmd.Flags().StringVar(&skillsAuthProfile, "profile", "default", "Credential profile name")
+	skillsAuthCompleteCmd.Flags().StringVar(&skillsAuthCode, "code", "", "OAuth authorization code")
+	skillsAuthCompleteCmd.Flags().StringVar(&skillsAuthState, "state", "", "OAuth state returned by provider")
+	skillsAuthCompleteCmd.Flags().StringVar(&skillsAuthCallbackURL, "callback-url", "", "Full callback URL containing code+state")
+	skillsAuthCompleteCmd.Flags().BoolVar(&skillsAuthJSON, "json", false, "Output JSON")
+	skillsExecCmd.Flags().BoolVar(&skillsExecJSON, "json", false, "Output JSON")
+	_ = skillsAuthStartCmd.MarkFlagRequired("client-id")
+	_ = skillsAuthStartCmd.MarkFlagRequired("client-secret")
+
+	rootCmd.AddCommand(skillsCmd)
+}
+
+func setSkillEnabled(skillName string, enabled bool) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	if cfg.Skills.Entries == nil {
+		cfg.Skills.Entries = map[string]config.SkillEntryConfig{}
+	}
+	cfg.Skills.Entries[skillName] = config.SkillEntryConfig{Enabled: enabled}
+	return config.Save(cfg)
+}
+
+func buildSkillsStatus(cfg *config.Config) skillsStatusPayload {
+	rows := make([]skillListRow, 0, len(skills.BundledCatalog))
+	bundledSet := map[string]struct{}{}
+	nodeFound := skills.HasBinary("node")
+	clawhubFound := skills.HasBinary("clawhub")
+	for _, s := range skills.BundledCatalog {
+		bundledSet[s.Name] = struct{}{}
+		_, configured := cfg.Skills.Entries[s.Name]
+		enabled := skills.EffectiveSkillEnabled(cfg, s.Name)
+		missing := skillMissingRequirements(cfg, s.Name)
+		rows = append(rows, skillListRow{
+			Name:       s.Name,
+			Source:     "bundled",
+			Enabled:    enabled,
+			Configured: configured,
+			Eligible:   len(missing) == 0,
+			Missing:    missing,
+		})
+	}
+	for name := range cfg.Skills.Entries {
+		if _, ok := bundledSet[name]; ok {
+			continue
+		}
+		missing := skillMissingRequirements(cfg, name)
+		rows = append(rows, skillListRow{
+			Name:       name,
+			Source:     "configured",
+			Enabled:    skills.EffectiveSkillEnabled(cfg, name),
+			Configured: true,
+			Eligible:   len(missing) == 0,
+			Missing:    missing,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Name < rows[j].Name })
+	return skillsStatusPayload{
+		SkillsEnabled:    cfg.Skills.Enabled,
+		Scope:            cfg.Skills.Scope,
+		RuntimeIsolation: cfg.Skills.RuntimeIsolation,
+		NodeFound:        nodeFound,
+		ClawhubFound:     clawhubFound,
+		Rows:             rows,
+	}
+}
+
+func skillMissingRequirements(cfg *config.Config, name string) []string {
+	missing := make([]string, 0)
+	if !cfg.Skills.Enabled {
+		missing = append(missing, "skills system disabled")
+	}
+	if !skills.HasBinary("node") {
+		missing = append(missing, "node missing")
+	}
+	if cfg.Skills.ExternalInstalls && !skills.HasBinary("clawhub") {
+		missing = append(missing, "clawhub missing")
+	}
+	if name == "google-cli" && !skills.HasBinary("gcloud") {
+		missing = append(missing, "gcloud missing")
+	}
+	return missing
+}
+
+func formatSkillError(code string, err error, remediation string) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("[%s] %v. remediation: %s", strings.ToUpper(strings.TrimSpace(code)), err, remediation)
+}

--- a/internal/cli/skills_test.go
+++ b/internal/cli/skills_test.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSkillsStatusCommand(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	_ = os.Setenv("HOME", tmpDir)
+
+	out, err := runRootCommand(t, "skills", "status")
+	if err != nil {
+		t.Fatalf("skills status failed: %v", err)
+	}
+	if !strings.Contains(out, "Skills enabled:") || !strings.Contains(out, "Eligible skills:") {
+		t.Fatalf("unexpected status output: %q", out)
+	}
+}
+
+func TestSkillsListShowsReadinessColumns(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgDir := filepath.Join(tmpDir, ".kafclaw")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(`{"skills":{"enabled":false}}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	_ = os.Setenv("HOME", tmpDir)
+
+	out, err := runRootCommand(t, "skills", "list")
+	if err != nil {
+		t.Fatalf("skills list failed: %v", err)
+	}
+	if !strings.Contains(out, "Columns: name | source | state | eligible | missing") {
+		t.Fatalf("missing readiness columns in list output: %q", out)
+	}
+}
+
+func TestFormatSkillError(t *testing.T) {
+	err := formatSkillError("verify_failed", assertErr("boom"), "fix and retry")
+	if err == nil {
+		t.Fatal("expected wrapped error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "[VERIFY_FAILED]") || !strings.Contains(msg, "remediation: fix and retry") {
+		t.Fatalf("unexpected formatted error: %s", msg)
+	}
+}
+
+func TestSkillsEnableDisableLifecycleConfigPersistence(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgDir := filepath.Join(tmpDir, ".kafclaw")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir cfg: %v", err)
+	}
+	origHome := os.Getenv("HOME")
+	origPath := os.Getenv("PATH")
+	defer os.Setenv("HOME", origHome)
+	defer os.Setenv("PATH", origPath)
+	_ = os.Setenv("HOME", tmpDir)
+
+	bin := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	for _, name := range []string{"node", "clawhub"} {
+		script := filepath.Join(bin, name)
+		if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	_ = os.Setenv("PATH", bin+string(os.PathListSeparator)+origPath)
+
+	if _, err := runRootCommand(t, "skills", "enable", "--install-clawhub=false"); err != nil {
+		t.Fatalf("skills enable failed: %v", err)
+	}
+	if _, err := runRootCommand(t, "skills", "disable"); err != nil {
+		t.Fatalf("skills disable failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(cfgDir, "config.json"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	skillCfg, ok := cfg["skills"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected skills section in config")
+	}
+	enabled, _ := skillCfg["enabled"].(bool)
+	if enabled {
+		t.Fatalf("expected skills.enabled false after disable, got %#v", skillCfg["enabled"])
+	}
+}
+
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }

--- a/internal/cliconfig/doctor_test.go
+++ b/internal/cliconfig/doctor_test.go
@@ -435,3 +435,34 @@ func TestDoctorSkillsSecretPermissionsFailAndFix(t *testing.T) {
 		t.Fatalf("expected tomb key mode 600 after fix, got %o", tombSt.Mode().Perm())
 	}
 }
+
+func TestEndpointLooksRemote(t *testing.T) {
+	cases := []struct {
+		endpoint string
+		remote   bool
+	}{
+		{endpoint: "", remote: false},
+		{endpoint: "http://127.0.0.1:8080", remote: false},
+		{endpoint: "http://localhost:9000", remote: false},
+		{endpoint: "https://example.com/api", remote: true},
+		{endpoint: "definitely-not-a-url", remote: true},
+	}
+	for _, tc := range cases {
+		got := endpointLooksRemote(tc.endpoint)
+		if got != tc.remote {
+			t.Fatalf("endpointLooksRemote(%q)=%v, want %v", tc.endpoint, got, tc.remote)
+		}
+	}
+}
+
+func TestTrimEnvQuotes(t *testing.T) {
+	if got := trimEnvQuotes(`"abc"`); got != "abc" {
+		t.Fatalf("expected double quotes trimmed, got %q", got)
+	}
+	if got := trimEnvQuotes(`'abc'`); got != "abc" {
+		t.Fatalf("expected single quotes trimmed, got %q", got)
+	}
+	if got := trimEnvQuotes("abc"); got != "abc" {
+		t.Fatalf("expected bare value unchanged, got %q", got)
+	}
+}

--- a/internal/cliconfig/security.go
+++ b/internal/cliconfig/security.go
@@ -1,0 +1,460 @@
+package cliconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+	skillruntime "github.com/KafClaw/KafClaw/internal/skills"
+)
+
+type SecurityStatus string
+
+const (
+	SecurityPass SecurityStatus = "pass"
+	SecurityWarn SecurityStatus = "warn"
+	SecurityFail SecurityStatus = "fail"
+)
+
+type SecurityCheck struct {
+	Name    string         `json:"name"`
+	Status  SecurityStatus `json:"status"`
+	Message string         `json:"message"`
+}
+
+type SecurityReport struct {
+	Mode    string          `json:"mode"`
+	Checks  []SecurityCheck `json:"checks"`
+	Created time.Time       `json:"created"`
+}
+
+type SecurityAuditOptions struct {
+	Deep bool
+}
+
+type SecurityFixOptions struct {
+	Yes bool
+}
+
+func (r SecurityReport) HasFailures() bool {
+	for _, c := range r.Checks {
+		if c.Status == SecurityFail {
+			return true
+		}
+	}
+	return false
+}
+
+func RunSecurityCheck() (SecurityReport, error) {
+	return runSecurity(SecurityAuditOptions{Deep: false})
+}
+
+func RunSecurityAudit(opts SecurityAuditOptions) (SecurityReport, error) {
+	return runSecurity(opts)
+}
+
+func RunSecurityFix(opts SecurityFixOptions) (SecurityReport, error) {
+	if !opts.Yes {
+		return SecurityReport{}, fmt.Errorf("security fix requires explicit confirmation (--yes)")
+	}
+	report, err := runSecurityFix()
+	if err != nil {
+		return report, err
+	}
+	return report, nil
+}
+
+func runSecurity(opts SecurityAuditOptions) (SecurityReport, error) {
+	report := SecurityReport{
+		Mode:    "check",
+		Checks:  make([]SecurityCheck, 0, 12),
+		Created: time.Now().UTC(),
+	}
+	if opts.Deep {
+		report.Mode = "audit-deep"
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		report.Checks = append(report.Checks, SecurityCheck{
+			Name:    "config_load",
+			Status:  SecurityFail,
+			Message: fmt.Sprintf("failed to load config: %v", err),
+		})
+		return report, nil
+	}
+
+	doctorReport, err := RunDoctorWithOptions(DoctorOptions{})
+	if err != nil {
+		report.Checks = append(report.Checks, SecurityCheck{
+			Name:    "doctor_run",
+			Status:  SecurityFail,
+			Message: fmt.Sprintf("doctor run failed: %v", err),
+		})
+	} else {
+		for _, c := range doctorReport.Checks {
+			status := SecurityPass
+			if c.Status == DoctorWarn {
+				status = SecurityWarn
+			}
+			if c.Status == DoctorFail {
+				status = SecurityFail
+			}
+			report.Checks = append(report.Checks, SecurityCheck{
+				Name:    "doctor:" + c.Name,
+				Status:  status,
+				Message: c.Message,
+			})
+		}
+	}
+
+	appendGapChecks(cfg, &report)
+	if opts.Deep {
+		appendDeepSkillAuditChecks(cfg, &report)
+	}
+	return report, nil
+}
+
+func runSecurityFix() (SecurityReport, error) {
+	report := SecurityReport{
+		Mode:    "fix",
+		Checks:  make([]SecurityCheck, 0, 16),
+		Created: time.Now().UTC(),
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		report.Checks = append(report.Checks, SecurityCheck{
+			Name:    "config_load",
+			Status:  SecurityFail,
+			Message: fmt.Sprintf("failed to load config: %v", err),
+		})
+		return report, nil
+	}
+
+	if _, err := RunDoctorWithOptions(DoctorOptions{Fix: true}); err != nil {
+		report.Checks = append(report.Checks, SecurityCheck{
+			Name:    "doctor_fix",
+			Status:  SecurityFail,
+			Message: fmt.Sprintf("doctor --fix failed: %v", err),
+		})
+	} else {
+		report.Checks = append(report.Checks, SecurityCheck{
+			Name:    "doctor_fix",
+			Status:  SecurityPass,
+			Message: "doctor --fix remediations applied",
+		})
+	}
+
+	changed := false
+	if !cfg.Skills.Enabled {
+		report.Checks = append(report.Checks, SecurityCheck{
+			Name:    "skills_policy_defaults",
+			Status:  SecurityPass,
+			Message: "skills disabled; no policy default changes needed",
+		})
+	} else {
+		mode := strings.ToLower(strings.TrimSpace(cfg.Skills.LinkPolicy.Mode))
+		switch mode {
+		case "allowlist", "denylist", "open":
+		default:
+			cfg.Skills.LinkPolicy.Mode = "allowlist"
+			changed = true
+		}
+		if strings.EqualFold(cfg.Skills.LinkPolicy.Mode, "allowlist") && len(cfg.Skills.LinkPolicy.AllowDomains) == 0 {
+			cfg.Skills.LinkPolicy.AllowDomains = []string{"clawhub.ai"}
+			changed = true
+		}
+		if cfg.Skills.LinkPolicy.AllowHTTP {
+			cfg.Skills.LinkPolicy.AllowHTTP = false
+			changed = true
+		}
+		if cfg.Skills.LinkPolicy.MaxLinksPerSkill <= 0 {
+			cfg.Skills.LinkPolicy.MaxLinksPerSkill = 20
+			changed = true
+		}
+		if !strings.EqualFold(strings.TrimSpace(cfg.Skills.Scope), "selected") {
+			cfg.Skills.Scope = "selected"
+			changed = true
+		}
+		if !strings.EqualFold(strings.TrimSpace(cfg.Skills.RuntimeIsolation), "strict") {
+			cfg.Skills.RuntimeIsolation = "strict"
+			changed = true
+		}
+		if changed {
+			if err := config.Save(cfg); err != nil {
+				report.Checks = append(report.Checks, SecurityCheck{
+					Name:    "skills_policy_defaults",
+					Status:  SecurityFail,
+					Message: fmt.Sprintf("failed to save security defaults: %v", err),
+				})
+			} else {
+				report.Checks = append(report.Checks, SecurityCheck{
+					Name:    "skills_policy_defaults",
+					Status:  SecurityPass,
+					Message: "applied secure skills defaults (allowlist, https-only, link cap, scope=selected, runtimeIsolation=strict)",
+				})
+			}
+		} else {
+			report.Checks = append(report.Checks, SecurityCheck{
+				Name:    "skills_policy_defaults",
+				Status:  SecurityPass,
+				Message: "skills policy defaults already secure",
+			})
+		}
+	}
+
+	post, err := runSecurity(SecurityAuditOptions{Deep: false})
+	if err != nil {
+		report.Checks = append(report.Checks, SecurityCheck{
+			Name:    "post_fix_check",
+			Status:  SecurityFail,
+			Message: fmt.Sprintf("post-fix check failed: %v", err),
+		})
+		return report, nil
+	}
+	report.Checks = append(report.Checks, post.Checks...)
+	return report, nil
+}
+
+func appendGapChecks(cfg *config.Config, report *SecurityReport) {
+	if cfg == nil || report == nil {
+		return
+	}
+	if cfg.Skills.Enabled {
+		mode := strings.ToLower(strings.TrimSpace(cfg.Skills.RuntimeIsolation))
+		if mode != "strict" {
+			report.Checks = append(report.Checks, SecurityCheck{
+				Name:    "gap_runtime_isolation",
+				Status:  SecurityWarn,
+				Message: "skills runtime isolation is not strict; set `skills.runtimeIsolation` to `strict` to require container isolation",
+			})
+		} else {
+			if runtimeBin, err := skillruntime.StrictIsolationPreflight(); err != nil {
+				report.Checks = append(report.Checks, SecurityCheck{
+					Name:    "gap_runtime_isolation",
+					Status:  SecurityFail,
+					Message: fmt.Sprintf("strict mode configured but runtime preflight failed: %v", err),
+				})
+			} else {
+				report.Checks = append(report.Checks, SecurityCheck{
+					Name:    "gap_runtime_isolation",
+					Status:  SecurityPass,
+					Message: fmt.Sprintf("strict container isolation is enabled and runtime `%s` is usable", runtimeBin),
+				})
+			}
+		}
+	}
+	if cfg.Skills.Enabled && cfg.Skills.AllowSystemRepoSkills && strings.EqualFold(strings.TrimSpace(cfg.Skills.Scope), "all") {
+		report.Checks = append(report.Checks, SecurityCheck{
+			Name:    "gap_prompt_skill_scope",
+			Status:  SecurityWarn,
+			Message: "system repo skill prompt loading is set to scope=all; switch to scope=selected for least privilege",
+		})
+	} else if cfg.Skills.Enabled && cfg.Skills.AllowSystemRepoSkills {
+		report.Checks = append(report.Checks, SecurityCheck{
+			Name:    "gap_prompt_skill_scope",
+			Status:  SecurityPass,
+			Message: "system repo skill prompt loading is constrained by selected-skill scope",
+		})
+	}
+	tokenCount, encryptedCount := countOAuthTokenFiles()
+	if tokenCount > 0 {
+		if encryptedCount == tokenCount {
+			report.Checks = append(report.Checks, SecurityCheck{
+				Name:    "gap_oauth_encryption",
+				Status:  SecurityPass,
+				Message: fmt.Sprintf("oauth token files are encrypted at rest (%d/%d)", encryptedCount, tokenCount),
+			})
+		} else {
+			report.Checks = append(report.Checks, SecurityCheck{
+				Name:    "gap_oauth_encryption",
+				Status:  SecurityWarn,
+				Message: fmt.Sprintf("oauth token encryption coverage is partial (%d/%d encrypted); re-auth to rotate old plaintext files", encryptedCount, tokenCount),
+			})
+		}
+	}
+	pinnableCount, pinnedCount := countPinnedExternalSkills()
+	if pinnableCount > 0 {
+		if pinnedCount == pinnableCount {
+			report.Checks = append(report.Checks, SecurityCheck{
+				Name:    "gap_skill_hash_pinning",
+				Status:  SecurityPass,
+				Message: fmt.Sprintf("external skill hash pinning coverage complete (%d/%d)", pinnedCount, pinnableCount),
+			})
+		} else {
+			report.Checks = append(report.Checks, SecurityCheck{
+				Name:    "gap_skill_hash_pinning",
+				Status:  SecurityWarn,
+				Message: fmt.Sprintf("external skill hash pinning is partial (%d/%d); use source URLs with #sha256=<digest>", pinnedCount, pinnableCount),
+			})
+		}
+	}
+}
+
+func appendDeepSkillAuditChecks(cfg *config.Config, report *SecurityReport) {
+	if cfg == nil || report == nil {
+		return
+	}
+	dirs, err := skillruntime.ResolveStateDirs()
+	if err != nil {
+		report.Checks = append(report.Checks, SecurityCheck{
+			Name:    "skills_verify_installed",
+			Status:  SecurityFail,
+			Message: fmt.Sprintf("failed to resolve state dirs: %v", err),
+		})
+		return
+	}
+	entries, err := os.ReadDir(dirs.Installed)
+	if err != nil {
+		if os.IsNotExist(err) {
+			report.Checks = append(report.Checks, SecurityCheck{
+				Name:    "skills_verify_installed",
+				Status:  SecurityPass,
+				Message: "no installed skills to audit",
+			})
+			return
+		}
+		report.Checks = append(report.Checks, SecurityCheck{
+			Name:    "skills_verify_installed",
+			Status:  SecurityFail,
+			Message: fmt.Sprintf("failed reading installed skills: %v", err),
+		})
+		return
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	if len(names) == 0 {
+		report.Checks = append(report.Checks, SecurityCheck{
+			Name:    "skills_verify_installed",
+			Status:  SecurityPass,
+			Message: "no installed skills to audit",
+		})
+		return
+	}
+
+	for _, name := range names {
+		p := filepath.Join(dirs.Installed, name)
+		verify, err := skillruntime.VerifySkillSource(cfg, p)
+		if err != nil {
+			report.Checks = append(report.Checks, SecurityCheck{
+				Name:    "skills_verify:" + name,
+				Status:  SecurityFail,
+				Message: fmt.Sprintf("verify failed: %v", err),
+			})
+			continue
+		}
+		if verify.CriticalCount() > 0 {
+			report.Checks = append(report.Checks, SecurityCheck{
+				Name:    "skills_verify:" + name,
+				Status:  SecurityFail,
+				Message: fmt.Sprintf("critical findings=%d warnings=%d", verify.CriticalCount(), verify.WarningCount()),
+			})
+		} else if verify.WarningCount() > 0 {
+			report.Checks = append(report.Checks, SecurityCheck{
+				Name:    "skills_verify:" + name,
+				Status:  SecurityWarn,
+				Message: fmt.Sprintf("warnings=%d", verify.WarningCount()),
+			})
+		} else {
+			report.Checks = append(report.Checks, SecurityCheck{
+				Name:    "skills_verify:" + name,
+				Status:  SecurityPass,
+				Message: "no findings",
+			})
+		}
+	}
+}
+
+func countOAuthTokenFiles() (total int, encrypted int) {
+	dirs, err := skillruntime.ResolveStateDirs()
+	if err != nil {
+		return 0, 0
+	}
+	authRoot := filepath.Join(dirs.ToolsDir, "auth")
+	total = 0
+	encrypted = 0
+	_ = filepath.WalkDir(authRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(path, string(os.PathSeparator)+"token.json") {
+			total++
+			if isEncryptedOAuthBlobFile(path) {
+				encrypted++
+			}
+		}
+		return nil
+	})
+	return total, encrypted
+}
+
+func isEncryptedOAuthBlobFile(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return false
+	}
+	_, hasCiphertext := obj["ciphertext"]
+	_, hasNonce := obj["nonce"]
+	_, hasVersion := obj["version"]
+	_, hasAccessToken := obj["access_token"]
+	return hasCiphertext && hasNonce && hasVersion && !hasAccessToken
+}
+
+func MarshalSecurityReport(r SecurityReport) string {
+	data, _ := json.MarshalIndent(r, "", "  ")
+	return string(data)
+}
+
+func countPinnedExternalSkills() (pinnable int, pinned int) {
+	dirs, err := skillruntime.ResolveStateDirs()
+	if err != nil {
+		return 0, 0
+	}
+	entries, err := os.ReadDir(dirs.Installed)
+	if err != nil {
+		return 0, 0
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dirs.Installed, e.Name(), ".kafclaw-skill.json"))
+		if err != nil {
+			continue
+		}
+		var meta struct {
+			Source     string `json:"source"`
+			PinnedHash string `json:"pinnedHash"`
+		}
+		if err := json.Unmarshal(data, &meta); err != nil {
+			continue
+		}
+		source := strings.ToLower(strings.TrimSpace(meta.Source))
+		if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
+			pinnable++
+			if strings.TrimSpace(meta.PinnedHash) != "" {
+				pinned++
+			}
+		}
+	}
+	return pinnable, pinned
+}

--- a/internal/cliconfig/security_test.go
+++ b/internal/cliconfig/security_test.go
@@ -1,0 +1,81 @@
+package cliconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunSecurityAuditDeepNoInstalledSkills(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgDir := filepath.Join(tmpDir, ".kafclaw")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(`{"skills":{"enabled":true}}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	_ = os.Setenv("HOME", tmpDir)
+
+	report, err := RunSecurityAudit(SecurityAuditOptions{Deep: true})
+	if err != nil {
+		t.Fatalf("run security audit: %v", err)
+	}
+	found := false
+	for _, c := range report.Checks {
+		if c.Name == "skills_verify_installed" {
+			found = true
+			if !strings.Contains(c.Message, "no installed skills") {
+				t.Fatalf("unexpected deep audit message: %#v", c)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected skills_verify_installed check, got %#v", report.Checks)
+	}
+}
+
+func TestRunSecurityCheckReportsHashPinningGap(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgDir := filepath.Join(tmpDir, ".kafclaw")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(`{"skills":{"enabled":true}}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	installed := filepath.Join(cfgDir, "skills", "installed")
+	if err := os.MkdirAll(filepath.Join(installed, "demo"), 0o700); err != nil {
+		t.Fatalf("mkdir installed skill: %v", err)
+	}
+	meta := `{"name":"demo","source":"https://example.org/demo.zip","sourceHash":"abc","pinnedHash":""}`
+	if err := os.WriteFile(filepath.Join(installed, "demo", ".kafclaw-skill.json"), []byte(meta), 0o600); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	_ = os.Setenv("HOME", tmpDir)
+
+	report, err := RunSecurityCheck()
+	if err != nil {
+		t.Fatalf("run security check: %v", err)
+	}
+	found := false
+	for _, c := range report.Checks {
+		if c.Name == "gap_skill_hash_pinning" {
+			found = true
+			if c.Status != SecurityWarn {
+				t.Fatalf("expected hash pinning warning, got %#v", c)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected gap_skill_hash_pinning check, got %#v", report.Checks)
+	}
+}

--- a/internal/cliconfig/security_test.go
+++ b/internal/cliconfig/security_test.go
@@ -1,10 +1,13 @@
 package cliconfig
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/KafClaw/KafClaw/internal/config"
 )
 
 func TestRunSecurityAuditDeepNoInstalledSkills(t *testing.T) {
@@ -77,5 +80,214 @@ func TestRunSecurityCheckReportsHashPinningGap(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected gap_skill_hash_pinning check, got %#v", report.Checks)
+	}
+}
+
+func TestRunSecurityFixRequiresConfirmation(t *testing.T) {
+	if _, err := RunSecurityFix(SecurityFixOptions{}); err == nil {
+		t.Fatal("expected confirmation error when --yes is missing")
+	}
+}
+
+func TestRunSecurityFixAppliesSecureSkillsDefaults(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgDir := filepath.Join(tmpDir, ".kafclaw")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	seed := `{
+  "skills": {
+    "enabled": true,
+    "scope": "all",
+    "runtimeIsolation": "auto",
+    "linkPolicy": {
+      "mode": "",
+      "allowHttp": true,
+      "maxLinksPerSkill": 0
+    }
+  }
+}`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(seed), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	_ = os.Setenv("HOME", tmpDir)
+
+	report, err := RunSecurityFix(SecurityFixOptions{Yes: true})
+	if err != nil {
+		t.Fatalf("RunSecurityFix error: %v", err)
+	}
+	if report.Mode != "fix" {
+		t.Fatalf("expected fix mode report, got %q", report.Mode)
+	}
+	marshaled := MarshalSecurityReport(report)
+	if !strings.Contains(marshaled, "skills_policy_defaults") {
+		t.Fatalf("expected skills_policy_defaults check in report: %s", marshaled)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("load config after fix: %v", err)
+	}
+	if cfg.Skills.Scope != "selected" {
+		t.Fatalf("expected scope=selected, got %q", cfg.Skills.Scope)
+	}
+	if cfg.Skills.RuntimeIsolation != "strict" {
+		t.Fatalf("expected runtimeIsolation=strict, got %q", cfg.Skills.RuntimeIsolation)
+	}
+	if cfg.Skills.LinkPolicy.Mode != "allowlist" {
+		t.Fatalf("expected linkPolicy.mode=allowlist, got %q", cfg.Skills.LinkPolicy.Mode)
+	}
+	if cfg.Skills.LinkPolicy.AllowHTTP {
+		t.Fatalf("expected linkPolicy.allowHttp=false")
+	}
+	if cfg.Skills.LinkPolicy.MaxLinksPerSkill != 20 {
+		t.Fatalf("expected maxLinksPerSkill=20, got %d", cfg.Skills.LinkPolicy.MaxLinksPerSkill)
+	}
+	if len(cfg.Skills.LinkPolicy.AllowDomains) == 0 {
+		t.Fatal("expected allowDomains default to be set")
+	}
+}
+
+func TestIsEncryptedOAuthBlobFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	encryptedPath := filepath.Join(tmpDir, "encrypted.json")
+	plainPath := filepath.Join(tmpDir, "token.json")
+
+	encryptedBlob := map[string]any{
+		"version":    "v1",
+		"nonce":      "abc",
+		"ciphertext": "def",
+	}
+	plainBlob := map[string]any{
+		"access_token": "token",
+		"expires_in":   3600,
+	}
+	encData, _ := json.Marshal(encryptedBlob)
+	plainData, _ := json.Marshal(plainBlob)
+	if err := os.WriteFile(encryptedPath, encData, 0o600); err != nil {
+		t.Fatalf("write encrypted blob: %v", err)
+	}
+	if err := os.WriteFile(plainPath, plainData, 0o600); err != nil {
+		t.Fatalf("write plain blob: %v", err)
+	}
+
+	if !isEncryptedOAuthBlobFile(encryptedPath) {
+		t.Fatalf("expected encrypted blob to be detected")
+	}
+	if isEncryptedOAuthBlobFile(plainPath) {
+		t.Fatalf("expected plain oauth token file to not be detected as encrypted")
+	}
+}
+
+func TestSecurityReportHasFailures(t *testing.T) {
+	report := SecurityReport{
+		Checks: []SecurityCheck{
+			{Name: "ok", Status: SecurityPass},
+			{Name: "warn", Status: SecurityWarn},
+			{Name: "fail", Status: SecurityFail},
+		},
+	}
+	if !report.HasFailures() {
+		t.Fatal("expected HasFailures to return true when at least one check failed")
+	}
+}
+
+func TestSecurityReportHasFailuresFalse(t *testing.T) {
+	report := SecurityReport{
+		Checks: []SecurityCheck{
+			{Name: "ok", Status: SecurityPass},
+			{Name: "warn", Status: SecurityWarn},
+		},
+	}
+	if report.HasFailures() {
+		t.Fatal("expected HasFailures to return false when no check failed")
+	}
+}
+
+func TestRunSecurityAuditDeepChecksInstalledSkills(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgDir := filepath.Join(tmpDir, ".kafclaw")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(`{"skills":{"enabled":true}}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	installedSkillDir := filepath.Join(cfgDir, "skills", "installed", "demo")
+	if err := os.MkdirAll(installedSkillDir, 0o700); err != nil {
+		t.Fatalf("mkdir installed skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(installedSkillDir, ".kafclaw-skill.json"), []byte(`{"name":"demo","source":"https://example.org/demo.zip"}`), 0o600); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	_ = os.Setenv("HOME", tmpDir)
+
+	report, err := RunSecurityAudit(SecurityAuditOptions{Deep: true})
+	if err != nil {
+		t.Fatalf("run security audit deep: %v", err)
+	}
+	found := false
+	for _, c := range report.Checks {
+		if strings.HasPrefix(c.Name, "skills_verify:demo") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected per-skill deep check for demo, got %#v", report.Checks)
+	}
+}
+
+func TestRunSecurityCheckReportsOAuthEncryptionPartialCoverage(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgDir := filepath.Join(tmpDir, ".kafclaw")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(`{"skills":{"enabled":true}}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	plainTokenDir := filepath.Join(cfgDir, "skills", "tools", "auth", "google-workspace", "default")
+	encTokenDir := filepath.Join(cfgDir, "skills", "tools", "auth", "m365", "default")
+	if err := os.MkdirAll(plainTokenDir, 0o700); err != nil {
+		t.Fatalf("mkdir plain token dir: %v", err)
+	}
+	if err := os.MkdirAll(encTokenDir, 0o700); err != nil {
+		t.Fatalf("mkdir encrypted token dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(plainTokenDir, "token.json"), []byte(`{"access_token":"plain"}`), 0o600); err != nil {
+		t.Fatalf("write plain token: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(encTokenDir, "token.json"), []byte(`{"version":"v1","nonce":"a","ciphertext":"b"}`), 0o600); err != nil {
+		t.Fatalf("write encrypted token: %v", err)
+	}
+
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	_ = os.Setenv("HOME", tmpDir)
+
+	report, err := RunSecurityCheck()
+	if err != nil {
+		t.Fatalf("run security check: %v", err)
+	}
+	found := false
+	for _, c := range report.Checks {
+		if c.Name == "gap_oauth_encryption" {
+			found = true
+			if c.Status != SecurityWarn {
+				t.Fatalf("expected oauth encryption warning for partial coverage, got %#v", c)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected gap_oauth_encryption check, got %#v", report.Checks)
 	}
 }

--- a/internal/cliconfig/service_test.go
+++ b/internal/cliconfig/service_test.go
@@ -241,3 +241,14 @@ func TestSetUnsetEmptyPathGuards(t *testing.T) {
 		t.Fatal("expected unsetAtPath empty path error")
 	}
 }
+
+func TestSaveFileConfigMapMarshalError(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, ".kafclaw", "config.json")
+	bad := map[string]any{
+		"bad": func() {},
+	}
+	if err := saveFileConfigMap(cfgPath, bad); err == nil {
+		t.Fatal("expected saveFileConfigMap to fail on non-JSON-serializable values")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -273,7 +273,8 @@ type SkillLinkPolicyConfig struct {
 
 // SkillEntryConfig holds per-skill toggles.
 type SkillEntryConfig struct {
-	Enabled bool `json:"enabled"`
+	Enabled      bool     `json:"enabled"`
+	Capabilities []string `json:"capabilities,omitempty"`
 }
 
 // AgentsConfig mirrors OpenClaw-style defaults block for future compatibility.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Providers    ProvidersConfig      `json:"providers"`
 	Gateway      GatewayConfig        `json:"gateway"`
 	Tools        ToolsConfig          `json:"tools"`
+	Skills       SkillsConfig         `json:"skills"`
 	Group        GroupConfig          `json:"group"`
 	Orchestrator OrchestratorConfig   `json:"orchestrator"`
 	Scheduler    SchedulerConfig      `json:"scheduler"`
@@ -248,6 +249,33 @@ type ToolsConfig struct {
 	Subagents SubagentsToolConfig `json:"subagents"`
 }
 
+// SkillsConfig contains skill-system settings.
+type SkillsConfig struct {
+	Enabled               bool                        `json:"enabled" envconfig:"ENABLED"`
+	AllowSystemRepoSkills bool                        `json:"allowSystemRepoSkills"`
+	AllowWorkspaceSkills  bool                        `json:"allowWorkspaceSkills"`
+	ExternalInstalls      bool                        `json:"externalInstalls"`
+	NodeManager           string                      `json:"nodeManager" envconfig:"NODE_MANAGER"`
+	Scope                 string                      `json:"scope" envconfig:"SCOPE"`
+	RuntimeIsolation      string                      `json:"runtimeIsolation" envconfig:"RUNTIME_ISOLATION"`
+	LinkPolicy            SkillLinkPolicyConfig       `json:"linkPolicy"`
+	Entries               map[string]SkillEntryConfig `json:"entries,omitempty"`
+}
+
+// SkillLinkPolicyConfig controls which links are permitted in skills/installers.
+type SkillLinkPolicyConfig struct {
+	Mode             string   `json:"mode"`
+	AllowDomains     []string `json:"allowDomains,omitempty"`
+	DenyDomains      []string `json:"denyDomains,omitempty"`
+	AllowHTTP        bool     `json:"allowHttp"`
+	MaxLinksPerSkill int      `json:"maxLinksPerSkill"`
+}
+
+// SkillEntryConfig holds per-skill toggles.
+type SkillEntryConfig struct {
+	Enabled bool `json:"enabled"`
+}
+
 // AgentsConfig mirrors OpenClaw-style defaults block for future compatibility.
 type AgentsConfig struct {
 	Defaults AgentDefaultsConfig `json:"defaults"`
@@ -396,6 +424,21 @@ func DefaultConfig() *Config {
 				MaxSpawnDepth:       1,
 				MaxChildrenPerAgent: 5,
 				ArchiveAfterMinutes: 60,
+			},
+		},
+		Skills: SkillsConfig{
+			Enabled:               false,
+			AllowSystemRepoSkills: true,
+			AllowWorkspaceSkills:  false,
+			ExternalInstalls:      false,
+			NodeManager:           "npm",
+			Scope:                 "selected",
+			RuntimeIsolation:      "auto",
+			LinkPolicy: SkillLinkPolicyConfig{
+				Mode:             "allowlist",
+				AllowDomains:     []string{"clawhub.ai"},
+				AllowHTTP:        false,
+				MaxLinksPerSkill: 20,
 			},
 		},
 		Group: GroupConfig{

--- a/internal/config/envfile.go
+++ b/internal/config/envfile.go
@@ -2,10 +2,24 @@ package config
 
 import (
 	"bufio"
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 )
+
+const localTombFileName = "tomb.rr"
+const localTombEnvAAD = "kafclaw-local-env-secrets-v1"
+
+type localTombDoc struct {
+	Version       string `json:"version"`
+	MasterKey     string `json:"masterKey"`
+	EnvNonce      string `json:"envNonce,omitempty"`
+	EnvCiphertext string `json:"envCiphertext,omitempty"`
+}
 
 // LoadEnvFileCandidates loads environment variables from known files.
 // Existing process env vars are never overridden.
@@ -37,6 +51,15 @@ func LoadEnvFileCandidates() {
 		}
 		seen[abs] = struct{}{}
 		_ = loadEnvFile(abs)
+	}
+	// Merge tomb-managed secrets into process env (without overriding explicit env).
+	if kv, err := loadEnvSecretsFromTomb(); err == nil {
+		for k, v := range kv {
+			if _, exists := os.LookupEnv(k); exists {
+				continue
+			}
+			_ = os.Setenv(k, v)
+		}
 	}
 }
 
@@ -85,4 +108,126 @@ func trimOptionalQuotes(v string) string {
 		return v[1 : len(v)-1]
 	}
 	return v
+}
+
+func loadEnvSecretsFromTomb() (map[string]string, error) {
+	tombPath, err := resolveLocalTombPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(tombPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]string{}, nil
+		}
+		return nil, err
+	}
+	doc, err := decodeLocalTombDoc(data)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(doc.EnvNonce) == "" || strings.TrimSpace(doc.EnvCiphertext) == "" {
+		return map[string]string{}, nil
+	}
+	key, err := decodeMasterKey(doc.MasterKey)
+	if err != nil {
+		return nil, err
+	}
+	nonce, err := base64.RawStdEncoding.DecodeString(strings.TrimSpace(doc.EnvNonce))
+	if err != nil {
+		return nil, err
+	}
+	ciphertext, err := base64.RawStdEncoding.DecodeString(strings.TrimSpace(doc.EnvCiphertext))
+	if err != nil {
+		return nil, err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	plain, err := gcm.Open(nil, nonce, ciphertext, []byte(localTombEnvAAD))
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]string{}
+	if err := json.Unmarshal(plain, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func resolveLocalTombPath() (string, error) {
+	if explicit := strings.TrimSpace(os.Getenv("KAFCLAW_OAUTH_TOMB_FILE")); explicit != "" {
+		if strings.HasPrefix(explicit, "~") {
+			home, err := resolveEnvHomeDir()
+			if err != nil {
+				return "", err
+			}
+			return expandTildePath(explicit, home), nil
+		}
+		return explicit, nil
+	}
+	home, err := resolveEnvHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "kafclaw", localTombFileName), nil
+}
+
+func resolveEnvHomeDir() (string, error) {
+	if h := strings.TrimSpace(os.Getenv("KAFCLAW_HOME")); h != "" {
+		if strings.HasPrefix(h, "~") {
+			base, err := os.UserHomeDir()
+			if err != nil {
+				return "", err
+			}
+			return expandTildePath(h, base), nil
+		}
+		return h, nil
+	}
+	return os.UserHomeDir()
+}
+
+func expandTildePath(path string, home string) string {
+	switch {
+	case path == "~":
+		return home
+	case strings.HasPrefix(path, "~/"):
+		return filepath.Join(home, path[2:])
+	default:
+		return path
+	}
+}
+
+func decodeLocalTombDoc(data []byte) (*localTombDoc, error) {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return nil, os.ErrInvalid
+	}
+	var doc localTombDoc
+	if err := json.Unmarshal([]byte(trimmed), &doc); err == nil && strings.TrimSpace(doc.MasterKey) != "" {
+		return &doc, nil
+	}
+	// Backward-compatible: raw base64 master key.
+	if _, err := decodeMasterKey(trimmed); err == nil {
+		return &localTombDoc{Version: "v1", MasterKey: trimmed}, nil
+	}
+	return nil, os.ErrInvalid
+}
+
+func decodeMasterKey(raw string) ([]byte, error) {
+	trimmed := strings.TrimSpace(raw)
+	decoded := make([]byte, base64.RawStdEncoding.DecodedLen(len(trimmed)))
+	n, err := base64.RawStdEncoding.Decode(decoded, []byte(trimmed))
+	if err != nil {
+		return nil, err
+	}
+	if n != 32 {
+		return nil, os.ErrInvalid
+	}
+	return decoded[:n], nil
 }

--- a/internal/config/envfile_test.go
+++ b/internal/config/envfile_test.go
@@ -1,6 +1,10 @@
 package config
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -62,5 +66,63 @@ func TestLoadEnvFileCandidatesFromExplicitPath(t *testing.T) {
 
 	if got := os.Getenv("EXPLICIT_KEY"); got != "42" {
 		t.Fatalf("expected EXPLICIT_KEY loaded from explicit env file, got %q", got)
+	}
+}
+
+func TestLoadEnvFileCandidatesLoadsSecretsFromTomb(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	tombPath := filepath.Join(home, ".config", "kafclaw", localTombFileName)
+	if err := os.MkdirAll(filepath.Dir(tombPath), 0o700); err != nil {
+		t.Fatalf("mkdir tomb dir: %v", err)
+	}
+	key := []byte("0123456789abcdef0123456789abcdef")
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("new gcm: %v", err)
+	}
+	plain, err := json.Marshal(map[string]string{
+		"OPENAI_API_KEY": "from_tomb",
+	})
+	if err != nil {
+		t.Fatalf("marshal plain: %v", err)
+	}
+	nonce := []byte("0123456789ab")
+	ciphertext := gcm.Seal(nil, nonce, plain, []byte(localTombEnvAAD))
+	doc := localTombDoc{
+		Version:       "v1",
+		MasterKey:     base64.RawStdEncoding.EncodeToString(key),
+		EnvNonce:      base64.RawStdEncoding.EncodeToString(nonce),
+		EnvCiphertext: base64.RawStdEncoding.EncodeToString(ciphertext),
+	}
+	docData, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal tomb doc: %v", err)
+	}
+	if err := os.WriteFile(tombPath, append(docData, '\n'), 0o600); err != nil {
+		t.Fatalf("write tomb file: %v", err)
+	}
+
+	origHome := os.Getenv("HOME")
+	origKey := os.Getenv("OPENAI_API_KEY")
+	defer os.Setenv("HOME", origHome)
+	defer os.Setenv("OPENAI_API_KEY", origKey)
+	_ = os.Setenv("HOME", home)
+	_ = os.Unsetenv("OPENAI_API_KEY")
+
+	LoadEnvFileCandidates()
+
+	if got := os.Getenv("OPENAI_API_KEY"); got != "from_tomb" {
+		t.Fatalf("expected OPENAI_API_KEY loaded from tomb, got %q", got)
+	}
+
+	_ = os.Setenv("OPENAI_API_KEY", "already_set")
+	LoadEnvFileCandidates()
+	if got := os.Getenv("OPENAI_API_KEY"); got != "already_set" {
+		t.Fatalf("expected existing env key preserved, got %q", got)
 	}
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -193,6 +193,7 @@ func Load() (*Config, error) {
 	envconfig.Process("MIKROBOT_TOOLS_EXEC", &cfg.Tools.Exec)
 	envconfig.Process("MIKROBOT_TOOLS_WEB_SEARCH", &cfg.Tools.Web.Search)
 	envconfig.Process("MIKROBOT_TOOLS_SUBAGENTS", &cfg.Tools.Subagents)
+	envconfig.Process("MIKROBOT_SKILLS", &cfg.Skills)
 	legacyAgentDefaults := SubagentsToolConfig{}
 	if cfg.Agents != nil {
 		legacyAgentDefaults = cfg.Agents.Defaults.Subagents
@@ -222,6 +223,7 @@ func Load() (*Config, error) {
 	envconfig.Process("KAFCLAW_TOOLS_EXEC", &cfg.Tools.Exec)
 	envconfig.Process("KAFCLAW_TOOLS_WEB_SEARCH", &cfg.Tools.Web.Search)
 	envconfig.Process("KAFCLAW_TOOLS_SUBAGENTS", &cfg.Tools.Subagents)
+	envconfig.Process("KAFCLAW_SKILLS", &cfg.Skills)
 	agentDefaults := SubagentsToolConfig{}
 	if cfg.Agents != nil {
 		agentDefaults = cfg.Agents.Defaults.Subagents
@@ -277,6 +279,38 @@ func Load() (*Config, error) {
 	}
 	if cfg.Tools.Subagents.ArchiveAfterMinutes <= 0 {
 		cfg.Tools.Subagents.ArchiveAfterMinutes = 60
+	}
+
+	if cfg.Skills.NodeManager == "" {
+		cfg.Skills.NodeManager = "npm"
+	}
+	switch strings.ToLower(strings.TrimSpace(cfg.Skills.NodeManager)) {
+	case "npm", "pnpm", "bun":
+		cfg.Skills.NodeManager = strings.ToLower(strings.TrimSpace(cfg.Skills.NodeManager))
+	default:
+		cfg.Skills.NodeManager = "npm"
+	}
+	switch strings.ToLower(strings.TrimSpace(cfg.Skills.Scope)) {
+	case "", "selected":
+		cfg.Skills.Scope = "selected"
+	case "all":
+		cfg.Skills.Scope = "all"
+	default:
+		cfg.Skills.Scope = "selected"
+	}
+	switch strings.ToLower(strings.TrimSpace(cfg.Skills.RuntimeIsolation)) {
+	case "", "auto":
+		cfg.Skills.RuntimeIsolation = "auto"
+	case "host", "strict":
+		cfg.Skills.RuntimeIsolation = strings.ToLower(strings.TrimSpace(cfg.Skills.RuntimeIsolation))
+	default:
+		cfg.Skills.RuntimeIsolation = "auto"
+	}
+	if cfg.Skills.LinkPolicy.Mode == "" {
+		cfg.Skills.LinkPolicy.Mode = "allowlist"
+	}
+	if cfg.Skills.LinkPolicy.MaxLinksPerSkill <= 0 {
+		cfg.Skills.LinkPolicy.MaxLinksPerSkill = 20
 	}
 	if cfg.Agents != nil {
 		cfg.Agents.Defaults.Subagents = cfg.Tools.Subagents

--- a/internal/skills/audit_chain.go
+++ b/internal/skills/audit_chain.go
@@ -1,0 +1,117 @@
+package skills
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func appendChainedAuditLine(path string, payload any) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	entry, err := normalizeAuditPayload(payload)
+	if err != nil {
+		return err
+	}
+	prevHash, err := readLastAuditHash(path)
+	if err != nil {
+		return err
+	}
+	if prevHash != "" {
+		entry["prevHash"] = prevHash
+	}
+	hash := computeAuditHash(entry)
+	entry["hash"] = hash
+	line, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.Write(append(line, '\n'))
+	return err
+}
+
+func normalizeAuditPayload(payload any) (map[string]any, error) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]any{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	delete(out, "hash")
+	delete(out, "prevHash")
+	return out, nil
+}
+
+func readLastAuditHash(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	defer f.Close()
+
+	var last string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line != "" {
+			last = line
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return "", err
+	}
+	if last == "" {
+		return "", nil
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(last), &obj); err != nil {
+		return "", fmt.Errorf("invalid existing audit line: %w", err)
+	}
+	return strings.TrimSpace(toString(obj["hash"])), nil
+}
+
+func computeAuditHash(entry map[string]any) string {
+	canonical := map[string]any{}
+	for k, v := range entry {
+		if k == "hash" {
+			continue
+		}
+		canonical[k] = v
+	}
+	data, _ := json.Marshal(canonical)
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func appendSecurityAuditEvent(eventType string, payload map[string]any) error {
+	state, err := EnsureStateDirs()
+	if err != nil {
+		return err
+	}
+	event := map[string]any{
+		"time":      time.Now().UTC(),
+		"eventType": strings.TrimSpace(eventType),
+	}
+	for k, v := range payload {
+		event[k] = v
+	}
+	return appendChainedAuditLine(filepath.Join(state.AuditDir, "security-events.jsonl"), event)
+}

--- a/internal/skills/bundled.go
+++ b/internal/skills/bundled.go
@@ -1,0 +1,53 @@
+package skills
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ValidateBundledArtifacts checks that all bundled skills and docs are present.
+func ValidateBundledArtifacts(repoRoot string) error {
+	root := strings.TrimSpace(repoRoot)
+	if root == "" {
+		var err error
+		root, err = findRepoRootFromWD()
+		if err != nil {
+			return err
+		}
+	}
+	var missing []string
+	for _, s := range BundledCatalog {
+		skillPath := filepath.Join(root, "skills", s.Name, "SKILL.md")
+		if fi, err := os.Stat(skillPath); err != nil || fi.IsDir() {
+			missing = append(missing, skillPath)
+		}
+		docPath := filepath.Join(root, "docs", "skills", s.Name+".md")
+		if fi, err := os.Stat(docPath); err != nil || fi.IsDir() {
+			missing = append(missing, docPath)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing bundled skill artifacts:\n- %s", strings.Join(missing, "\n- "))
+	}
+	return nil
+}
+
+func findRepoRootFromWD() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	cur := wd
+	for {
+		if fi, err := os.Stat(filepath.Join(cur, "go.mod")); err == nil && !fi.IsDir() {
+			return cur, nil
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return "", fmt.Errorf("repo root not found from %s", wd)
+		}
+		cur = parent
+	}
+}

--- a/internal/skills/bundled_test.go
+++ b/internal/skills/bundled_test.go
@@ -1,0 +1,9 @@
+package skills
+
+import "testing"
+
+func TestBundledArtifactsPresent(t *testing.T) {
+	if err := ValidateBundledArtifacts(""); err != nil {
+		t.Fatalf("bundled artifacts validation failed: %v", err)
+	}
+}

--- a/internal/skills/catalog.go
+++ b/internal/skills/catalog.go
@@ -1,0 +1,22 @@
+package skills
+
+// BundledSkill describes a built-in skill shipped with KafClaw.
+type BundledSkill struct {
+	Name           string
+	DefaultEnabled bool
+}
+
+// BundledCatalog is the baseline bundled skill set.
+var BundledCatalog = []BundledSkill{
+	{Name: "skill-creator", DefaultEnabled: false},
+	{Name: "session-logs", DefaultEnabled: false},
+	{Name: "summarize", DefaultEnabled: false},
+	{Name: "github", DefaultEnabled: false},
+	{Name: "gh-issues", DefaultEnabled: false},
+	{Name: "weather", DefaultEnabled: false},
+	{Name: "google-cli", DefaultEnabled: false},
+	{Name: "google-workspace", DefaultEnabled: false},
+	{Name: "m365", DefaultEnabled: false},
+	{Name: "incident-comms", DefaultEnabled: false},
+	{Name: "channel-onboarding", DefaultEnabled: true},
+}

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -1,0 +1,714 @@
+package skills
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+)
+
+const metadataFileName = ".kafclaw-skill.json"
+const snapshotRetentionPerSkill = 5
+const clawhubStateLockFile = "lock.json"
+const clawhubStateIndexFile = "managed-lock.json"
+
+// InstallResult contains install/update outcome for a single skill.
+type InstallResult struct {
+	Name         string       `json:"name"`
+	Target       string       `json:"target"`
+	InstalledAt  time.Time    `json:"installedAt"`
+	Updated      bool         `json:"updated"`
+	Report       VerifyReport `json:"report"`
+	InstallPath  string       `json:"installPath"`
+	WarningCount int          `json:"warningCount"`
+}
+
+type installedMetadata struct {
+	Name           string    `json:"name"`
+	Source         string    `json:"source"`
+	SourceHash     string    `json:"sourceHash,omitempty"`
+	PinnedHash     string    `json:"pinnedHash,omitempty"`
+	InstalledAt    time.Time `json:"installedAt"`
+	UpdatedAt      time.Time `json:"updatedAt,omitempty"`
+	ClawhubSlug    string    `json:"clawhubSlug,omitempty"`
+	ClawhubVersion string    `json:"clawhubVersion,omitempty"`
+}
+
+type clawhubInstallMetadata struct {
+	Slug    string
+	Version string
+	LockRaw []byte
+}
+
+type clawhubStateEntry struct {
+	Slug      string    `json:"slug"`
+	Version   string    `json:"version,omitempty"`
+	SkillName string    `json:"skillName,omitempty"`
+	Source    string    `json:"source,omitempty"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+type installAuditEntry struct {
+	Time             time.Time `json:"time"`
+	Action           string    `json:"action"`
+	Target           string    `json:"target"`
+	SkillName        string    `json:"skillName,omitempty"`
+	Success          bool      `json:"success"`
+	ApprovedWarnings bool      `json:"approvedWarnings"`
+	Warnings         int       `json:"warnings"`
+	Criticals        int       `json:"criticals"`
+	Message          string    `json:"message,omitempty"`
+	InstallPath      string    `json:"installPath,omitempty"`
+	PrevHash         string    `json:"prevHash,omitempty"`
+	Hash             string    `json:"hash,omitempty"`
+}
+
+// InstallSkill verifies then installs one skill source.
+func InstallSkill(cfg *config.Config, target string, approveWarnings bool) (*InstallResult, error) {
+	if cfg == nil {
+		cfg = config.DefaultConfig()
+	}
+	effectiveTarget, sourceOverride, clawhubMeta, cleanup, err := prepareInstallTarget(cfg, target)
+	if err != nil {
+		_ = appendInstallAudit(installAuditEntry{
+			Time:             time.Now().UTC(),
+			Action:           "install",
+			Target:           target,
+			Success:          false,
+			ApprovedWarnings: approveWarnings,
+			Message:          err.Error(),
+		})
+		return nil, err
+	}
+	defer cleanup()
+
+	pkg, report, err := loadSkillPackage(cfg, effectiveTarget)
+	if err != nil {
+		_ = appendInstallAudit(installAuditEntry{
+			Time:             time.Now().UTC(),
+			Action:           "install",
+			Target:           target,
+			Success:          false,
+			ApprovedWarnings: approveWarnings,
+			Message:          err.Error(),
+		})
+		return nil, err
+	}
+	if strings.TrimSpace(sourceOverride) != "" {
+		report.ResolvedTarget = sourceOverride
+	}
+	scanPackage(cfg, pkg, report)
+	validateManifestAndFrontmatter(cfg, pkg, report)
+	report.OK = report.CriticalCount() == 0
+	if report.CriticalCount() > 0 {
+		err := fmt.Errorf("verification failed with %d critical finding(s)", report.CriticalCount())
+		_ = appendInstallAudit(installAuditEntry{
+			Time:             time.Now().UTC(),
+			Action:           "install",
+			Target:           target,
+			SkillName:        pkg.SkillName,
+			Success:          false,
+			ApprovedWarnings: approveWarnings,
+			Warnings:         report.WarningCount(),
+			Criticals:        report.CriticalCount(),
+			Message:          err.Error(),
+		})
+		return nil, err
+	}
+	if report.WarningCount() > 0 && !approveWarnings {
+		err := fmt.Errorf("verification produced %d warning(s); re-run with warning approval", report.WarningCount())
+		_ = appendInstallAudit(installAuditEntry{
+			Time:             time.Now().UTC(),
+			Action:           "install",
+			Target:           target,
+			SkillName:        pkg.SkillName,
+			Success:          false,
+			ApprovedWarnings: approveWarnings,
+			Warnings:         report.WarningCount(),
+			Criticals:        report.CriticalCount(),
+			Message:          err.Error(),
+		})
+		return nil, err
+	}
+	if pkg.SkillName == "" {
+		err := fmt.Errorf("skill name missing after verification")
+		_ = appendInstallAudit(installAuditEntry{
+			Time:             time.Now().UTC(),
+			Action:           "install",
+			Target:           target,
+			Success:          false,
+			ApprovedWarnings: approveWarnings,
+			Message:          err.Error(),
+		})
+		return nil, err
+	}
+	state, err := EnsureStateDirs()
+	if err != nil {
+		return nil, err
+	}
+	dest := filepath.Join(state.Installed, pkg.SkillName)
+	snapshot := filepath.Join(state.Snapshots, pkg.SkillName, time.Now().UTC().Format("20060102T150405Z"))
+	stage := filepath.Join(state.TmpDir, fmt.Sprintf("install-%s-%d", pkg.SkillName, time.Now().UnixNano()))
+	if err := os.MkdirAll(stage, 0o700); err != nil {
+		return nil, err
+	}
+	if err := writePackageFiles(stage, pkg.Files); err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	prevInstalledAt := now
+	if prevMeta, err := readMetadata(filepath.Join(dest, metadataFileName)); err == nil && !prevMeta.InstalledAt.IsZero() {
+		prevInstalledAt = prevMeta.InstalledAt
+	}
+	meta := installedMetadata{
+		Name:        pkg.SkillName,
+		Source:      report.ResolvedTarget,
+		SourceHash:  computeSourceHash(pkg.Files),
+		InstalledAt: prevInstalledAt,
+	}
+	pinnedHash, hasPinnedHash := extractPinnedSourceHash(target)
+	if !hasPinnedHash {
+		if pinnedFromResolved, ok := extractPinnedSourceHash(report.ResolvedTarget); ok {
+			pinnedHash = pinnedFromResolved
+			hasPinnedHash = true
+		}
+	}
+	if hasPinnedHash {
+		if meta.SourceHash != pinnedHash {
+			err := fmt.Errorf("source hash pin mismatch (expected %s got %s)", pinnedHash, meta.SourceHash)
+			_ = appendInstallAudit(installAuditEntry{
+				Time:             now,
+				Action:           "install",
+				Target:           target,
+				SkillName:        pkg.SkillName,
+				Success:          false,
+				ApprovedWarnings: approveWarnings,
+				Warnings:         report.WarningCount(),
+				Criticals:        report.CriticalCount(),
+				Message:          err.Error(),
+			})
+			return nil, err
+		}
+		meta.PinnedHash = pinnedHash
+	}
+	if clawhubMeta != nil {
+		meta.ClawhubSlug = clawhubMeta.Slug
+		meta.ClawhubVersion = clawhubMeta.Version
+	}
+	updated := false
+	if _, err := os.Stat(dest); err == nil {
+		updated = true
+		meta.UpdatedAt = now
+		if err := os.MkdirAll(filepath.Dir(snapshot), 0o700); err != nil {
+			return nil, err
+		}
+		if err := os.Rename(dest, snapshot); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := writeMetadata(filepath.Join(stage, metadataFileName), meta); err != nil {
+		return nil, err
+	}
+	if err := os.Rename(stage, dest); err != nil {
+		if updated {
+			_ = os.Rename(snapshot, dest)
+		}
+		_ = appendInstallAudit(installAuditEntry{
+			Time:             now,
+			Action:           "install",
+			Target:           target,
+			SkillName:        pkg.SkillName,
+			Success:          false,
+			ApprovedWarnings: approveWarnings,
+			Warnings:         report.WarningCount(),
+			Criticals:        report.CriticalCount(),
+			Message:          err.Error(),
+		})
+		return nil, err
+	}
+	if updated {
+		_ = pruneSkillSnapshots(filepath.Join(state.Snapshots, pkg.SkillName), snapshotRetentionPerSkill)
+	}
+	if clawhubMeta != nil {
+		_ = syncClawhubState(state, pkg.SkillName, report.ResolvedTarget, clawhubMeta)
+	}
+	result := &InstallResult{
+		Name:         pkg.SkillName,
+		Target:       target,
+		InstalledAt:  now,
+		Updated:      updated,
+		Report:       *report,
+		InstallPath:  dest,
+		WarningCount: report.WarningCount(),
+	}
+	_ = appendInstallAudit(installAuditEntry{
+		Time:             now,
+		Action:           "install",
+		Target:           target,
+		SkillName:        pkg.SkillName,
+		Success:          true,
+		ApprovedWarnings: approveWarnings,
+		Warnings:         report.WarningCount(),
+		Criticals:        report.CriticalCount(),
+		InstallPath:      dest,
+	})
+	return result, nil
+}
+
+func prepareInstallTarget(cfg *config.Config, target string) (effectiveTarget string, sourceOverride string, clawhubMeta *clawhubInstallMetadata, cleanup func(), err error) {
+	noCleanup := func() {}
+	slug, ok := normalizeClawhubTarget(target)
+	if !ok {
+		return target, "", nil, noCleanup, nil
+	}
+	if cfg == nil || !cfg.Skills.ExternalInstalls {
+		return target, "", nil, noCleanup, nil
+	}
+	if !HasBinary("clawhub") {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(target)), "clawhub:") {
+			return "", "", nil, noCleanup, fmt.Errorf("clawhub source requested but `clawhub` is not in PATH")
+		}
+		return target, "", nil, noCleanup, nil
+	}
+	dirs, err := EnsureStateDirs()
+	if err != nil {
+		return "", "", nil, noCleanup, err
+	}
+	stage := filepath.Join(dirs.Quarantine, fmt.Sprintf("clawhub-%d", time.Now().UnixNano()))
+	skillsDir := filepath.Join(stage, "skills")
+	if err := os.MkdirAll(skillsDir, 0o700); err != nil {
+		return "", "", nil, noCleanup, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	args := []string{"install", slug, "--force", "--no-input", "--workdir", stage, "--dir", "skills"}
+	cmd := exec.CommandContext(ctx, "clawhub", args...)
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		_ = os.RemoveAll(stage)
+		return "", "", nil, noCleanup, fmt.Errorf("clawhub install %q failed: %w (%s)", slug, runErr, strings.TrimSpace(string(out)))
+	}
+	skillPath, err := detectSingleInstalledSkillDir(skillsDir, slug)
+	if err != nil {
+		_ = os.RemoveAll(stage)
+		return "", "", nil, noCleanup, err
+	}
+	meta := loadClawhubInstallMetadata(stage, slug)
+	return skillPath, "clawhub:" + slug, meta, func() { _ = os.RemoveAll(stage) }, nil
+}
+
+func normalizeClawhubTarget(target string) (string, bool) {
+	t := strings.TrimSpace(target)
+	if t == "" {
+		return "", false
+	}
+	lower := strings.ToLower(t)
+	if strings.HasPrefix(lower, "clawhub:") {
+		slug := sanitizeSkillName(strings.TrimSpace(t[len("clawhub:"):]))
+		return slug, slug != ""
+	}
+	if strings.Contains(t, "/") || strings.Contains(t, `\`) {
+		return "", false
+	}
+	if isLikelyURL(t) {
+		return "", false
+	}
+	if _, err := os.Stat(t); err == nil {
+		return "", false
+	}
+	slug := sanitizeSkillName(t)
+	return slug, slug != ""
+}
+
+func isLikelyURL(raw string) bool {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(u.Scheme, "http") || strings.EqualFold(u.Scheme, "https")
+}
+
+func detectSingleInstalledSkillDir(root string, slug string) (string, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return "", err
+	}
+	cands := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			cands = append(cands, e.Name())
+		}
+	}
+	if len(cands) == 0 {
+		return "", fmt.Errorf("clawhub install produced no skill directory")
+	}
+	sort.Strings(cands)
+	preferred := sanitizeSkillName(slug)
+	for _, c := range cands {
+		if sanitizeSkillName(c) == preferred {
+			return filepath.Join(root, c), nil
+		}
+	}
+	if len(cands) == 1 {
+		return filepath.Join(root, cands[0]), nil
+	}
+	return "", fmt.Errorf("clawhub install produced multiple skill directories: %s", strings.Join(cands, ", "))
+}
+
+func loadClawhubInstallMetadata(stage string, slug string) *clawhubInstallMetadata {
+	meta := &clawhubInstallMetadata{Slug: sanitizeSkillName(slug)}
+	lockPath := filepath.Join(stage, ".clawhub", clawhubStateLockFile)
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		return meta
+	}
+	meta.LockRaw = data
+	meta.Version = extractClawhubVersion(data, meta.Slug)
+	return meta
+}
+
+func extractClawhubVersion(lockRaw []byte, slug string) string {
+	var doc any
+	if err := json.Unmarshal(lockRaw, &doc); err != nil {
+		return ""
+	}
+	slug = sanitizeSkillName(slug)
+	versionFromObj := func(obj map[string]any) string {
+		s := sanitizeSkillName(toString(obj["slug"]))
+		if s == "" || s != slug {
+			return ""
+		}
+		for _, k := range []string{"version", "resolvedVersion", "tag"} {
+			if v := strings.TrimSpace(toString(obj[k])); v != "" {
+				return v
+			}
+		}
+		return ""
+	}
+	switch v := doc.(type) {
+	case map[string]any:
+		if ver := versionFromObj(v); ver != "" {
+			return ver
+		}
+		if skills, ok := v["skills"].([]any); ok {
+			for _, it := range skills {
+				if m, ok := it.(map[string]any); ok {
+					if ver := versionFromObj(m); ver != "" {
+						return ver
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func toString(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+func syncClawhubState(state StateDirs, skillName, source string, meta *clawhubInstallMetadata) error {
+	if meta == nil || strings.TrimSpace(meta.Slug) == "" {
+		return nil
+	}
+	root := filepath.Join(state.ToolsDir, "clawhub")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return err
+	}
+	if len(meta.LockRaw) > 0 {
+		if err := os.WriteFile(filepath.Join(root, clawhubStateLockFile), meta.LockRaw, 0o600); err != nil {
+			return err
+		}
+	}
+	indexPath := filepath.Join(root, clawhubStateIndexFile)
+	idx := map[string]clawhubStateEntry{}
+	if data, err := os.ReadFile(indexPath); err == nil {
+		_ = json.Unmarshal(data, &idx)
+	}
+	idx[meta.Slug] = clawhubStateEntry{
+		Slug:      meta.Slug,
+		Version:   strings.TrimSpace(meta.Version),
+		SkillName: strings.TrimSpace(skillName),
+		Source:    strings.TrimSpace(source),
+		UpdatedAt: time.Now().UTC(),
+	}
+	out, err := json.MarshalIndent(idx, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(indexPath, append(out, '\n'), 0o600)
+}
+
+func extractPinnedSourceHash(target string) (string, bool) {
+	t := strings.TrimSpace(target)
+	if t == "" {
+		return "", false
+	}
+	u, err := url.Parse(t)
+	if err != nil || u.Fragment == "" {
+		return "", false
+	}
+	const prefix = "sha256="
+	frag := strings.ToLower(strings.TrimSpace(u.Fragment))
+	if !strings.HasPrefix(frag, prefix) {
+		return "", false
+	}
+	v := strings.TrimSpace(frag[len(prefix):])
+	if len(v) != 64 {
+		return "", false
+	}
+	for _, ch := range v {
+		if !(ch >= '0' && ch <= '9' || ch >= 'a' && ch <= 'f') {
+			return "", false
+		}
+	}
+	return v, true
+}
+
+func verifyInstalledSkillIntegrity(root string, meta *installedMetadata) error {
+	if meta == nil || strings.TrimSpace(meta.SourceHash) == "" {
+		return nil
+	}
+	files, err := readLocalDir(root)
+	if err != nil {
+		return err
+	}
+	filtered := make([]sourceFile, 0, len(files))
+	for _, f := range files {
+		if filepath.ToSlash(strings.TrimSpace(f.Path)) == metadataFileName {
+			continue
+		}
+		filtered = append(filtered, f)
+	}
+	current := computeSourceHash(filtered)
+	if current == "" {
+		return fmt.Errorf("empty computed source hash")
+	}
+	if current != strings.TrimSpace(meta.SourceHash) {
+		return fmt.Errorf("source hash mismatch (expected %s got %s)", meta.SourceHash, current)
+	}
+	return nil
+}
+
+func computeSourceHash(files []sourceFile) string {
+	if len(files) == 0 {
+		return ""
+	}
+	normalized := make([]sourceFile, 0, len(files))
+	for _, f := range files {
+		p := filepath.ToSlash(strings.TrimSpace(f.Path))
+		if p == "" {
+			continue
+		}
+		normalized = append(normalized, sourceFile{Path: p, Data: f.Data})
+	}
+	sort.Slice(normalized, func(i, j int) bool { return normalized[i].Path < normalized[j].Path })
+	h := sha256.New()
+	for _, f := range normalized {
+		sum := sha256.Sum256(f.Data)
+		_, _ = h.Write([]byte(f.Path))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(hex.EncodeToString(sum[:])))
+		_, _ = h.Write([]byte{'\n'})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// UpdateSkills updates one installed skill by name, or all when name is empty.
+func UpdateSkills(cfg *config.Config, name string, approveWarnings bool) ([]InstallResult, error) {
+	if cfg == nil {
+		cfg = config.DefaultConfig()
+	}
+	state, err := EnsureStateDirs()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(state.Installed)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("no installed skills found")
+		}
+		return nil, err
+	}
+
+	var targets []string
+	targetName := sanitizeSkillName(name)
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if targetName != "" && e.Name() != targetName {
+			continue
+		}
+		meta, err := readMetadata(filepath.Join(state.Installed, e.Name(), metadataFileName))
+		if err != nil {
+			continue
+		}
+		if err := verifyInstalledSkillIntegrity(filepath.Join(state.Installed, e.Name()), meta); err != nil {
+			return nil, fmt.Errorf("installed skill %q failed integrity check: %w", e.Name(), err)
+		}
+		if strings.TrimSpace(meta.Source) == "" {
+			continue
+		}
+		targets = append(targets, meta.Source)
+	}
+	if len(targets) == 0 {
+		if targetName != "" {
+			return nil, fmt.Errorf("skill %q not installed or has no update source", targetName)
+		}
+		return nil, fmt.Errorf("no installed skills with update source metadata")
+	}
+	sort.Strings(targets)
+	out := make([]InstallResult, 0, len(targets))
+	for _, target := range targets {
+		_ = appendInstallAudit(installAuditEntry{
+			Time:             time.Now().UTC(),
+			Action:           "update",
+			Target:           target,
+			Success:          false,
+			ApprovedWarnings: approveWarnings,
+			Message:          "update started",
+		})
+		res, err := InstallSkill(cfg, target, approveWarnings)
+		if err != nil {
+			_ = appendInstallAudit(installAuditEntry{
+				Time:             time.Now().UTC(),
+				Action:           "update",
+				Target:           target,
+				SkillName:        sanitizeSkillName(name),
+				Success:          false,
+				ApprovedWarnings: approveWarnings,
+				Message:          err.Error(),
+			})
+			return nil, err
+		}
+		out = append(out, *res)
+		_ = appendInstallAudit(installAuditEntry{
+			Time:             time.Now().UTC(),
+			Action:           "update",
+			Target:           target,
+			SkillName:        res.Name,
+			Success:          true,
+			ApprovedWarnings: approveWarnings,
+			Warnings:         res.WarningCount,
+			Criticals:        res.Report.CriticalCount(),
+			InstallPath:      res.InstallPath,
+		})
+	}
+	return out, nil
+}
+
+func writePackageFiles(root string, files []sourceFile) error {
+	for _, f := range files {
+		rel := filepath.ToSlash(strings.TrimSpace(f.Path))
+		if !isSafeRelativePath(rel) {
+			return fmt.Errorf("unsafe file path in package: %s", rel)
+		}
+		dst := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+			return err
+		}
+		if err := os.WriteFile(dst, f.Data, 0o600); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeMetadata(path string, meta installedMetadata) error {
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o600)
+}
+
+func readMetadata(path string) (*installedMetadata, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var meta installedMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, err
+	}
+	return &meta, nil
+}
+
+func appendInstallAudit(entry installAuditEntry) error {
+	state, err := EnsureStateDirs()
+	if err != nil {
+		return err
+	}
+	if entry.Time.IsZero() {
+		entry.Time = time.Now().UTC()
+	}
+	if err := os.MkdirAll(state.AuditDir, 0o700); err != nil {
+		return err
+	}
+	installPath := filepath.Join(state.AuditDir, "install-decisions.jsonl")
+	if err := appendChainedAuditLine(installPath, &entry); err != nil {
+		return err
+	}
+	securityEvent := map[string]any{
+		"action":           entry.Action,
+		"target":           entry.Target,
+		"skillName":        entry.SkillName,
+		"success":          entry.Success,
+		"approvedWarnings": entry.ApprovedWarnings,
+		"warnings":         entry.Warnings,
+		"criticals":        entry.Criticals,
+		"message":          entry.Message,
+		"installPath":      entry.InstallPath,
+	}
+	return appendSecurityAuditEvent("skills_install", securityEvent)
+}
+
+func pruneSkillSnapshots(snapshotRoot string, keep int) error {
+	if keep <= 0 {
+		keep = 1
+	}
+	entries, err := os.ReadDir(snapshotRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if len(entries) <= keep {
+		return nil
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	if len(names) <= keep {
+		return nil
+	}
+	for _, old := range names[:len(names)-keep] {
+		if err := os.RemoveAll(filepath.Join(snapshotRoot, old)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/skills/install_test.go
+++ b/internal/skills/install_test.go
@@ -1,0 +1,120 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+)
+
+func TestNormalizeClawhubTarget(t *testing.T) {
+	if slug, ok := normalizeClawhubTarget("clawhub:My-Skill"); !ok || slug != "my-skill" {
+		t.Fatalf("unexpected normalized clawhub target: %q %v", slug, ok)
+	}
+	if slug, ok := normalizeClawhubTarget("weather"); !ok || slug != "weather" {
+		t.Fatalf("unexpected normalized slug target: %q %v", slug, ok)
+	}
+	if _, ok := normalizeClawhubTarget("https://clawhub.ai/skills/weather.zip"); ok {
+		t.Fatal("url should not normalize as clawhub slug")
+	}
+}
+
+func TestInstallSkillWithClawhubSource(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KAFCLAW_HOME", home)
+	t.Setenv("KAFCLAW_CONFIG", filepath.Join(home, ".kafclaw", "config.json"))
+
+	bin := filepath.Join(home, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+origPath)
+
+	clawhubScript := `#!/bin/sh
+slug="$2"
+workdir=""
+dir="skills"
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--workdir" ]; then
+    workdir="$2"
+    shift 2
+    continue
+  fi
+  if [ "$1" = "--dir" ]; then
+    dir="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+[ -z "$workdir" ] && exit 2
+target="$workdir/$dir/$slug"
+mkdir -p "$target"
+mkdir -p "$workdir/.clawhub"
+cat > "$target/SKILL.md" <<'EOF'
+---
+name: demo-skill
+description: demo
+---
+EOF
+cat > "$workdir/.clawhub/lock.json" <<'EOF'
+{"skills":[{"slug":"demo-skill","version":"1.2.3"}]}
+EOF
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(bin, "clawhub"), []byte(clawhubScript), 0o755); err != nil {
+		t.Fatalf("write clawhub script: %v", err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Skills.Enabled = true
+	cfg.Skills.ExternalInstalls = true
+	cfg.Skills.LinkPolicy.Mode = "open"
+
+	res, err := InstallSkill(cfg, "clawhub:demo-skill", true)
+	if err != nil {
+		t.Fatalf("install via clawhub source failed: %v", err)
+	}
+	if res == nil || strings.TrimSpace(res.Name) != "demo-skill" {
+		t.Fatalf("unexpected install result: %#v", res)
+	}
+	if !strings.HasPrefix(res.Report.ResolvedTarget, "clawhub:") {
+		t.Fatalf("expected clawhub source marker, got %q", res.Report.ResolvedTarget)
+	}
+	dirs, err := EnsureStateDirs()
+	if err != nil {
+		t.Fatalf("ensure state dirs: %v", err)
+	}
+	meta, err := readMetadata(filepath.Join(res.InstallPath, metadataFileName))
+	if err != nil {
+		t.Fatalf("read metadata: %v", err)
+	}
+	if meta.ClawhubSlug != "demo-skill" || meta.ClawhubVersion != "1.2.3" {
+		t.Fatalf("unexpected clawhub metadata: %#v", meta)
+	}
+	if _, err := os.Stat(filepath.Join(dirs.ToolsDir, "clawhub", "managed-lock.json")); err != nil {
+		t.Fatalf("expected managed clawhub lock index: %v", err)
+	}
+}
+
+func TestExtractPinnedSourceHash(t *testing.T) {
+	hash := strings.Repeat("a", 64)
+	cases := []struct {
+		target string
+		ok     bool
+	}{
+		{target: "https://example.com/skill.zip#sha256=" + hash, ok: true},
+		{target: "https://example.com/skill.zip#sha256=abcd", ok: false},
+		{target: "https://example.com/skill.zip#sha512=" + hash, ok: false},
+		{target: "clawhub:demo-skill", ok: false},
+	}
+	for _, tc := range cases {
+		_, ok := extractPinnedSourceHash(tc.target)
+		if ok != tc.ok {
+			t.Fatalf("target=%q expected ok=%v got %v", tc.target, tc.ok, ok)
+		}
+	}
+}

--- a/internal/skills/manager.go
+++ b/internal/skills/manager.go
@@ -1,0 +1,141 @@
+package skills
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+)
+
+// StateDirs contains the private filesystem locations used by the skills runtime.
+type StateDirs struct {
+	Root       string
+	TmpDir     string
+	ToolsDir   string
+	Quarantine string
+	Installed  string
+	Snapshots  string
+	AuditDir   string
+}
+
+func resolveStateRoot() (string, error) {
+	cfgPath, err := config.ConfigPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(filepath.Dir(cfgPath), "skills"), nil
+}
+
+// ResolveStateDirs computes the private skill runtime directories.
+func ResolveStateDirs() (StateDirs, error) {
+	root, err := resolveStateRoot()
+	if err != nil {
+		return StateDirs{}, err
+	}
+	return StateDirs{
+		Root:       root,
+		TmpDir:     filepath.Join(root, "tmp"),
+		ToolsDir:   filepath.Join(root, "tools"),
+		Quarantine: filepath.Join(root, "quarantine"),
+		Installed:  filepath.Join(root, "installed"),
+		Snapshots:  filepath.Join(root, "snapshots"),
+		AuditDir:   filepath.Join(root, "audit"),
+	}, nil
+}
+
+// EnsureStateDirs creates required private skill directories with 0700 permissions.
+func EnsureStateDirs() (StateDirs, error) {
+	dirs, err := ResolveStateDirs()
+	if err != nil {
+		return StateDirs{}, err
+	}
+	for _, dir := range []string{dirs.Root, dirs.TmpDir, dirs.ToolsDir, dirs.Quarantine, dirs.Installed, dirs.Snapshots, dirs.AuditDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return StateDirs{}, err
+		}
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return StateDirs{}, err
+		}
+	}
+	return dirs, nil
+}
+
+// EnsureNVMRC writes a pinned Node version to .nvmrc when missing.
+func EnsureNVMRC(workRepo string, nodeMajor string) (string, error) {
+	repo := strings.TrimSpace(workRepo)
+	if repo == "" {
+		return "", nil
+	}
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		return "", err
+	}
+	nvmrc := filepath.Join(repo, ".nvmrc")
+	if _, err := os.Stat(nvmrc); err == nil {
+		return nvmrc, nil
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+	val := strings.TrimSpace(nodeMajor)
+	if val == "" {
+		val = "20"
+	}
+	if err := os.WriteFile(nvmrc, []byte(val+"\n"), 0o644); err != nil {
+		return "", err
+	}
+	return nvmrc, nil
+}
+
+// HasBinary returns whether a command exists in PATH.
+func HasBinary(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}
+
+// EnsureClawhub verifies clawhub exists, optionally installing it with npm.
+func EnsureClawhub(installIfMissing bool) error {
+	if HasBinary("clawhub") {
+		return nil
+	}
+	if !installIfMissing {
+		return fmt.Errorf("clawhub not found in PATH; install with: npm install -g --ignore-scripts clawhub")
+	}
+	if !HasBinary("npm") {
+		return fmt.Errorf("npm not found in PATH; install Node.js/npm first")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "npm", "install", "-g", "--ignore-scripts", "clawhub")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to install clawhub with npm: %w", err)
+	}
+	if !HasBinary("clawhub") {
+		return fmt.Errorf("clawhub install completed but binary is not discoverable in PATH")
+	}
+	return nil
+}
+
+// EffectiveSkillEnabled resolves a skill toggle from config entries + bundled defaults.
+func EffectiveSkillEnabled(cfg *config.Config, skillName string) bool {
+	if cfg == nil || !cfg.Skills.Enabled {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(cfg.Skills.Scope), "all") {
+		return true
+	}
+	if entry, ok := cfg.Skills.Entries[skillName]; ok {
+		return entry.Enabled
+	}
+	for _, bundled := range BundledCatalog {
+		if bundled.Name == skillName {
+			return bundled.DefaultEnabled
+		}
+	}
+	return false
+}

--- a/internal/skills/manager_test.go
+++ b/internal/skills/manager_test.go
@@ -1,0 +1,41 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureNVMRCWritesWhenMissing(t *testing.T) {
+	repo := t.TempDir()
+	path, err := EnsureNVMRC(repo, "22")
+	if err != nil {
+		t.Fatalf("EnsureNVMRC failed: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read nvmrc: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "22" {
+		t.Fatalf("expected node major 22, got %q", string(data))
+	}
+}
+
+func TestEnsureClawhubWithFakeBinary(t *testing.T) {
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	origPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", origPath)
+
+	if err := os.WriteFile(filepath.Join(bin, "clawhub"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write clawhub: %v", err)
+	}
+	_ = os.Setenv("PATH", bin+string(os.PathListSeparator)+origPath)
+	if err := EnsureClawhub(false); err != nil {
+		t.Fatalf("EnsureClawhub should succeed with fake binary: %v", err)
+	}
+}

--- a/internal/skills/oauth.go
+++ b/internal/skills/oauth.go
@@ -1,0 +1,453 @@
+package skills
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// OAuthProvider identifies supported auth providers.
+type OAuthProvider string
+
+const (
+	ProviderGoogleWorkspace OAuthProvider = "google-workspace"
+	ProviderM365            OAuthProvider = "m365"
+)
+
+// OAuthStartInput defines auth-start parameters.
+type OAuthStartInput struct {
+	Provider     OAuthProvider
+	Profile      string
+	ClientID     string
+	ClientSecret string
+	RedirectURI  string
+	Scopes       []string
+	TenantID     string
+}
+
+// OAuthStartResult returns URL + metadata to continue auth.
+type OAuthStartResult struct {
+	Provider     OAuthProvider `json:"provider"`
+	Profile      string        `json:"profile"`
+	AuthorizeURL string        `json:"authorizeUrl"`
+	State        string        `json:"state"`
+	StartedAt    time.Time     `json:"startedAt"`
+}
+
+// OAuthCompleteInput defines auth completion payload.
+type OAuthCompleteInput struct {
+	Provider OAuthProvider
+	Profile  string
+	Code     string
+	State    string
+}
+
+// OAuthTokenResult is a sanitized token response.
+type OAuthTokenResult struct {
+	Provider   OAuthProvider `json:"provider"`
+	Profile    string        `json:"profile"`
+	TokenPath  string        `json:"tokenPath"`
+	ExpiresAt  time.Time     `json:"expiresAt,omitempty"`
+	Scope      string        `json:"scope,omitempty"`
+	TokenType  string        `json:"tokenType,omitempty"`
+	ObtainedAt time.Time     `json:"obtainedAt"`
+}
+
+type oauthPending struct {
+	Provider     OAuthProvider `json:"provider"`
+	Profile      string        `json:"profile"`
+	ClientID     string        `json:"clientId"`
+	ClientSecret string        `json:"clientSecret"`
+	RedirectURI  string        `json:"redirectUri"`
+	Scopes       []string      `json:"scopes"`
+	State        string        `json:"state"`
+	CodeVerifier string        `json:"codeVerifier"`
+	TenantID     string        `json:"tenantId,omitempty"`
+	CreatedAt    time.Time     `json:"createdAt"`
+}
+
+type oauthTokenRaw struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	TokenType    string `json:"token_type,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+	ExpiresIn    int    `json:"expires_in,omitempty"`
+	IDToken      string `json:"id_token,omitempty"`
+	Error        string `json:"error,omitempty"`
+	ErrorDesc    string `json:"error_description,omitempty"`
+}
+
+// StartOAuthFlow starts browser/copy auth flow for Google Workspace or M365.
+func StartOAuthFlow(in OAuthStartInput) (*OAuthStartResult, error) {
+	pending, err := buildPending(in)
+	if err != nil {
+		_ = appendOAuthSecurityEvent("skills_oauth_start", in.Provider, in.Profile, false, err.Error())
+		return nil, err
+	}
+	if err := savePendingOAuth(pending); err != nil {
+		_ = appendOAuthSecurityEvent("skills_oauth_start", pending.Provider, pending.Profile, false, err.Error())
+		return nil, err
+	}
+	authURL := buildAuthorizeURL(pending)
+	if authURL == "" {
+		_ = appendOAuthSecurityEvent("skills_oauth_start", pending.Provider, pending.Profile, false, "failed to build authorization URL")
+		return nil, errors.New("failed to build authorization URL")
+	}
+	_ = appendOAuthSecurityEvent("skills_oauth_start", pending.Provider, pending.Profile, true, "")
+	return &OAuthStartResult{
+		Provider:     pending.Provider,
+		Profile:      pending.Profile,
+		AuthorizeURL: authURL,
+		State:        pending.State,
+		StartedAt:    pending.CreatedAt,
+	}, nil
+}
+
+// CompleteOAuthFlow exchanges auth code for tokens and stores them securely.
+func CompleteOAuthFlow(in OAuthCompleteInput) (*OAuthTokenResult, error) {
+	profile := sanitizeSkillName(in.Profile)
+	if profile == "" {
+		profile = "default"
+	}
+	pending, err := loadPendingOAuth(in.Provider, profile)
+	if err != nil {
+		_ = appendOAuthSecurityEvent("skills_oauth_complete", in.Provider, profile, false, err.Error())
+		return nil, err
+	}
+	if in.State == "" || in.State != pending.State {
+		_ = appendOAuthSecurityEvent("skills_oauth_complete", pending.Provider, pending.Profile, false, "oauth state mismatch")
+		return nil, errors.New("oauth state mismatch")
+	}
+	code := strings.TrimSpace(in.Code)
+	if code == "" {
+		_ = appendOAuthSecurityEvent("skills_oauth_complete", pending.Provider, pending.Profile, false, "oauth code is required")
+		return nil, errors.New("oauth code is required")
+	}
+
+	tokenRaw, err := exchangeCodeForToken(pending, code)
+	if err != nil {
+		_ = appendOAuthSecurityEvent("skills_oauth_complete", pending.Provider, pending.Profile, false, err.Error())
+		return nil, err
+	}
+	if strings.TrimSpace(tokenRaw.AccessToken) == "" {
+		_ = appendOAuthSecurityEvent("skills_oauth_complete", pending.Provider, pending.Profile, false, "token response missing access_token")
+		return nil, errors.New("token response missing access_token")
+	}
+	now := time.Now().UTC()
+	var expiresAt time.Time
+	if tokenRaw.ExpiresIn > 0 {
+		expiresAt = now.Add(time.Duration(tokenRaw.ExpiresIn) * time.Second)
+	}
+
+	tokenPath, err := saveOAuthToken(pending.Provider, pending.Profile, tokenRaw, now, expiresAt)
+	if err != nil {
+		_ = appendOAuthSecurityEvent("skills_oauth_complete", pending.Provider, pending.Profile, false, err.Error())
+		return nil, err
+	}
+	_ = removePendingOAuth(pending.Provider, pending.Profile)
+	_ = appendOAuthSecurityEvent("skills_oauth_complete", pending.Provider, pending.Profile, true, "")
+	return &OAuthTokenResult{
+		Provider:   pending.Provider,
+		Profile:    pending.Profile,
+		TokenPath:  tokenPath,
+		ExpiresAt:  expiresAt,
+		Scope:      tokenRaw.Scope,
+		TokenType:  tokenRaw.TokenType,
+		ObtainedAt: now,
+	}, nil
+}
+
+// ParseOAuthCallbackURL extracts code/state from a provider callback URL.
+func ParseOAuthCallbackURL(raw string) (code string, state string, err error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", "", err
+	}
+	q := u.Query()
+	code = strings.TrimSpace(q.Get("code"))
+	state = strings.TrimSpace(q.Get("state"))
+	if code == "" || state == "" {
+		return "", "", errors.New("callback URL missing code or state")
+	}
+	return code, state, nil
+}
+
+func buildPending(in OAuthStartInput) (*oauthPending, error) {
+	p := OAuthProvider(strings.ToLower(strings.TrimSpace(string(in.Provider))))
+	if p != ProviderGoogleWorkspace && p != ProviderM365 {
+		return nil, fmt.Errorf("unsupported provider: %s", in.Provider)
+	}
+	profile := sanitizeSkillName(in.Profile)
+	if profile == "" {
+		profile = "default"
+	}
+	clientID := strings.TrimSpace(in.ClientID)
+	clientSecret := strings.TrimSpace(in.ClientSecret)
+	redirectURI := strings.TrimSpace(in.RedirectURI)
+	if clientID == "" || clientSecret == "" || redirectURI == "" {
+		return nil, errors.New("client-id, client-secret, and redirect-uri are required")
+	}
+	if _, err := url.ParseRequestURI(redirectURI); err != nil {
+		return nil, fmt.Errorf("invalid redirect-uri: %w", err)
+	}
+	scopes := normalizeScopes(in.Scopes)
+	if len(scopes) == 0 {
+		if p == ProviderGoogleWorkspace {
+			scopes = []string{"openid", "email", "profile", "https://www.googleapis.com/auth/userinfo.email"}
+		} else {
+			scopes = []string{"openid", "offline_access", "User.Read"}
+		}
+	}
+	state, err := randomB64URL(24)
+	if err != nil {
+		return nil, err
+	}
+	verifier, err := randomB64URL(48)
+	if err != nil {
+		return nil, err
+	}
+	return &oauthPending{
+		Provider:     p,
+		Profile:      profile,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURI:  redirectURI,
+		Scopes:       scopes,
+		State:        state,
+		CodeVerifier: verifier,
+		TenantID:     strings.TrimSpace(in.TenantID),
+		CreatedAt:    time.Now().UTC(),
+	}, nil
+}
+
+func buildAuthorizeURL(p *oauthPending) string {
+	values := url.Values{}
+	values.Set("client_id", p.ClientID)
+	values.Set("redirect_uri", p.RedirectURI)
+	values.Set("response_type", "code")
+	values.Set("scope", strings.Join(p.Scopes, " "))
+	values.Set("state", p.State)
+	values.Set("code_challenge_method", "S256")
+	values.Set("code_challenge", pkceChallenge(p.CodeVerifier))
+	values.Set("access_type", "offline")
+	values.Set("prompt", "consent")
+
+	switch p.Provider {
+	case ProviderGoogleWorkspace:
+		return "https://accounts.google.com/o/oauth2/v2/auth?" + values.Encode()
+	case ProviderM365:
+		tenant := p.TenantID
+		if tenant == "" {
+			tenant = "common"
+		}
+		values.Del("access_type")
+		values.Del("prompt")
+		return fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/authorize?%s", tenant, values.Encode())
+	default:
+		return ""
+	}
+}
+
+func exchangeCodeForToken(p *oauthPending, code string) (*oauthTokenRaw, error) {
+	form := url.Values{}
+	form.Set("client_id", p.ClientID)
+	form.Set("client_secret", p.ClientSecret)
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", p.RedirectURI)
+	form.Set("code_verifier", p.CodeVerifier)
+
+	tokenURL := ""
+	switch p.Provider {
+	case ProviderGoogleWorkspace:
+		tokenURL = "https://oauth2.googleapis.com/token"
+	case ProviderM365:
+		tenant := p.TenantID
+		if tenant == "" {
+			tenant = "common"
+		}
+		tokenURL = fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenant)
+	default:
+		return nil, fmt.Errorf("unsupported provider: %s", p.Provider)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var out oauthTokenRaw
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode token response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if out.Error != "" {
+			return nil, fmt.Errorf("token exchange failed: %s (%s)", out.Error, out.ErrorDesc)
+		}
+		return nil, fmt.Errorf("token exchange failed: status %d", resp.StatusCode)
+	}
+	return &out, nil
+}
+
+func savePendingOAuth(p *oauthPending) error {
+	dir, err := oauthStateDir(p.Provider, p.Profile)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return err
+	}
+	sealed, err := encryptOAuthStateBlob(append(data, '\n'))
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "pending.json"), sealed, 0o600)
+}
+
+func loadPendingOAuth(provider OAuthProvider, profile string) (*oauthPending, error) {
+	path, err := oauthStateFile(provider, profile, "pending.json")
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	data, err = decryptOAuthStateBlob(data)
+	if err != nil {
+		return nil, err
+	}
+	var p oauthPending
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func removePendingOAuth(provider OAuthProvider, profile string) error {
+	path, err := oauthStateFile(provider, profile, "pending.json")
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func saveOAuthToken(provider OAuthProvider, profile string, raw *oauthTokenRaw, obtainedAt, expiresAt time.Time) (string, error) {
+	dir, err := oauthStateDir(provider, profile)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	payload := map[string]any{
+		"provider":      provider,
+		"profile":       profile,
+		"access_token":  raw.AccessToken,
+		"refresh_token": raw.RefreshToken,
+		"id_token":      raw.IDToken,
+		"token_type":    raw.TokenType,
+		"scope":         raw.Scope,
+		"obtained_at":   obtainedAt.Format(time.RFC3339),
+	}
+	if !expiresAt.IsZero() {
+		payload["expires_at"] = expiresAt.Format(time.RFC3339)
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	sealed, err := encryptOAuthStateBlob(append(data, '\n'))
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, "token.json")
+	if err := os.WriteFile(path, sealed, 0o600); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func oauthStateDir(provider OAuthProvider, profile string) (string, error) {
+	dirs, err := EnsureStateDirs()
+	if err != nil {
+		return "", err
+	}
+	profile = sanitizeSkillName(profile)
+	if profile == "" {
+		profile = "default"
+	}
+	base := filepath.Join(dirs.ToolsDir, "auth", string(provider), profile)
+	return base, nil
+}
+
+func oauthStateFile(provider OAuthProvider, profile, file string) (string, error) {
+	dir, err := oauthStateDir(provider, profile)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, file), nil
+}
+
+func normalizeScopes(in []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		for _, part := range strings.Split(s, ",") {
+			v := strings.TrimSpace(part)
+			if v == "" {
+				continue
+			}
+			if _, ok := seen[v]; ok {
+				continue
+			}
+			seen[v] = struct{}{}
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+func pkceChallenge(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func randomB64URL(n int) (string, error) {
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func appendOAuthSecurityEvent(eventType string, provider OAuthProvider, profile string, success bool, message string) error {
+	return appendSecurityAuditEvent(eventType, map[string]any{
+		"provider": string(provider),
+		"profile":  sanitizeSkillName(profile),
+		"success":  success,
+		"message":  strings.TrimSpace(message),
+	})
+}

--- a/internal/skills/oauth_crypto.go
+++ b/internal/skills/oauth_crypto.go
@@ -1,0 +1,449 @@
+package skills
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/zalando/go-keyring"
+)
+
+const oauthKeyFileName = "master.key"
+const oauthLocalTombFileName = "tomb.rr"
+const oauthKeyringService = "kafclaw.skills.oauth"
+const oauthKeyringUser = "master-key"
+const localTombEnvAAD = "kafclaw-local-env-secrets-v1"
+
+type localTomb struct {
+	Version       string `json:"version"`
+	MasterKey     string `json:"masterKey"`
+	EnvNonce      string `json:"envNonce,omitempty"`
+	EnvCiphertext string `json:"envCiphertext,omitempty"`
+}
+
+type encryptedOAuthBlob struct {
+	Version    string `json:"version"`
+	Nonce      string `json:"nonce"`
+	Ciphertext string `json:"ciphertext"`
+}
+
+func encryptOAuthStateBlob(plain []byte) ([]byte, error) {
+	key, err := loadOrCreateOAuthMasterKey()
+	if err != nil {
+		return nil, err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	ciphertext := gcm.Seal(nil, nonce, plain, nil)
+	out := encryptedOAuthBlob{
+		Version:    "v1",
+		Nonce:      base64.RawStdEncoding.EncodeToString(nonce),
+		Ciphertext: base64.RawStdEncoding.EncodeToString(ciphertext),
+	}
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func decryptOAuthStateBlob(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty oauth state blob")
+	}
+	var wrapped encryptedOAuthBlob
+	if err := json.Unmarshal(data, &wrapped); err != nil {
+		// Backward compatibility: old plaintext JSON.
+		return data, nil
+	}
+	if wrapped.Version == "" || wrapped.Nonce == "" || wrapped.Ciphertext == "" {
+		// Backward compatibility: plaintext JSON object.
+		return data, nil
+	}
+	if wrapped.Version != "v1" {
+		return nil, fmt.Errorf("unsupported oauth state blob version: %s", wrapped.Version)
+	}
+	key, err := loadOrCreateOAuthMasterKey()
+	if err != nil {
+		return nil, err
+	}
+	nonce, err := base64.RawStdEncoding.DecodeString(strings.TrimSpace(wrapped.Nonce))
+	if err != nil {
+		return nil, err
+	}
+	ciphertext, err := base64.RawStdEncoding.DecodeString(strings.TrimSpace(wrapped.Ciphertext))
+	if err != nil {
+		return nil, err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	plain, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, err
+	}
+	return plain, nil
+}
+
+func loadOrCreateOAuthMasterKey() ([]byte, error) {
+	if envKey := strings.TrimSpace(os.Getenv("KAFCLAW_OAUTH_MASTER_KEY")); envKey != "" {
+		key, err := decodeMasterKey(envKey)
+		if err != nil {
+			return nil, fmt.Errorf("invalid KAFCLAW_OAUTH_MASTER_KEY: %w", err)
+		}
+		return key, nil
+	}
+
+	switch resolveOAuthKeyBackend() {
+	case "local":
+		return loadOrCreateOAuthMasterKeyLocalOnly()
+	case "keyring":
+		return loadOrCreateOAuthMasterKeyKeyringOnly()
+	case "file":
+		return loadOrCreateOAuthMasterKeyFileOnly()
+	default:
+		if key, err := loadOrCreateOAuthMasterKeyKeyringOnly(); err == nil {
+			return key, nil
+		}
+		if key, err := loadOrCreateOAuthMasterKeyLocalOnly(); err == nil {
+			return key, nil
+		}
+		return loadOrCreateOAuthMasterKeyFileOnly()
+	}
+}
+
+func resolveOAuthKeyBackend() string {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("KAFCLAW_OAUTH_KEY_BACKEND")))
+	switch v {
+	case "local", "keyring", "file", "auto":
+		return v
+	default:
+		return "local"
+	}
+}
+
+func loadOrCreateOAuthMasterKeyKeyringOnly() ([]byte, error) {
+	val, err := keyring.Get(oauthKeyringService, oauthKeyringUser)
+	if err == nil {
+		return decodeMasterKey(val)
+	}
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return nil, err
+	}
+	encoded := base64.RawStdEncoding.EncodeToString(key)
+	if setErr := keyring.Set(oauthKeyringService, oauthKeyringUser, encoded); setErr != nil {
+		return nil, setErr
+	}
+	return key, nil
+}
+
+func loadOrCreateOAuthMasterKeyFileOnly() ([]byte, error) {
+	dirs, err := EnsureStateDirs()
+	if err != nil {
+		return nil, err
+	}
+	authRoot := filepath.Join(dirs.ToolsDir, "auth")
+	if err := os.MkdirAll(authRoot, 0o700); err != nil {
+		return nil, err
+	}
+	keyPath := filepath.Join(authRoot, oauthKeyFileName)
+	if data, err := os.ReadFile(keyPath); err == nil {
+		return decodeMasterKey(strings.TrimSpace(string(data)))
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return nil, err
+	}
+	encoded := base64.RawStdEncoding.EncodeToString(key)
+	if err := os.WriteFile(keyPath, []byte(encoded+"\n"), 0o600); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// ResolveLocalOAuthTombPath returns the local key tomb file path.
+func ResolveLocalOAuthTombPath() (string, error) {
+	if explicit := strings.TrimSpace(os.Getenv("KAFCLAW_OAUTH_TOMB_FILE")); explicit != "" {
+		if strings.HasPrefix(explicit, "~") {
+			home, err := resolveOAuthHomeDir()
+			if err != nil {
+				return "", err
+			}
+			return expandOAuthTildePath(explicit, home), nil
+		}
+		return explicit, nil
+	}
+	home, err := resolveOAuthHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "kafclaw", oauthLocalTombFileName), nil
+}
+
+func resolveOAuthHomeDir() (string, error) {
+	if h := strings.TrimSpace(os.Getenv("KAFCLAW_HOME")); h != "" {
+		if strings.HasPrefix(h, "~") {
+			base, err := os.UserHomeDir()
+			if err != nil {
+				return "", err
+			}
+			return expandOAuthTildePath(h, base), nil
+		}
+		return h, nil
+	}
+	return os.UserHomeDir()
+}
+
+func expandOAuthTildePath(path string, home string) string {
+	switch {
+	case path == "~":
+		return home
+	case strings.HasPrefix(path, "~/"):
+		return filepath.Join(home, path[2:])
+	default:
+		return path
+	}
+}
+
+func loadOrCreateOAuthMasterKeyLocalOnly() ([]byte, error) {
+	tombPath, doc, err := loadOrCreateLocalTomb()
+	if err != nil {
+		return nil, err
+	}
+	key, err := decodeMasterKey(doc.MasterKey)
+	if err != nil {
+		return nil, err
+	}
+	_ = os.Chmod(tombPath, 0o600)
+	return key, nil
+}
+
+func loadOrCreateLocalTomb() (string, *localTomb, error) {
+	tombPath, err := ResolveLocalOAuthTombPath()
+	if err != nil {
+		return "", nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(tombPath), 0o700); err != nil {
+		return "", nil, err
+	}
+	if data, err := os.ReadFile(tombPath); err == nil {
+		doc, decErr := decodeLocalTomb(data)
+		if decErr != nil {
+			return "", nil, decErr
+		}
+		return tombPath, doc, nil
+	} else if !os.IsNotExist(err) {
+		return "", nil, err
+	}
+
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return "", nil, err
+	}
+	encoded := base64.RawStdEncoding.EncodeToString(key)
+	doc := &localTomb{
+		Version:   "v1",
+		MasterKey: encoded,
+	}
+	if err := writeLocalTomb(tombPath, doc); err != nil {
+		return "", nil, err
+	}
+	return tombPath, doc, nil
+}
+
+func decodeLocalTomb(data []byte) (*localTomb, error) {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return nil, fmt.Errorf("empty tomb file")
+	}
+	var doc localTomb
+	if err := json.Unmarshal([]byte(trimmed), &doc); err == nil && strings.TrimSpace(doc.MasterKey) != "" {
+		if strings.TrimSpace(doc.Version) == "" {
+			doc.Version = "v1"
+		}
+		return &doc, nil
+	}
+	// Backward-compatible: tomb was raw base64 key only.
+	if _, err := decodeMasterKey(trimmed); err == nil {
+		return &localTomb{
+			Version:   "v1",
+			MasterKey: trimmed,
+		}, nil
+	}
+	return nil, fmt.Errorf("invalid tomb file format")
+}
+
+func writeLocalTomb(path string, doc *localTomb) error {
+	if doc == nil {
+		return fmt.Errorf("nil tomb payload")
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o600)
+}
+
+func loadEnvSecretsFromLocalTombDoc(doc *localTomb) (map[string]string, error) {
+	out := map[string]string{}
+	if doc == nil || strings.TrimSpace(doc.EnvNonce) == "" || strings.TrimSpace(doc.EnvCiphertext) == "" {
+		return out, nil
+	}
+	key, err := decodeMasterKey(doc.MasterKey)
+	if err != nil {
+		return nil, err
+	}
+	nonce, err := base64.RawStdEncoding.DecodeString(strings.TrimSpace(doc.EnvNonce))
+	if err != nil {
+		return nil, err
+	}
+	ciphertext, err := base64.RawStdEncoding.DecodeString(strings.TrimSpace(doc.EnvCiphertext))
+	if err != nil {
+		return nil, err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	plain, err := gcm.Open(nil, nonce, ciphertext, []byte(localTombEnvAAD))
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(plain, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func sealEnvSecretsIntoLocalTombDoc(doc *localTomb, kv map[string]string) error {
+	if doc == nil {
+		return fmt.Errorf("nil tomb payload")
+	}
+	if kv == nil {
+		kv = map[string]string{}
+	}
+	key, err := decodeMasterKey(doc.MasterKey)
+	if err != nil {
+		return err
+	}
+	plain, err := json.Marshal(kv)
+	if err != nil {
+		return err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return err
+	}
+	ciphertext := gcm.Seal(nil, nonce, plain, []byte(localTombEnvAAD))
+	doc.EnvNonce = base64.RawStdEncoding.EncodeToString(nonce)
+	doc.EnvCiphertext = base64.RawStdEncoding.EncodeToString(ciphertext)
+	return nil
+}
+
+// StoreEnvSecretsInLocalTomb merges sensitive env kv into tomb-managed encrypted payload.
+func StoreEnvSecretsInLocalTomb(kv map[string]string) (int, error) {
+	if len(kv) == 0 {
+		return 0, nil
+	}
+	tombPath, doc, err := loadOrCreateLocalTomb()
+	if err != nil {
+		return 0, err
+	}
+	existing, err := loadEnvSecretsFromLocalTombDoc(doc)
+	if err != nil {
+		return 0, err
+	}
+	changed := 0
+	for k, v := range kv {
+		if strings.TrimSpace(k) == "" {
+			continue
+		}
+		if old, ok := existing[k]; !ok || old != v {
+			existing[k] = v
+			changed++
+		}
+	}
+	if changed == 0 {
+		return 0, nil
+	}
+	if err := sealEnvSecretsIntoLocalTombDoc(doc, existing); err != nil {
+		return 0, err
+	}
+	if err := writeLocalTomb(tombPath, doc); err != nil {
+		return 0, err
+	}
+	if err := os.Chmod(tombPath, 0o600); err != nil {
+		return 0, err
+	}
+	return changed, nil
+}
+
+// LoadEnvSecretsFromLocalTomb decrypts env secrets previously stored in tomb.
+func LoadEnvSecretsFromLocalTomb() (map[string]string, error) {
+	tombPath, err := ResolveLocalOAuthTombPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(tombPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]string{}, nil
+		}
+		return nil, err
+	}
+	doc, err := decodeLocalTomb(data)
+	if err != nil {
+		return nil, err
+	}
+	return loadEnvSecretsFromLocalTombDoc(doc)
+}
+
+func decodeMasterKey(raw string) ([]byte, error) {
+	trimmed := strings.TrimSpace(raw)
+	decoded := make([]byte, base64.RawStdEncoding.DecodedLen(len(trimmed)))
+	n, err := base64.RawStdEncoding.Decode(decoded, []byte(trimmed))
+	if err != nil {
+		return nil, err
+	}
+	if n != 32 {
+		return nil, fmt.Errorf("invalid oauth master key length: %d", n)
+	}
+	return decoded[:n], nil
+}

--- a/internal/skills/oauth_test.go
+++ b/internal/skills/oauth_test.go
@@ -1,0 +1,245 @@
+package skills
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStartOAuthFlowGoogleWritesPending(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KAFCLAW_HOME", home)
+	t.Setenv("KAFCLAW_CONFIG", filepath.Join(home, ".kafclaw", "config.json"))
+
+	out, err := StartOAuthFlow(OAuthStartInput{
+		Provider:     ProviderGoogleWorkspace,
+		Profile:      "default",
+		ClientID:     "cid",
+		ClientSecret: "secret",
+		RedirectURI:  "http://localhost:53682/callback",
+		Scopes:       []string{"openid", "email"},
+	})
+	if err != nil {
+		t.Fatalf("start oauth failed: %v", err)
+	}
+	if !strings.Contains(out.AuthorizeURL, "accounts.google.com") {
+		t.Fatalf("unexpected google auth url: %s", out.AuthorizeURL)
+	}
+	path, err := oauthStateFile(ProviderGoogleWorkspace, "default", "pending.json")
+	if err != nil {
+		t.Fatalf("state file path: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected pending state file: %v", err)
+	}
+}
+
+func TestParseOAuthCallbackURL(t *testing.T) {
+	code, state, err := ParseOAuthCallbackURL("http://localhost:53682/callback?code=abc123&state=xyz456")
+	if err != nil {
+		t.Fatalf("parse callback: %v", err)
+	}
+	if code != "abc123" || state != "xyz456" {
+		t.Fatalf("unexpected code/state: %s %s", code, state)
+	}
+}
+
+func TestCompleteOAuthFlowStateMismatch(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KAFCLAW_HOME", home)
+	t.Setenv("KAFCLAW_CONFIG", filepath.Join(home, ".kafclaw", "config.json"))
+
+	_, err := StartOAuthFlow(OAuthStartInput{
+		Provider:     ProviderM365,
+		Profile:      "default",
+		ClientID:     "cid",
+		ClientSecret: "secret",
+		RedirectURI:  "http://localhost:53682/callback",
+		Scopes:       []string{"openid"},
+	})
+	if err != nil {
+		t.Fatalf("start oauth failed: %v", err)
+	}
+	_, err = CompleteOAuthFlow(OAuthCompleteInput{
+		Provider: ProviderM365,
+		Profile:  "default",
+		Code:     "test-code",
+		State:    "wrong-state",
+	})
+	if err == nil || !strings.Contains(err.Error(), "state mismatch") {
+		t.Fatalf("expected state mismatch error, got: %v", err)
+	}
+}
+
+func TestCompleteOAuthFlowSuccessWithMockTokenExchange(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KAFCLAW_HOME", home)
+	t.Setenv("KAFCLAW_CONFIG", filepath.Join(home, ".kafclaw", "config.json"))
+	t.Setenv("KAFCLAW_OAUTH_KEY_BACKEND", "file")
+
+	start, err := StartOAuthFlow(OAuthStartInput{
+		Provider:     ProviderGoogleWorkspace,
+		Profile:      "default",
+		ClientID:     "cid",
+		ClientSecret: "secret",
+		RedirectURI:  "http://localhost:53682/callback",
+		Scopes:       []string{"openid"},
+	})
+	if err != nil {
+		t.Fatalf("start oauth failed: %v", err)
+	}
+
+	origTransport := http.DefaultTransport
+	defer func() { http.DefaultTransport = origTransport }()
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if strings.Contains(req.URL.Host, "oauth2.googleapis.com") {
+			body := `{"access_token":"at","refresh_token":"rt","token_type":"Bearer","expires_in":3600}`
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBufferString(body)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: 404,
+			Body:       io.NopCloser(bytes.NewBufferString(`{"error":"not_found"}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	res, err := CompleteOAuthFlow(OAuthCompleteInput{
+		Provider: ProviderGoogleWorkspace,
+		Profile:  "default",
+		Code:     "abc-code",
+		State:    start.State,
+	})
+	if err != nil {
+		t.Fatalf("complete oauth failed: %v", err)
+	}
+	if res.TokenPath == "" {
+		t.Fatal("expected token path")
+	}
+	if _, err := os.Stat(res.TokenPath); err != nil {
+		t.Fatalf("expected token file: %v", err)
+	}
+	data, err := os.ReadFile(res.TokenPath)
+	if err != nil {
+		t.Fatalf("read token file: %v", err)
+	}
+	text := string(data)
+	if strings.Contains(text, "access_token") {
+		t.Fatalf("expected encrypted token payload at rest, got plaintext token json: %s", text)
+	}
+	if !strings.Contains(text, "ciphertext") {
+		t.Fatalf("expected encrypted token wrapper with ciphertext field, got: %s", text)
+	}
+	dirs, err := EnsureStateDirs()
+	if err != nil {
+		t.Fatalf("ensure state dirs: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dirs.ToolsDir, "auth", "master.key")); err != nil {
+		t.Fatalf("expected oauth master key file fallback/presence: %v", err)
+	}
+}
+
+func TestStartOAuthFlowWritesSecurityEvent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KAFCLAW_HOME", home)
+	t.Setenv("KAFCLAW_CONFIG", filepath.Join(home, ".kafclaw", "config.json"))
+	t.Setenv("KAFCLAW_OAUTH_KEY_BACKEND", "file")
+
+	_, err := StartOAuthFlow(OAuthStartInput{
+		Provider:     ProviderGoogleWorkspace,
+		Profile:      "audit-profile",
+		ClientID:     "cid",
+		ClientSecret: "secret",
+		RedirectURI:  "http://localhost:53682/callback",
+		Scopes:       []string{"openid"},
+	})
+	if err != nil {
+		t.Fatalf("start oauth failed: %v", err)
+	}
+	dirs, err := EnsureStateDirs()
+	if err != nil {
+		t.Fatalf("ensure state dirs: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dirs.AuditDir, "security-events.jsonl"))
+	if err != nil {
+		t.Fatalf("read security events: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "\"eventType\":\"skills_oauth_start\"") {
+		t.Fatalf("expected oauth start event, got: %s", text)
+	}
+	if !strings.Contains(text, "\"success\":true") {
+		t.Fatalf("expected oauth success event, got: %s", text)
+	}
+}
+
+func TestOAuthLocalBackendCreatesTombKeyFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KAFCLAW_HOME", home)
+	t.Setenv("KAFCLAW_CONFIG", filepath.Join(home, ".kafclaw", "config.json"))
+	t.Setenv("KAFCLAW_OAUTH_KEY_BACKEND", "local")
+
+	_, err := StartOAuthFlow(OAuthStartInput{
+		Provider:     ProviderGoogleWorkspace,
+		Profile:      "local-key",
+		ClientID:     "cid",
+		ClientSecret: "secret",
+		RedirectURI:  "http://localhost:53682/callback",
+		Scopes:       []string{"openid"},
+	})
+	if err != nil {
+		t.Fatalf("start oauth failed: %v", err)
+	}
+	tombPath, err := ResolveLocalOAuthTombPath()
+	if err != nil {
+		t.Fatalf("resolve tomb path: %v", err)
+	}
+	st, err := os.Stat(tombPath)
+	if err != nil {
+		t.Fatalf("expected tomb key file: %v", err)
+	}
+	if st.Mode().Perm() != 0o600 {
+		t.Fatalf("expected tomb key perms 600, got %o", st.Mode().Perm())
+	}
+}
+
+func TestStoreAndLoadEnvSecretsInLocalTomb(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KAFCLAW_HOME", home)
+	t.Setenv("KAFCLAW_CONFIG", filepath.Join(home, ".kafclaw", "config.json"))
+
+	written, err := StoreEnvSecretsInLocalTomb(map[string]string{
+		"OPENAI_API_KEY":   "sk-test",
+		"SOME_OTHER_KEY":   "ignored",
+		"GITHUB_TOKEN":     "ghp-test",
+		"KAFCLAW_PASSWORD": "pw",
+	})
+	if err != nil {
+		t.Fatalf("store tomb env secrets: %v", err)
+	}
+	if written == 0 {
+		t.Fatalf("expected at least one secret written")
+	}
+	got, err := LoadEnvSecretsFromLocalTomb()
+	if err != nil {
+		t.Fatalf("load tomb env secrets: %v", err)
+	}
+	if got["OPENAI_API_KEY"] != "sk-test" || got["GITHUB_TOKEN"] != "ghp-test" {
+		t.Fatalf("unexpected tomb env payload: %#v", got)
+	}
+}
+
+type roundTripFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/internal/skills/prereq.go
+++ b/internal/skills/prereq.go
@@ -1,0 +1,221 @@
+package skills
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// PrereqResult captures prerequisite status/install output.
+type PrereqResult struct {
+	Name      string   `json:"name"`
+	Installed bool     `json:"installed"`
+	Messages  []string `json:"messages,omitempty"`
+}
+
+// CheckPrerequisite checks whether a named prerequisite is present.
+func CheckPrerequisite(name string) (*PrereqResult, error) {
+	name = strings.ToLower(strings.TrimSpace(name))
+	switch name {
+	case "google-cli", "gcloud":
+		return &PrereqResult{
+			Name:      "google-cli",
+			Installed: HasBinary("gcloud"),
+			Messages:  []string{"checks `gcloud` in PATH"},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported prerequisite: %s", name)
+	}
+}
+
+// InstallPrerequisite installs a named prerequisite using an OS-specific routine.
+func InstallPrerequisite(name string, dryRun bool) (*PrereqResult, error) {
+	name = strings.ToLower(strings.TrimSpace(name))
+	switch name {
+	case "google-cli", "gcloud":
+		return installGoogleCLI(dryRun)
+	default:
+		return nil, fmt.Errorf("unsupported prerequisite: %s", name)
+	}
+}
+
+func installGoogleCLI(dryRun bool) (*PrereqResult, error) {
+	if HasBinary("gcloud") {
+		return &PrereqResult{
+			Name:      "google-cli",
+			Installed: true,
+			Messages:  []string{"gcloud already present in PATH"},
+		}, nil
+	}
+	switch runtime.GOOS {
+	case "linux":
+		return installGoogleCLILinuxAPT(dryRun)
+	case "darwin":
+		return installGoogleCLIDarwinBrew(dryRun)
+	default:
+		return nil, fmt.Errorf("google-cli install not implemented for os=%s", runtime.GOOS)
+	}
+}
+
+func installGoogleCLIDarwinBrew(dryRun bool) (*PrereqResult, error) {
+	if !HasBinary("brew") {
+		return nil, errors.New("homebrew not found; install brew first")
+	}
+	cmds := [][]string{
+		{"brew", "update"},
+		{"brew", "install", "--cask", "google-cloud-sdk"},
+	}
+	msgs := formatCommands(cmds)
+	if dryRun {
+		return &PrereqResult{Name: "google-cli", Installed: false, Messages: msgs}, nil
+	}
+	for _, c := range cmds {
+		if err := runCommand(3*time.Minute, c[0], c[1:]...); err != nil {
+			return nil, err
+		}
+	}
+	return CheckPrerequisite("google-cli")
+}
+
+func installGoogleCLILinuxAPT(dryRun bool) (*PrereqResult, error) {
+	if !HasBinary("apt-get") {
+		return nil, errors.New("apt-get not found; only apt-based install is currently supported")
+	}
+	if !HasBinary("sudo") {
+		return nil, errors.New("sudo is required for apt install routine")
+	}
+	if !HasBinary("gpg") {
+		return nil, errors.New("gpg is required")
+	}
+
+	cmds := [][]string{
+		{"sudo", "apt-get", "update"},
+		{"sudo", "apt-get", "install", "-y", "ca-certificates", "gnupg", "curl"},
+		{"sudo", "install", "-m", "0755", "-d", "/usr/share/keyrings"},
+		{"sudo", "tee", "/etc/apt/sources.list.d/google-cloud-sdk.list"},
+		{"sudo", "apt-get", "update"},
+		{"sudo", "apt-get", "install", "-y", "google-cloud-cli"},
+	}
+	msgs := formatCommands(cmds)
+	if dryRun {
+		return &PrereqResult{Name: "google-cli", Installed: false, Messages: msgs}, nil
+	}
+
+	key, err := fetchGoogleCloudAPTKey()
+	if err != nil {
+		return nil, err
+	}
+	dearmored, err := dearmorGPGKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := runCommand(5*time.Minute, "sudo", "apt-get", "update"); err != nil {
+		return nil, err
+	}
+	if err := runCommand(5*time.Minute, "sudo", "apt-get", "install", "-y", "ca-certificates", "gnupg", "curl"); err != nil {
+		return nil, err
+	}
+	if err := runCommand(1*time.Minute, "sudo", "install", "-m", "0755", "-d", "/usr/share/keyrings"); err != nil {
+		return nil, err
+	}
+	if err := runCommandWithStdin(1*time.Minute, dearmored, "sudo", "tee", "/usr/share/keyrings/cloud.google.gpg"); err != nil {
+		return nil, err
+	}
+	repoLine := "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main\n"
+	if err := runCommandWithStdin(1*time.Minute, []byte(repoLine), "sudo", "tee", "/etc/apt/sources.list.d/google-cloud-sdk.list"); err != nil {
+		return nil, err
+	}
+	if err := runCommand(5*time.Minute, "sudo", "apt-get", "update"); err != nil {
+		return nil, err
+	}
+	if err := runCommand(10*time.Minute, "sudo", "apt-get", "install", "-y", "google-cloud-cli"); err != nil {
+		return nil, err
+	}
+	return CheckPrerequisite("google-cli")
+}
+
+func fetchGoogleCloudAPTKey() ([]byte, error) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://packages.cloud.google.com/apt/doc/apt-key.gpg", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("failed to fetch apt key: %s", resp.Status)
+	}
+	var b bytes.Buffer
+	if _, err := b.ReadFrom(resp.Body); err != nil {
+		return nil, err
+	}
+	if b.Len() == 0 {
+		return nil, errors.New("fetched apt key is empty")
+	}
+	return b.Bytes(), nil
+}
+
+func dearmorGPGKey(key []byte) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gpg", "--dearmor")
+	cmd.Stdin = bytes.NewReader(key)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("gpg --dearmor failed: %w (%s)", err, out.String())
+	}
+	if out.Len() == 0 {
+		return nil, errors.New("gpg --dearmor produced empty output")
+	}
+	return out.Bytes(), nil
+}
+
+func runCommand(timeout time.Duration, name string, args ...string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if stderr.Len() > 0 {
+			return fmt.Errorf("%s %s failed: %w (%s)", name, strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+		}
+		return fmt.Errorf("%s %s failed: %w", name, strings.Join(args, " "), err)
+	}
+	return nil
+}
+
+func runCommandWithStdin(timeout time.Duration, stdin []byte, name string, args ...string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdin = bytes.NewReader(stdin)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if stderr.Len() > 0 {
+			return fmt.Errorf("%s %s failed: %w (%s)", name, strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+		}
+		return fmt.Errorf("%s %s failed: %w", name, strings.Join(args, " "), err)
+	}
+	return nil
+}
+
+func formatCommands(cmds [][]string) []string {
+	out := make([]string, 0, len(cmds))
+	for _, c := range cmds {
+		out = append(out, strings.Join(c, " "))
+	}
+	return out
+}

--- a/internal/skills/prereq_test.go
+++ b/internal/skills/prereq_test.go
@@ -1,0 +1,69 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCheckPrerequisiteGoogleCLI(t *testing.T) {
+	res, err := CheckPrerequisite("google-cli")
+	if err != nil {
+		t.Fatalf("check prerequisite failed: %v", err)
+	}
+	if res.Name != "google-cli" {
+		t.Fatalf("unexpected prerequisite name: %s", res.Name)
+	}
+}
+
+func TestInstallPrerequisiteDryRun(t *testing.T) {
+	res, err := InstallPrerequisite("google-cli", true)
+	if err != nil {
+		t.Fatalf("dry-run install prerequisite failed: %v", err)
+	}
+	if res.Name != "google-cli" {
+		t.Fatalf("unexpected prerequisite name: %s", res.Name)
+	}
+	if len(res.Messages) == 0 && !res.Installed {
+		t.Fatal("expected dry-run output messages when not installed")
+	}
+}
+
+func TestRunCommandAndRunCommandWithStdin(t *testing.T) {
+	if err := runCommand(2*time.Second, "sh", "-c", "exit 0"); err != nil {
+		t.Fatalf("runCommand expected success: %v", err)
+	}
+	if err := runCommandWithStdin(2*time.Second, []byte("hello"), "sh", "-c", "cat >/dev/null"); err != nil {
+		t.Fatalf("runCommandWithStdin expected success: %v", err)
+	}
+}
+
+func TestFormatCommands(t *testing.T) {
+	out := formatCommands([][]string{{"a", "b"}, {"c"}})
+	if len(out) != 2 || out[0] != "a b" || out[1] != "c" {
+		t.Fatalf("unexpected formatCommands output: %#v", out)
+	}
+}
+
+func TestInstallGoogleCLIDryRunDarwinPath(t *testing.T) {
+	origPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", origPath)
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(bin, "brew"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write brew: %v", err)
+	}
+	_ = os.Setenv("PATH", bin+string(os.PathListSeparator)+origPath)
+	res, err := installGoogleCLIDarwinBrew(true)
+	if err != nil {
+		t.Fatalf("dry run should succeed: %v", err)
+	}
+	if len(res.Messages) == 0 || !strings.Contains(res.Messages[0], "brew update") {
+		t.Fatalf("unexpected dry-run messages: %#v", res.Messages)
+	}
+}

--- a/internal/skills/runtime.go
+++ b/internal/skills/runtime.go
@@ -1,0 +1,382 @@
+package skills
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+)
+
+const (
+	defaultExecTimeout    = 30 * time.Second
+	defaultMaxOutputBytes = 64 * 1024
+)
+
+var defaultNetworkDeniedCommands = []string{
+	"curl", "wget", "nc", "ncat", "netcat", "ssh", "scp", "sftp", "ftp", "telnet", "dig", "nslookup", "ping", "traceroute",
+	"git", "node", "npm", "npx", "pnpm", "yarn", "python", "python3", "pip", "pip3", "go", "cargo",
+}
+
+var blockedInterpreterCommands = []string{
+	"sh", "bash", "zsh", "fish", "dash", "ksh", "csh", "tcsh", "cmd", "powershell", "pwsh",
+}
+
+// SkillExecResult contains runtime execution details.
+type SkillExecResult struct {
+	SkillName       string        `json:"skillName"`
+	Command         []string      `json:"command"`
+	ScratchDir      string        `json:"scratchDir"`
+	Duration        time.Duration `json:"duration"`
+	ExitCode        int           `json:"exitCode"`
+	Stdout          string        `json:"stdout,omitempty"`
+	Stderr          string        `json:"stderr,omitempty"`
+	OutputTruncated bool          `json:"outputTruncated"`
+}
+
+type runtimePolicy struct {
+	AllowCommands     []string
+	DenyCommands      []string
+	Network           bool
+	ReadOnlyWorkspace bool
+	Timeout           time.Duration
+	MaxOutputBytes    int
+}
+
+// ExecuteSkillCommand runs one command in a skill sandbox with policy checks.
+func ExecuteSkillCommand(cfg *config.Config, skillName string, command []string) (*SkillExecResult, error) {
+	if cfg == nil {
+		cfg = config.DefaultConfig()
+	}
+	if len(command) == 0 {
+		return nil, fmt.Errorf("command is required")
+	}
+	skillName = sanitizeSkillName(skillName)
+	if skillName == "" {
+		return nil, fmt.Errorf("skill name is required")
+	}
+	if !EffectiveSkillEnabled(cfg, skillName) {
+		return nil, fmt.Errorf("skill %q is not enabled", skillName)
+	}
+
+	dirs, err := EnsureStateDirs()
+	if err != nil {
+		return nil, err
+	}
+	skillRoot := filepath.Join(dirs.Installed, skillName)
+	if st, err := os.Stat(skillRoot); err != nil || !st.IsDir() {
+		return nil, fmt.Errorf("skill %q is not installed", skillName)
+	}
+
+	policy, err := loadRuntimePolicy(skillRoot)
+	if err != nil {
+		return nil, err
+	}
+	if err := enforceRuntimePolicy(policy, cfg.Paths.WorkRepoPath, command); err != nil {
+		return nil, err
+	}
+
+	scratch, err := prepareSkillScratch(dirs.TmpDir, skillName)
+	if err != nil {
+		return nil, err
+	}
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), policy.Timeout)
+	defer cancel()
+	stdoutBuf := newLimitedBuffer(policy.MaxOutputBytes)
+	stderrBuf := newLimitedBuffer(policy.MaxOutputBytes)
+	err = runSkillCommandWithIsolation(ctx, cfg, skillRoot, scratch, command, stdoutBuf, stderrBuf)
+	dur := time.Since(start)
+	exitCode := 0
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			exitCode = ee.ExitCode()
+		} else {
+			exitCode = -1
+		}
+		if ctx.Err() == context.DeadlineExceeded {
+			return &SkillExecResult{
+				SkillName:       skillName,
+				Command:         append([]string{}, command...),
+				ScratchDir:      scratch,
+				Duration:        dur,
+				ExitCode:        exitCode,
+				Stdout:          stdoutBuf.String(),
+				Stderr:          stderrBuf.String(),
+				OutputTruncated: stdoutBuf.Truncated() || stderrBuf.Truncated(),
+			}, fmt.Errorf("skill command timed out after %s", policy.Timeout)
+		}
+	}
+
+	return &SkillExecResult{
+		SkillName:       skillName,
+		Command:         append([]string{}, command...),
+		ScratchDir:      scratch,
+		Duration:        dur,
+		ExitCode:        exitCode,
+		Stdout:          stdoutBuf.String(),
+		Stderr:          stderrBuf.String(),
+		OutputTruncated: stdoutBuf.Truncated() || stderrBuf.Truncated(),
+	}, err
+}
+
+func runSkillCommandWithIsolation(ctx context.Context, cfg *config.Config, skillRoot, scratch string, command []string, stdout io.Writer, stderr io.Writer) error {
+	mode := "auto"
+	if cfg != nil {
+		mode = strings.ToLower(strings.TrimSpace(cfg.Skills.RuntimeIsolation))
+		if mode == "" {
+			mode = "auto"
+		}
+	}
+	switch mode {
+	case "host":
+		return runHostCommand(ctx, scratch, command, stdout, stderr)
+	case "strict":
+		runtimeBin, err := StrictIsolationPreflight()
+		if err != nil {
+			return err
+		}
+		return runContainerIsolatedCommand(ctx, runtimeBin, skillRoot, scratch, command, stdout, stderr)
+	case "auto":
+		if runtimeBin, ok := detectContainerRuntime(); ok {
+			if err := runContainerIsolatedCommand(ctx, runtimeBin, skillRoot, scratch, command, stdout, stderr); err == nil {
+				return nil
+			}
+		}
+		return runHostCommand(ctx, scratch, command, stdout, stderr)
+	default:
+		return runHostCommand(ctx, scratch, command, stdout, stderr)
+	}
+}
+
+func runHostCommand(ctx context.Context, scratch string, command []string, stdout io.Writer, stderr io.Writer) error {
+	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
+	cmd.Dir = scratch
+	cmd.Env = minimalRuntimeEnv(scratch)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
+func detectContainerRuntime() (string, bool) {
+	for _, name := range []string{"docker", "podman"} {
+		if HasBinary(name) {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+// StrictIsolationPreflight validates strict runtime isolation prerequisites.
+func StrictIsolationPreflight() (string, error) {
+	runtimeBin, ok := detectContainerRuntime()
+	if !ok {
+		return "", fmt.Errorf("strict runtime isolation enabled but no container runtime (docker/podman) found")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, runtimeBin, "version")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("strict runtime isolation requires %s to be usable by current user: %w", runtimeBin, err)
+	}
+	return runtimeBin, nil
+}
+
+func runContainerIsolatedCommand(ctx context.Context, runtimeBin, skillRoot, scratch string, command []string, stdout io.Writer, stderr io.Writer) error {
+	if len(command) == 0 {
+		return fmt.Errorf("invalid command")
+	}
+	image := strings.TrimSpace(os.Getenv("KAFCLAW_SKILL_SANDBOX_IMAGE"))
+	if image == "" {
+		image = "alpine:3.20"
+	}
+	args := []string{
+		"run", "--rm",
+		"--network", "none",
+		"--read-only",
+		"--pids-limit", "64",
+		"--memory", "256m",
+		"--cpus", "1.0",
+		"--cap-drop", "ALL",
+		"--security-opt", "no-new-privileges",
+		"--user", "65534:65534",
+		"-v", skillRoot + ":/skill:ro",
+		"-v", scratch + ":/work:rw",
+		"-w", "/work",
+		"--tmpfs", "/tmp:rw,noexec,nosuid,size=64m",
+		"-e", "HOME=/work",
+		"-e", "TMPDIR=/tmp",
+		"-e", "KAFCLAW_SKILL_NETWORK=disabled",
+		image,
+	}
+	args = append(args, command...)
+	cmd := exec.CommandContext(ctx, runtimeBin, args...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
+func loadRuntimePolicy(skillRoot string) (runtimePolicy, error) {
+	p := runtimePolicy{
+		Network:           false,
+		ReadOnlyWorkspace: true,
+		Timeout:           defaultExecTimeout,
+		MaxOutputBytes:    defaultMaxOutputBytes,
+	}
+	data, err := os.ReadFile(filepath.Join(skillRoot, "SKILL-POLICY.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return p, nil
+		}
+		return p, err
+	}
+	var manifest skillPolicyManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return p, fmt.Errorf("invalid SKILL-POLICY.json: %w", err)
+	}
+	if manifest.Execution.Network != nil {
+		p.Network = *manifest.Execution.Network
+	}
+	if manifest.Execution.ReadOnlyWorkspace != nil {
+		p.ReadOnlyWorkspace = *manifest.Execution.ReadOnlyWorkspace
+	}
+	if manifest.Execution.TimeoutSeconds > 0 {
+		p.Timeout = time.Duration(manifest.Execution.TimeoutSeconds) * time.Second
+	}
+	if manifest.Execution.MaxOutputBytes > 0 {
+		p.MaxOutputBytes = manifest.Execution.MaxOutputBytes
+	}
+	p.AllowCommands = normalizeCommandList(manifest.Execution.AllowCommands)
+	p.DenyCommands = normalizeCommandList(manifest.Execution.DenyCommands)
+	return p, nil
+}
+
+func normalizeCommandList(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		v = strings.ToLower(strings.TrimSpace(v))
+		v = filepath.Base(v)
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	slices.Sort(out)
+	return slices.Compact(out)
+}
+
+func enforceRuntimePolicy(p runtimePolicy, workspace string, command []string) error {
+	if len(command) == 0 {
+		return fmt.Errorf("invalid command")
+	}
+	baseCmd := strings.ToLower(filepath.Base(strings.TrimSpace(command[0])))
+	if baseCmd == "" || baseCmd == "." {
+		return fmt.Errorf("invalid command")
+	}
+	if len(p.AllowCommands) > 0 && !slices.Contains(p.AllowCommands, baseCmd) {
+		return fmt.Errorf("command %q blocked by allowlist policy", baseCmd)
+	}
+	if len(p.DenyCommands) > 0 && slices.Contains(p.DenyCommands, baseCmd) {
+		return fmt.Errorf("command %q blocked by denylist policy", baseCmd)
+	}
+	if slices.Contains(blockedInterpreterCommands, baseCmd) {
+		return fmt.Errorf("command %q blocked: interpreter shells are not allowed in skills runtime", baseCmd)
+	}
+	if !p.Network && slices.Contains(defaultNetworkDeniedCommands, baseCmd) {
+		return fmt.Errorf("command %q blocked by no-network policy", baseCmd)
+	}
+	if p.ReadOnlyWorkspace {
+		ws := strings.TrimSpace(workspace)
+		if ws != "" {
+			if abs, err := filepath.Abs(ws); err == nil {
+				ws = abs
+			}
+			for _, arg := range command[1:] {
+				arg = strings.TrimSpace(arg)
+				if arg == "" || !filepath.IsAbs(arg) {
+					continue
+				}
+				clean := filepath.Clean(arg)
+				if clean == ws || strings.HasPrefix(clean, ws+string(os.PathSeparator)) {
+					return fmt.Errorf("workspace path argument blocked by read-only policy: %s", arg)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func prepareSkillScratch(tmpRoot, skill string) (string, error) {
+	dir := filepath.Join(tmpRoot, skill, fmt.Sprintf("run-%d", time.Now().UnixNano()))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+func minimalRuntimeEnv(scratch string) []string {
+	path := os.Getenv("PATH")
+	if strings.TrimSpace(path) == "" {
+		path = "/usr/bin:/bin"
+	}
+	return []string{
+		"PATH=" + path,
+		"HOME=" + scratch,
+		"TMPDIR=" + scratch,
+		"LANG=C.UTF-8",
+		"LC_ALL=C.UTF-8",
+		"HTTP_PROXY=",
+		"HTTPS_PROXY=",
+		"ALL_PROXY=",
+		"NO_PROXY=*",
+		"KAFCLAW_SKILL_NETWORK=disabled",
+	}
+}
+
+type limitedBuffer struct {
+	buf       bytes.Buffer
+	maxBytes  int
+	truncated bool
+}
+
+func newLimitedBuffer(max int) *limitedBuffer {
+	return &limitedBuffer{maxBytes: max}
+}
+
+func (l *limitedBuffer) Write(p []byte) (int, error) {
+	if l.maxBytes <= 0 {
+		l.truncated = true
+		return len(p), nil
+	}
+	remaining := l.maxBytes - l.buf.Len()
+	if remaining <= 0 {
+		l.truncated = true
+		return len(p), nil
+	}
+	if len(p) > remaining {
+		l.truncated = true
+		_, _ = l.buf.Write(p[:remaining])
+		return len(p), nil
+	}
+	_, err := l.buf.Write(p)
+	return len(p), err
+}
+
+func (l *limitedBuffer) String() string {
+	return l.buf.String()
+}
+
+func (l *limitedBuffer) Truncated() bool {
+	return l.truncated
+}
+
+var _ io.Writer = (*limitedBuffer)(nil)

--- a/internal/skills/runtime_test.go
+++ b/internal/skills/runtime_test.go
@@ -1,0 +1,179 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+)
+
+func TestExecuteSkillCommand_AllowlistBlocks(t *testing.T) {
+	cfg, skillName := setupRuntimeSkill(t, `{
+  "version": "1",
+  "execution": {
+    "allowCommands": ["echo"]
+  }
+}`)
+	_, err := ExecuteSkillCommand(cfg, skillName, []string{"ls"})
+	if err == nil || !strings.Contains(err.Error(), "allowlist") {
+		t.Fatalf("expected allowlist block error, got: %v", err)
+	}
+}
+
+func TestExecuteSkillCommand_NoNetworkDefaultBlocksCurl(t *testing.T) {
+	cfg, skillName := setupRuntimeSkill(t, "")
+	_, err := ExecuteSkillCommand(cfg, skillName, []string{"curl", "https://example.com"})
+	if err == nil || !strings.Contains(err.Error(), "no-network") {
+		t.Fatalf("expected no-network block, got: %v", err)
+	}
+}
+
+func TestExecuteSkillCommand_ReadOnlyWorkspaceBlocksAbsolutePathArg(t *testing.T) {
+	cfg, skillName := setupRuntimeSkill(t, `{"version":"1","execution":{"allowCommands":["echo"]}}`)
+	target := filepath.Join(cfg.Paths.WorkRepoPath, "foo.txt")
+	_, err := ExecuteSkillCommand(cfg, skillName, []string{"echo", target})
+	if err == nil || !strings.Contains(err.Error(), "read-only") {
+		t.Fatalf("expected read-only workspace block, got: %v", err)
+	}
+}
+
+func TestExecuteSkillCommand_OutputCapAndScratch(t *testing.T) {
+	cfg, skillName := setupRuntimeSkill(t, `{
+  "version": "1",
+  "execution": {
+    "allowCommands": ["printf"],
+    "maxOutputBytes": 8
+  }
+}`)
+	res, err := ExecuteSkillCommand(cfg, skillName, []string{"printf", "1234567890"})
+	if err != nil {
+		t.Fatalf("exec failed: %v", err)
+	}
+	if !res.OutputTruncated {
+		t.Fatalf("expected output truncation")
+	}
+	if res.ScratchDir == "" {
+		t.Fatalf("expected scratch dir")
+	}
+	if !strings.HasPrefix(res.ScratchDir, filepath.Join(filepath.Dir(mustConfigPath(t)), "skills", "tmp", skillName)+string(os.PathSeparator)) {
+		t.Fatalf("unexpected scratch dir: %s", res.ScratchDir)
+	}
+}
+
+func TestExecuteSkillCommand_TimeoutCap(t *testing.T) {
+	cfg, skillName := setupRuntimeSkill(t, `{
+  "version": "1",
+  "execution": {
+    "allowCommands": ["sleep"],
+    "timeoutSeconds": 1
+  }
+}`)
+	_, err := ExecuteSkillCommand(cfg, skillName, []string{"sleep", "2"})
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout error, got: %v", err)
+	}
+}
+
+func TestExecuteSkillCommand_BlocksShellInterpreter(t *testing.T) {
+	cfg, skillName := setupRuntimeSkill(t, `{"version":"1","execution":{"allowCommands":["bash"]}}`)
+	_, err := ExecuteSkillCommand(cfg, skillName, []string{"bash", "-lc", "echo hi"})
+	if err == nil || !strings.Contains(err.Error(), "interpreter shells") {
+		t.Fatalf("expected interpreter block, got: %v", err)
+	}
+}
+
+func TestEnforceRuntimePolicyMatrix(t *testing.T) {
+	workspace := t.TempDir()
+	cases := []struct {
+		name    string
+		policy  runtimePolicy
+		cmd     []string
+		wantErr bool
+	}{
+		{name: "missing command vector", policy: runtimePolicy{}, cmd: []string{}, wantErr: true},
+		{name: "invalid command", policy: runtimePolicy{}, cmd: []string{""}, wantErr: true},
+		{name: "dot command invalid", policy: runtimePolicy{}, cmd: []string{"."}, wantErr: true},
+		{name: "allowlist pass", policy: runtimePolicy{AllowCommands: []string{"echo"}}, cmd: []string{"echo", "ok"}, wantErr: false},
+		{name: "allowlist block", policy: runtimePolicy{AllowCommands: []string{"echo"}}, cmd: []string{"ls"}, wantErr: true},
+		{name: "denylist block", policy: runtimePolicy{DenyCommands: []string{"ls"}}, cmd: []string{"ls"}, wantErr: true},
+		{name: "network block", policy: runtimePolicy{Network: false}, cmd: []string{"curl", "https://x"}, wantErr: true},
+		{name: "network allow", policy: runtimePolicy{Network: true}, cmd: []string{"curl", "https://x"}, wantErr: false},
+		{name: "workspace readonly block", policy: runtimePolicy{ReadOnlyWorkspace: true}, cmd: []string{"echo", filepath.Join(workspace, "a.txt")}, wantErr: true},
+		{name: "workspace readonly pass outside", policy: runtimePolicy{ReadOnlyWorkspace: true}, cmd: []string{"echo", "/tmp/outside.txt"}, wantErr: false},
+		{name: "workspace readonly ignores relative", policy: runtimePolicy{ReadOnlyWorkspace: true}, cmd: []string{"echo", "relative.txt"}, wantErr: false},
+		{name: "workspace readonly disabled", policy: runtimePolicy{ReadOnlyWorkspace: false}, cmd: []string{"echo", filepath.Join(workspace, "a.txt")}, wantErr: false},
+		{name: "workspace empty passthrough", policy: runtimePolicy{ReadOnlyWorkspace: true}, cmd: []string{"echo", filepath.Join(workspace, "a.txt")}, wantErr: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ws := workspace
+			if tc.name == "workspace empty passthrough" {
+				ws = ""
+			}
+			err := enforceRuntimePolicy(tc.policy, ws, tc.cmd)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestStrictIsolationPreflightNoRuntime(t *testing.T) {
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", "")
+	defer os.Setenv("PATH", origPath)
+	_, err := StrictIsolationPreflight()
+	if err == nil || !strings.Contains(err.Error(), "no container runtime") {
+		t.Fatalf("expected strict preflight runtime error, got: %v", err)
+	}
+}
+
+func setupRuntimeSkill(t *testing.T, policy string) (*config.Config, string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("KAFCLAW_HOME", home)
+	t.Setenv("KAFCLAW_CONFIG", filepath.Join(home, ".kafclaw", "config.json"))
+	work := filepath.Join(home, "workspace")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+	cfg := config.DefaultConfig()
+	cfg.Paths.WorkRepoPath = work
+	cfg.Skills.Enabled = true
+	cfg.Skills.RuntimeIsolation = "host"
+	skillName := "runtime-test-skill"
+	cfg.Skills.Entries = map[string]config.SkillEntryConfig{
+		skillName: {Enabled: true},
+	}
+	dirs, err := EnsureStateDirs()
+	if err != nil {
+		t.Fatalf("ensure state dirs: %v", err)
+	}
+	root := filepath.Join(dirs.Installed, skillName)
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("mkdir skill root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "SKILL.md"), []byte("---\nname: runtime-test-skill\ndescription: rt\n---\n"), 0o600); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	if strings.TrimSpace(policy) != "" {
+		if err := os.WriteFile(filepath.Join(root, "SKILL-POLICY.json"), []byte(policy), 0o600); err != nil {
+			t.Fatalf("write policy: %v", err)
+		}
+	}
+	return cfg, skillName
+}
+
+func mustConfigPath(t *testing.T) string {
+	t.Helper()
+	p, err := config.ConfigPath()
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	return p
+}

--- a/internal/skills/verify.go
+++ b/internal/skills/verify.go
@@ -25,10 +25,10 @@ import (
 )
 
 const (
-	maxRemoteSkillBytes = 20 << 20 // 20 MiB
-	maxSkillFiles       = 1500
-	maxFileBytes        = 1 << 20 // 1 MiB per scanned file
-	maxArchiveEntryBytes = 5 << 20 // 5 MiB per archive entry
+	maxRemoteSkillBytes  = 20 << 20 // 20 MiB
+	maxSkillFiles        = 1500
+	maxFileBytes         = 1 << 20  // 1 MiB per scanned file
+	maxArchiveEntryBytes = 5 << 20  // 5 MiB per archive entry
 	maxArchiveTotalBytes = 40 << 20 // 40 MiB total extracted bytes
 	maxDownloadRedirects = 10
 )

--- a/internal/skills/verify.go
+++ b/internal/skills/verify.go
@@ -1,0 +1,783 @@
+package skills
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+)
+
+const (
+	maxRemoteSkillBytes = 20 << 20 // 20 MiB
+	maxSkillFiles       = 1500
+	maxFileBytes        = 1 << 20 // 1 MiB per scanned file
+	maxArchiveEntryBytes = 5 << 20 // 5 MiB per archive entry
+	maxArchiveTotalBytes = 40 << 20 // 40 MiB total extracted bytes
+	maxDownloadRedirects = 10
+)
+
+// Severity indicates a verification finding level.
+type Severity string
+
+const (
+	SeverityCritical Severity = "critical"
+	SeverityWarn     Severity = "warn"
+	SeverityInfo     Severity = "info"
+)
+
+// Finding represents a single verification result.
+type Finding struct {
+	Severity Severity `json:"severity"`
+	Code     string   `json:"code"`
+	Message  string   `json:"message"`
+	File     string   `json:"file,omitempty"`
+}
+
+// VerifyReport summarizes verification checks for a skill source.
+type VerifyReport struct {
+	OK             bool      `json:"ok"`
+	Target         string    `json:"target"`
+	ResolvedTarget string    `json:"resolvedTarget,omitempty"`
+	SourceType     string    `json:"sourceType"`
+	SkillName      string    `json:"skillName,omitempty"`
+	FileCount      int       `json:"fileCount"`
+	LinkCount      int       `json:"linkCount"`
+	Findings       []Finding `json:"findings,omitempty"`
+}
+
+func (r *VerifyReport) appendFinding(sev Severity, code, msg, file string) {
+	r.Findings = append(r.Findings, Finding{
+		Severity: sev,
+		Code:     code,
+		Message:  msg,
+		File:     file,
+	})
+}
+
+// CriticalCount returns number of critical findings.
+func (r *VerifyReport) CriticalCount() int {
+	n := 0
+	for _, f := range r.Findings {
+		if f.Severity == SeverityCritical {
+			n++
+		}
+	}
+	return n
+}
+
+// WarningCount returns number of warning findings.
+func (r *VerifyReport) WarningCount() int {
+	n := 0
+	for _, f := range r.Findings {
+		if f.Severity == SeverityWarn {
+			n++
+		}
+	}
+	return n
+}
+
+type sourceFile struct {
+	Path string
+	Data []byte
+}
+
+type sourcePackage struct {
+	SourceType     string
+	Target         string
+	ResolvedTarget string
+	SkillName      string
+	Files          []sourceFile
+}
+
+var (
+	urlRegex            = regexp.MustCompile(`https?://[^\s"'<>]+`)
+	frontmatterNameExpr = regexp.MustCompile(`(?m)^name:\s*([a-zA-Z0-9_.-]+)\s*$`)
+	frontmatterDescExpr = regexp.MustCompile(`(?m)^description:\s*(.+)\s*$`)
+)
+
+type skillFrontmatter struct {
+	Name        string
+	Description string
+}
+
+type skillPolicyManifest struct {
+	Version   string `json:"version"`
+	Execution struct {
+		Network           *bool    `json:"network,omitempty"`
+		ReadOnlyWorkspace *bool    `json:"readOnlyWorkspace,omitempty"`
+		AllowCommands     []string `json:"allowCommands,omitempty"`
+		DenyCommands      []string `json:"denyCommands,omitempty"`
+		TimeoutSeconds    int      `json:"timeoutSeconds,omitempty"`
+		MaxOutputBytes    int      `json:"maxOutputBytes,omitempty"`
+	} `json:"execution,omitempty"`
+	LinkPolicy struct {
+		AllowDomains []string `json:"allowDomains,omitempty"`
+		DenyDomains  []string `json:"denyDomains,omitempty"`
+		AllowHTTP    *bool    `json:"allowHttp,omitempty"`
+	} `json:"linkPolicy,omitempty"`
+}
+
+var suspiciousPatterns = []struct {
+	re       *regexp.Regexp
+	code     string
+	severity Severity
+	message  string
+}{
+	{regexp.MustCompile(`(?i)\b(curl|wget)\b[^\n]{0,200}\|\s*(sh|bash)\b`), "pipe_shell_exec", SeverityCritical, "Potential remote script execution pattern"},
+	{regexp.MustCompile(`(?i)\bpowershell\b[^\n]{0,200}-enc(odedcommand)?\b`), "encoded_powershell", SeverityCritical, "Potential encoded PowerShell execution pattern"},
+	{regexp.MustCompile(`(?i)\beval\s*\(`), "eval_usage", SeverityWarn, "Dynamic eval usage detected"},
+	{regexp.MustCompile(`(?i)exec\.Command\(`), "exec_command_usage", SeverityWarn, "Command execution usage detected"},
+	{regexp.MustCompile(`(?i)\bos/exec\b`), "os_exec_import", SeverityWarn, "os/exec import detected"},
+	{regexp.MustCompile(`(?i)\bsubprocess\b`), "subprocess_usage", SeverityWarn, "subprocess usage detected"},
+	{regexp.MustCompile(`(?i)base64[^\n]{0,100}(decode|DecodeString)`), "base64_decode", SeverityWarn, "Base64 decode usage detected"},
+}
+
+// VerifySkillSource runs static security checks for local/remote skill sources.
+func VerifySkillSource(cfg *config.Config, target string) (*VerifyReport, error) {
+	if cfg == nil {
+		cfg = config.DefaultConfig()
+	}
+	pkg, report, err := loadSkillPackage(cfg, target)
+	if err != nil {
+		return nil, err
+	}
+	report.SkillName = pkg.SkillName
+	report.FileCount = len(pkg.Files)
+	scanPackage(cfg, pkg, report)
+	validateManifestAndFrontmatter(cfg, pkg, report)
+	report.OK = report.CriticalCount() == 0
+	return report, nil
+}
+
+func loadSkillPackage(cfg *config.Config, target string) (*sourcePackage, *VerifyReport, error) {
+	resolved := resolveTarget(strings.TrimSpace(target))
+	if resolved == "" {
+		return nil, nil, fmt.Errorf("target is required")
+	}
+	report := &VerifyReport{Target: target, ResolvedTarget: resolved}
+
+	if isHTTPURL(resolved) {
+		report.SourceType = "url"
+		if !cfg.Skills.ExternalInstalls {
+			return nil, nil, fmt.Errorf("external skill installs are disabled by config")
+		}
+		if err := validatePolicyURL(cfg, resolved); err != nil {
+			return nil, nil, err
+		}
+		b, finalURL, err := downloadSkillArchive(context.Background(), resolved, cfg)
+		if err != nil {
+			return nil, nil, err
+		}
+		if strings.TrimSpace(finalURL) != "" {
+			resolved = finalURL
+			report.ResolvedTarget = finalURL
+		}
+		files, stype, err := unpackArchive(resolved, b)
+		if err != nil {
+			return nil, nil, err
+		}
+		report.SourceType = stype
+		return normalizePackage(&sourcePackage{
+			SourceType:     stype,
+			Target:         target,
+			ResolvedTarget: resolved,
+			Files:          files,
+		}, cfg, report)
+	}
+
+	fi, err := os.Stat(resolved)
+	if err != nil {
+		return nil, nil, err
+	}
+	if fi.IsDir() {
+		report.SourceType = "dir"
+		files, err := readLocalDir(resolved)
+		if err != nil {
+			return nil, nil, err
+		}
+		return normalizePackage(&sourcePackage{
+			SourceType:     "dir",
+			Target:         target,
+			ResolvedTarget: resolved,
+			Files:          files,
+		}, cfg, report)
+	}
+
+	report.SourceType = "archive"
+	b, err := os.ReadFile(resolved)
+	if err != nil {
+		return nil, nil, err
+	}
+	files, stype, err := unpackArchive(resolved, b)
+	if err != nil {
+		return nil, nil, err
+	}
+	report.SourceType = stype
+	return normalizePackage(&sourcePackage{
+		SourceType:     stype,
+		Target:         target,
+		ResolvedTarget: resolved,
+		Files:          files,
+	}, cfg, report)
+}
+
+func normalizePackage(pkg *sourcePackage, cfg *config.Config, report *VerifyReport) (*sourcePackage, *VerifyReport, error) {
+	if len(pkg.Files) == 0 {
+		return nil, nil, errors.New("skill source is empty")
+	}
+	if len(pkg.Files) > maxSkillFiles {
+		return nil, nil, fmt.Errorf("skill source contains too many files (%d > %d)", len(pkg.Files), maxSkillFiles)
+	}
+
+	prefix, err := detectSkillRootPrefix(pkg.Files)
+	if err != nil {
+		return nil, nil, err
+	}
+	trimmed := make([]sourceFile, 0, len(pkg.Files))
+	for _, f := range pkg.Files {
+		p := filepath.ToSlash(strings.TrimSpace(f.Path))
+		if prefix != "" {
+			if p == strings.TrimSuffix(prefix, "/") {
+				continue
+			}
+			if !strings.HasPrefix(p, prefix) {
+				continue
+			}
+			p = strings.TrimPrefix(p, prefix)
+		}
+		p = strings.TrimPrefix(p, "./")
+		p = strings.TrimLeft(p, "/")
+		if p == "" {
+			continue
+		}
+		trimmed = append(trimmed, sourceFile{Path: p, Data: f.Data})
+	}
+	if len(trimmed) == 0 {
+		return nil, nil, errors.New("skill source root did not contain files")
+	}
+	pkg.Files = trimmed
+
+	skillData, ok := findFile(pkg.Files, "SKILL.md")
+	if !ok {
+		return nil, nil, errors.New("SKILL.md not found in skill source root")
+	}
+	fm, _ := parseSkillFrontmatter(skillData)
+	name := fm.Name
+	if name == "" && prefix != "" {
+		name = strings.TrimSuffix(prefix, "/")
+	}
+	if name == "" {
+		base := filepath.Base(pkg.ResolvedTarget)
+		base = strings.TrimSuffix(base, filepath.Ext(base))
+		name = sanitizeSkillName(base)
+	}
+	if name == "" {
+		return nil, nil, errors.New("could not determine skill name")
+	}
+	pkg.SkillName = name
+	report.SkillName = name
+	return pkg, report, nil
+}
+
+func scanPackage(cfg *config.Config, pkg *sourcePackage, report *VerifyReport) {
+	linkCount := 0
+	maxLinks := cfg.Skills.LinkPolicy.MaxLinksPerSkill
+	if maxLinks <= 0 {
+		maxLinks = 20
+	}
+
+	for _, f := range pkg.Files {
+		if len(f.Data) > maxFileBytes {
+			report.appendFinding(SeverityWarn, "large_file", fmt.Sprintf("Large file skipped after %d bytes", maxFileBytes), f.Path)
+		}
+		data := f.Data
+		if len(data) > maxFileBytes {
+			data = data[:maxFileBytes]
+		}
+		if !isTextContent(data) {
+			continue
+		}
+		text := string(data)
+		for _, p := range suspiciousPatterns {
+			if p.re.MatchString(text) {
+				report.appendFinding(p.severity, p.code, p.message, f.Path)
+			}
+		}
+
+		matches := urlRegex.FindAllString(text, -1)
+		for _, raw := range matches {
+			linkCount++
+			if linkCount > maxLinks {
+				report.appendFinding(SeverityCritical, "max_links_exceeded", fmt.Sprintf("Skill contains too many links (%d > %d)", linkCount, maxLinks), f.Path)
+				break
+			}
+			if err := validatePolicyURL(cfg, raw); err != nil {
+				report.appendFinding(SeverityCritical, "link_policy_block", err.Error(), f.Path)
+			}
+		}
+	}
+	report.LinkCount = linkCount
+}
+
+func detectSkillRootPrefix(files []sourceFile) (string, error) {
+	if _, ok := findFile(files, "SKILL.md"); ok {
+		return "", nil
+	}
+	candidates := map[string]struct{}{}
+	for _, f := range files {
+		p := filepath.ToSlash(f.Path)
+		if strings.HasSuffix(p, "/SKILL.md") {
+			dir := strings.TrimSuffix(p, "SKILL.md")
+			candidates[dir] = struct{}{}
+		}
+	}
+	if len(candidates) == 1 {
+		for k := range candidates {
+			return k, nil
+		}
+	}
+	return "", errors.New("unable to locate unique skill root containing SKILL.md")
+}
+
+func findFile(files []sourceFile, rel string) ([]byte, bool) {
+	rel = filepath.ToSlash(rel)
+	for _, f := range files {
+		if filepath.ToSlash(f.Path) == rel {
+			return f.Data, true
+		}
+	}
+	return nil, false
+}
+
+func parseSkillName(skillMD []byte) string {
+	fm, _ := parseSkillFrontmatter(skillMD)
+	return fm.Name
+}
+
+func parseSkillFrontmatter(skillMD []byte) (skillFrontmatter, bool) {
+	text := string(skillMD)
+	if !strings.HasPrefix(text, "---\n") {
+		return skillFrontmatter{}, false
+	}
+	end := strings.Index(text[4:], "\n---")
+	if end < 0 {
+		return skillFrontmatter{}, false
+	}
+	block := text[4 : 4+end]
+	var out skillFrontmatter
+	if nameMatch := frontmatterNameExpr.FindStringSubmatch(block); len(nameMatch) >= 2 {
+		out.Name = sanitizeSkillName(nameMatch[1])
+	}
+	if descMatch := frontmatterDescExpr.FindStringSubmatch(block); len(descMatch) >= 2 {
+		out.Description = strings.TrimSpace(descMatch[1])
+		out.Description = strings.Trim(out.Description, `"'`)
+	}
+	return out, true
+}
+
+func sanitizeSkillName(v string) string {
+	v = strings.ToLower(strings.TrimSpace(v))
+	v = strings.ReplaceAll(v, " ", "-")
+	var out strings.Builder
+	for _, r := range v {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {
+			out.WriteRune(r)
+		}
+	}
+	name := strings.Trim(out.String(), "-_.")
+	return name
+}
+
+func readLocalDir(root string) ([]sourceFile, error) {
+	var files []sourceFile
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symlink not allowed in local skill source: %s", path)
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if !isSafeRelativePath(rel) {
+			return fmt.Errorf("unsafe path in skill source: %s", rel)
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		files = append(files, sourceFile{Path: rel, Data: b})
+		return nil
+	})
+	return files, err
+}
+
+func unpackArchive(name string, data []byte) ([]sourceFile, string, error) {
+	if len(data) == 0 {
+		return nil, "", errors.New("empty archive")
+	}
+	lower := strings.ToLower(name)
+	switch {
+	case strings.HasSuffix(lower, ".zip"):
+		files, err := unpackZIP(data)
+		return files, "zip", err
+	case strings.HasSuffix(lower, ".tar.gz"), strings.HasSuffix(lower, ".tgz"):
+		files, err := unpackTarGZ(data)
+		return files, "tar.gz", err
+	default:
+		if files, err := unpackZIP(data); err == nil {
+			return files, "zip", nil
+		}
+		if files, err := unpackTarGZ(data); err == nil {
+			return files, "tar.gz", nil
+		}
+		return nil, "", errors.New("unsupported archive format (expected .zip or .tar.gz/.tgz)")
+	}
+}
+
+func unpackZIP(data []byte) ([]sourceFile, error) {
+	r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return nil, err
+	}
+	files := make([]sourceFile, 0, len(r.File))
+	var totalRead int64
+	for _, f := range r.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		if f.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("symlink entry not allowed: %s", f.Name)
+		}
+		if f.UncompressedSize64 > uint64(maxArchiveEntryBytes) {
+			return nil, fmt.Errorf("archive entry exceeds max size (%d bytes): %s", maxArchiveEntryBytes, f.Name)
+		}
+		totalRead += int64(f.UncompressedSize64)
+		if totalRead > maxArchiveTotalBytes {
+			return nil, fmt.Errorf("archive extracted size exceeds max total (%d bytes)", maxArchiveTotalBytes)
+		}
+		name := filepath.ToSlash(strings.TrimPrefix(f.Name, "./"))
+		if !isSafeRelativePath(name) {
+			return nil, fmt.Errorf("unsafe archive path: %s", f.Name)
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return nil, err
+		}
+		b, err := io.ReadAll(io.LimitReader(rc, maxArchiveEntryBytes+1))
+		_ = rc.Close()
+		if err != nil {
+			return nil, err
+		}
+		if len(b) > maxArchiveEntryBytes {
+			return nil, fmt.Errorf("archive entry exceeds max size while reading: %s", f.Name)
+		}
+		files = append(files, sourceFile{Path: name, Data: b})
+	}
+	return files, nil
+}
+
+func unpackTarGZ(data []byte) ([]sourceFile, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	var files []sourceFile
+	var totalRead int64
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			continue
+		case tar.TypeSymlink, tar.TypeLink:
+			return nil, fmt.Errorf("link entry not allowed: %s", hdr.Name)
+		case tar.TypeReg, tar.TypeRegA:
+			if hdr.Size < 0 {
+				return nil, fmt.Errorf("invalid tar entry size for %s", hdr.Name)
+			}
+			if hdr.Size > maxArchiveEntryBytes {
+				return nil, fmt.Errorf("archive entry exceeds max size (%d bytes): %s", maxArchiveEntryBytes, hdr.Name)
+			}
+			totalRead += hdr.Size
+			if totalRead > maxArchiveTotalBytes {
+				return nil, fmt.Errorf("archive extracted size exceeds max total (%d bytes)", maxArchiveTotalBytes)
+			}
+			name := filepath.ToSlash(strings.TrimPrefix(hdr.Name, "./"))
+			if !isSafeRelativePath(name) {
+				return nil, fmt.Errorf("unsafe archive path: %s", hdr.Name)
+			}
+			b, err := io.ReadAll(io.LimitReader(tr, maxArchiveEntryBytes+1))
+			if err != nil {
+				return nil, err
+			}
+			if len(b) > maxArchiveEntryBytes {
+				return nil, fmt.Errorf("archive entry exceeds max size while reading: %s", hdr.Name)
+			}
+			files = append(files, sourceFile{Path: name, Data: b})
+		default:
+			return nil, fmt.Errorf("unsupported tar entry type for %s", hdr.Name)
+		}
+	}
+	return files, nil
+}
+
+func isSafeRelativePath(p string) bool {
+	p = filepath.ToSlash(strings.TrimSpace(p))
+	if p == "" {
+		return false
+	}
+	if strings.HasPrefix(p, "/") {
+		return false
+	}
+	clean := filepath.ToSlash(filepath.Clean(p))
+	if clean == "." || strings.HasPrefix(clean, "../") || strings.Contains(clean, "/../") {
+		return false
+	}
+	return true
+}
+
+func isTextContent(b []byte) bool {
+	if len(b) == 0 {
+		return true
+	}
+	if bytes.IndexByte(b, 0) >= 0 {
+		return false
+	}
+	return utf8.Valid(b)
+}
+
+func downloadSkillArchive(ctx context.Context, rawURL string, cfg *config.Config) ([]byte, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	client := &http.Client{
+		Timeout: 45 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= maxDownloadRedirects {
+				return fmt.Errorf("too many redirects while downloading skill archive")
+			}
+			if cfg != nil {
+				if err := validatePolicyURL(cfg, req.URL.String()); err != nil {
+					return fmt.Errorf("redirect blocked by link policy: %w", err)
+				}
+			}
+			return nil
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", fmt.Errorf("download failed: %s", resp.Status)
+	}
+	finalURL := rawURL
+	if resp.Request != nil && resp.Request.URL != nil {
+		finalURL = resp.Request.URL.String()
+	}
+	if cfg != nil {
+		if err := validatePolicyURL(cfg, finalURL); err != nil {
+			return nil, "", fmt.Errorf("resolved URL blocked by link policy: %w", err)
+		}
+	}
+	reader := io.LimitReader(resp.Body, maxRemoteSkillBytes+1)
+	b, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, "", err
+	}
+	if int64(len(b)) > maxRemoteSkillBytes {
+		return nil, "", fmt.Errorf("download exceeds max size (%d bytes)", maxRemoteSkillBytes)
+	}
+	return b, finalURL, nil
+}
+
+func validatePolicyURL(cfg *config.Config, raw string) error {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return fmt.Errorf("invalid URL: %q", raw)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "https" && scheme != "http" {
+		return fmt.Errorf("unsupported URL scheme: %s", scheme)
+	}
+	if scheme == "http" && !cfg.Skills.LinkPolicy.AllowHTTP {
+		return fmt.Errorf("http URL is blocked by policy: %s", raw)
+	}
+	host := strings.ToLower(strings.TrimSpace(u.Hostname()))
+	if host == "" {
+		return fmt.Errorf("URL missing host: %s", raw)
+	}
+
+	mode := strings.ToLower(strings.TrimSpace(cfg.Skills.LinkPolicy.Mode))
+	allow := normalizeDomains(cfg.Skills.LinkPolicy.AllowDomains)
+	deny := normalizeDomains(cfg.Skills.LinkPolicy.DenyDomains)
+	switch mode {
+	case "", "allowlist":
+		if len(allow) == 0 {
+			return nil
+		}
+		if !matchesAnyDomain(host, allow) {
+			return fmt.Errorf("domain blocked by allowlist policy: %s", host)
+		}
+	case "denylist":
+		if matchesAnyDomain(host, deny) {
+			return fmt.Errorf("domain blocked by denylist policy: %s", host)
+		}
+	case "open":
+		// no domain restrictions
+	default:
+		return fmt.Errorf("unknown link policy mode: %s", mode)
+	}
+	return nil
+}
+
+func normalizeDomains(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, d := range in {
+		d = strings.ToLower(strings.TrimSpace(d))
+		d = strings.TrimPrefix(d, ".")
+		if d != "" {
+			out = append(out, d)
+		}
+	}
+	slices.Sort(out)
+	return slices.Compact(out)
+}
+
+func matchesAnyDomain(host string, domains []string) bool {
+	for _, d := range domains {
+		if host == d || strings.HasSuffix(host, "."+d) {
+			return true
+		}
+	}
+	return false
+}
+
+func isHTTPURL(target string) bool {
+	u, err := url.Parse(target)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(u.Scheme, "http") || strings.EqualFold(u.Scheme, "https")
+}
+
+func resolveTarget(target string) string {
+	if target == "" {
+		return ""
+	}
+	if isHTTPURL(target) {
+		return target
+	}
+	if fi, err := os.Stat(target); err == nil {
+		if abs, err := filepath.Abs(target); err == nil {
+			return abs
+		}
+		if fi.Mode().IsRegular() || fi.IsDir() {
+			return target
+		}
+	}
+	// Slug fallback for clawhub catalog.
+	if !strings.Contains(target, "/") && !strings.Contains(target, `\`) {
+		return fmt.Sprintf("https://clawhub.ai/skills/%s.zip", target)
+	}
+	return target
+}
+
+func validateManifestAndFrontmatter(cfg *config.Config, pkg *sourcePackage, report *VerifyReport) {
+	skillData, ok := findFile(pkg.Files, "SKILL.md")
+	if !ok {
+		report.appendFinding(SeverityCritical, "missing_skill_md", "SKILL.md missing from package root", "")
+		return
+	}
+	fm, hasFM := parseSkillFrontmatter(skillData)
+	if !hasFM {
+		report.appendFinding(SeverityCritical, "missing_frontmatter", "SKILL.md must include YAML frontmatter", "SKILL.md")
+	} else {
+		if fm.Name == "" {
+			report.appendFinding(SeverityCritical, "frontmatter_name_missing", "SKILL.md frontmatter missing `name`", "SKILL.md")
+		}
+		if fm.Description == "" {
+			report.appendFinding(SeverityCritical, "frontmatter_description_missing", "SKILL.md frontmatter missing `description`", "SKILL.md")
+		}
+		if fm.Name != "" && report.SkillName != "" && fm.Name != report.SkillName {
+			report.appendFinding(SeverityWarn, "frontmatter_name_mismatch", fmt.Sprintf("frontmatter name %q differs from resolved skill name %q", fm.Name, report.SkillName), "SKILL.md")
+		}
+	}
+
+	policyData, hasPolicy := findFile(pkg.Files, "SKILL-POLICY.json")
+	if !hasPolicy {
+		report.appendFinding(SeverityWarn, "policy_manifest_missing", "SKILL-POLICY.json not found; using global policy defaults", "")
+		return
+	}
+	var policy skillPolicyManifest
+	if err := json.Unmarshal(policyData, &policy); err != nil {
+		report.appendFinding(SeverityCritical, "policy_manifest_invalid_json", fmt.Sprintf("invalid SKILL-POLICY.json: %v", err), "SKILL-POLICY.json")
+		return
+	}
+	if strings.TrimSpace(policy.Version) == "" {
+		report.appendFinding(SeverityCritical, "policy_manifest_version_missing", "SKILL-POLICY.json requires non-empty `version`", "SKILL-POLICY.json")
+	}
+	for _, d := range append([]string{}, policy.LinkPolicy.AllowDomains...) {
+		if strings.TrimSpace(d) == "" || strings.Contains(strings.TrimSpace(d), " ") {
+			report.appendFinding(SeverityCritical, "policy_manifest_invalid_domain", fmt.Sprintf("invalid allow domain entry: %q", d), "SKILL-POLICY.json")
+		}
+	}
+	for _, d := range append([]string{}, policy.LinkPolicy.DenyDomains...) {
+		if strings.TrimSpace(d) == "" || strings.Contains(strings.TrimSpace(d), " ") {
+			report.appendFinding(SeverityCritical, "policy_manifest_invalid_domain", fmt.Sprintf("invalid deny domain entry: %q", d), "SKILL-POLICY.json")
+		}
+	}
+	if policy.LinkPolicy.AllowHTTP != nil && !cfg.Skills.LinkPolicy.AllowHTTP && *policy.LinkPolicy.AllowHTTP {
+		report.appendFinding(SeverityWarn, "policy_manifest_allowhttp_overrides_global", "SKILL-POLICY allowHttp=true conflicts with stricter global policy", "SKILL-POLICY.json")
+	}
+	if policy.Execution.TimeoutSeconds < 0 {
+		report.appendFinding(SeverityCritical, "policy_manifest_timeout_invalid", "execution.timeoutSeconds must be >= 0", "SKILL-POLICY.json")
+	}
+	if policy.Execution.MaxOutputBytes < 0 {
+		report.appendFinding(SeverityCritical, "policy_manifest_output_limit_invalid", "execution.maxOutputBytes must be >= 0", "SKILL-POLICY.json")
+	}
+	for _, c := range append([]string{}, policy.Execution.AllowCommands...) {
+		if strings.TrimSpace(c) == "" {
+			report.appendFinding(SeverityCritical, "policy_manifest_command_invalid", "execution.allowCommands cannot include empty values", "SKILL-POLICY.json")
+			break
+		}
+	}
+	for _, c := range append([]string{}, policy.Execution.DenyCommands...) {
+		if strings.TrimSpace(c) == "" {
+			report.appendFinding(SeverityCritical, "policy_manifest_command_invalid", "execution.denyCommands cannot include empty values", "SKILL-POLICY.json")
+			break
+		}
+	}
+}

--- a/internal/skills/verify.go
+++ b/internal/skills/verify.go
@@ -479,7 +479,14 @@ func unpackZIP(data []byte) ([]sourceFile, error) {
 		if totalRead > maxArchiveTotalBytes {
 			return nil, fmt.Errorf("archive extracted size exceeds max total (%d bytes)", maxArchiveTotalBytes)
 		}
-		name, err := sanitizeArchiveEntryPath(f.Name)
+		rawName := strings.ReplaceAll(strings.TrimSpace(f.Name), "\\", "/")
+		if strings.Contains(rawName, "..") {
+			return nil, fmt.Errorf("unsafe archive path: %s", f.Name)
+		}
+		if strings.HasPrefix(rawName, "/") {
+			return nil, fmt.Errorf("unsafe archive path: %s", f.Name)
+		}
+		name, err := sanitizeArchiveEntryPath(rawName)
 		if err != nil {
 			return nil, fmt.Errorf("unsafe archive path: %s", f.Name)
 		}
@@ -533,7 +540,14 @@ func unpackTarGZ(data []byte) ([]sourceFile, error) {
 			if totalRead > maxArchiveTotalBytes {
 				return nil, fmt.Errorf("archive extracted size exceeds max total (%d bytes)", maxArchiveTotalBytes)
 			}
-			name, err := sanitizeArchiveEntryPath(hdr.Name)
+			rawName := strings.ReplaceAll(strings.TrimSpace(hdr.Name), "\\", "/")
+			if strings.Contains(rawName, "..") {
+				return nil, fmt.Errorf("unsafe archive path: %s", hdr.Name)
+			}
+			if strings.HasPrefix(rawName, "/") {
+				return nil, fmt.Errorf("unsafe archive path: %s", hdr.Name)
+			}
+			name, err := sanitizeArchiveEntryPath(rawName)
 			if err != nil {
 				return nil, fmt.Errorf("unsafe archive path: %s", hdr.Name)
 			}

--- a/internal/skills/verify_test.go
+++ b/internal/skills/verify_test.go
@@ -1,0 +1,451 @@
+package skills
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+)
+
+func TestVerifySkillSource_LocalDirOK(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "SKILL.md"), []byte("---\nname: test-skill\ndescription: test skill\n---\n\n# Test\n"), 0o644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "script.sh"), []byte("#!/bin/sh\necho ok\n"), 0o644); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	cfg := config.DefaultConfig()
+	cfg.Skills.Enabled = true
+	report, err := VerifySkillSource(cfg, root)
+	if err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+	if !report.OK {
+		t.Fatalf("expected ok report, got findings: %#v", report.Findings)
+	}
+	if report.SkillName != "test-skill" {
+		t.Fatalf("expected parsed name test-skill, got %q", report.SkillName)
+	}
+}
+
+func TestVerifySkillSource_BlockedLink(t *testing.T) {
+	root := t.TempDir()
+	md := strings.Join([]string{
+		"---",
+		"name: link-skill",
+		"---",
+		"",
+		"# link-skill",
+		"https://evil.example/payload.sh",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(root, "SKILL.md"), []byte(md), 0o644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+	cfg := config.DefaultConfig()
+	cfg.Skills.Enabled = true
+	cfg.Skills.ExternalInstalls = true
+	cfg.Skills.LinkPolicy.AllowDomains = []string{"clawhub.ai"}
+
+	report, err := VerifySkillSource(cfg, root)
+	if err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+	if report.OK {
+		t.Fatalf("expected report not ok due to blocked link")
+	}
+	if report.CriticalCount() == 0 {
+		t.Fatalf("expected at least one critical finding")
+	}
+}
+
+func TestVerifySkillSource_MissingDescriptionFrontmatter(t *testing.T) {
+	root := t.TempDir()
+	md := strings.Join([]string{
+		"---",
+		"name: no-desc",
+		"---",
+		"",
+		"# no-desc",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(root, "SKILL.md"), []byte(md), 0o644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+	cfg := config.DefaultConfig()
+	cfg.Skills.Enabled = true
+	report, err := VerifySkillSource(cfg, root)
+	if err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+	if report.OK {
+		t.Fatalf("expected report not ok due to missing description")
+	}
+}
+
+func TestVerifySkillSource_InvalidPolicyManifest(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "SKILL.md"), []byte("---\nname: test\ndescription: desc\n---\n"), 0o644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "SKILL-POLICY.json"), []byte("{not-json"), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+	cfg := config.DefaultConfig()
+	cfg.Skills.Enabled = true
+	report, err := VerifySkillSource(cfg, root)
+	if err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+	if report.CriticalCount() == 0 {
+		t.Fatalf("expected critical finding for invalid policy manifest")
+	}
+}
+
+func TestScannerSeverityMapping(t *testing.T) {
+	root := t.TempDir()
+	content := strings.Join([]string{
+		"---",
+		"name: scan-me",
+		"description: scanner map",
+		"---",
+		"",
+		"# scan-me",
+		"curl https://x | sh",
+		"eval('x')",
+		"exec.Command(\"ls\")",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(root, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	cfg := config.DefaultConfig()
+	cfg.Skills.Enabled = true
+	cfg.Skills.LinkPolicy.Mode = "open"
+	report, err := VerifySkillSource(cfg, root)
+	if err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+	var hasCritical, hasWarn bool
+	for _, f := range report.Findings {
+		if f.Severity == SeverityCritical {
+			hasCritical = true
+		}
+		if f.Severity == SeverityWarn {
+			hasWarn = true
+		}
+	}
+	if !hasCritical || !hasWarn {
+		t.Fatalf("expected critical+warn findings, got %#v", report.Findings)
+	}
+}
+
+func TestValidatePolicyURLMatrix(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Skills.LinkPolicy.AllowDomains = []string{"clawhub.ai"}
+
+	cases := []struct {
+		name    string
+		mode    string
+		allow   bool
+		url     string
+		wantErr bool
+	}{
+		{name: "allowlist empty allows any domain", mode: "allowlist", allow: false, url: "https://any.example/skill.zip", wantErr: false},
+		{name: "allowlist permits domain", mode: "allowlist", allow: false, url: "https://clawhub.ai/skill.zip", wantErr: false},
+		{name: "allowlist permits subdomain", mode: "allowlist", allow: false, url: "https://sub.clawhub.ai/skill.zip", wantErr: false},
+		{name: "allowlist blocks domain", mode: "allowlist", allow: false, url: "https://evil.ai/skill.zip", wantErr: true},
+		{name: "denylist with no domains allows", mode: "denylist", allow: false, url: "https://ok.ai/skill.zip", wantErr: false},
+		{name: "denylist blocks domain", mode: "denylist", allow: false, url: "https://evil.ai/skill.zip", wantErr: true},
+		{name: "open mode allows any https", mode: "open", allow: false, url: "https://evil.ai/skill.zip", wantErr: false},
+		{name: "http blocked", mode: "open", allow: false, url: "http://clawhub.ai/skill.zip", wantErr: true},
+		{name: "http allowed", mode: "open", allow: true, url: "http://clawhub.ai/skill.zip", wantErr: false},
+		{name: "unknown mode", mode: "invalid-mode", allow: false, url: "https://clawhub.ai/skill.zip", wantErr: true},
+		{name: "invalid url", mode: "open", allow: false, url: "://bad", wantErr: true},
+		{name: "unsupported scheme", mode: "open", allow: false, url: "ftp://clawhub.ai/skill.zip", wantErr: true},
+		{name: "missing host", mode: "open", allow: false, url: "https:///x", wantErr: true},
+	}
+	cfg.Skills.LinkPolicy.DenyDomains = []string{"evil.ai"}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg.Skills.LinkPolicy.Mode = tc.mode
+			cfg.Skills.LinkPolicy.AllowHTTP = tc.allow
+			if tc.name == "allowlist empty allows any domain" {
+				cfg.Skills.LinkPolicy.AllowDomains = nil
+			} else {
+				cfg.Skills.LinkPolicy.AllowDomains = []string{"clawhub.ai"}
+			}
+			if tc.name == "denylist with no domains allows" {
+				cfg.Skills.LinkPolicy.DenyDomains = nil
+			} else {
+				cfg.Skills.LinkPolicy.DenyDomains = []string{"evil.ai"}
+			}
+			err := validatePolicyURL(cfg, tc.url)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestIsSafeRelativePathMatrix(t *testing.T) {
+	cases := []struct {
+		path string
+		ok   bool
+	}{
+		{"SKILL.md", true},
+		{"dir/file.txt", true},
+		{"", false},
+		{"/abs/path", false},
+		{"../up", false},
+		{"dir/../../x", false},
+		{"./", false},
+	}
+	for _, tc := range cases {
+		if got := isSafeRelativePath(tc.path); got != tc.ok {
+			t.Fatalf("isSafeRelativePath(%q)=%v want %v", tc.path, got, tc.ok)
+		}
+	}
+}
+
+func TestArchiveExtractionGuards(t *testing.T) {
+	t.Run("zip slip blocked", func(t *testing.T) {
+		var buf bytes.Buffer
+		zw := zip.NewWriter(&buf)
+		w, err := zw.Create("../evil.txt")
+		if err != nil {
+			t.Fatalf("create zip entry: %v", err)
+		}
+		if _, err := w.Write([]byte("x")); err != nil {
+			t.Fatalf("write zip entry: %v", err)
+		}
+		if err := zw.Close(); err != nil {
+			t.Fatalf("close zip: %v", err)
+		}
+		if _, err := unpackZIP(buf.Bytes()); err == nil {
+			t.Fatal("expected zip slip to be blocked")
+		}
+	})
+
+	t.Run("tar symlink blocked", func(t *testing.T) {
+		var payload bytes.Buffer
+		gzw := gzip.NewWriter(&payload)
+		tw := tar.NewWriter(gzw)
+		h := &tar.Header{Name: "ln", Typeflag: tar.TypeSymlink, Linkname: "/etc/passwd", Mode: 0o777}
+		if err := tw.WriteHeader(h); err != nil {
+			t.Fatalf("write tar header: %v", err)
+		}
+		if err := tw.Close(); err != nil {
+			t.Fatalf("close tar: %v", err)
+		}
+		if err := gzw.Close(); err != nil {
+			t.Fatalf("close gzip: %v", err)
+		}
+		if _, err := unpackTarGZ(payload.Bytes()); err == nil {
+			t.Fatal("expected tar symlink to be blocked")
+		}
+	})
+}
+
+func TestUnpackArchiveDetectsZIPAndTar(t *testing.T) {
+	var zipBuf bytes.Buffer
+	zw := zip.NewWriter(&zipBuf)
+	w, _ := zw.Create("SKILL.md")
+	_, _ = w.Write([]byte("---\nname: x\ndescription: y\n---\n"))
+	_ = zw.Close()
+	files, typ, err := unpackArchive("skill.zip", zipBuf.Bytes())
+	if err != nil || typ != "zip" || len(files) == 0 {
+		t.Fatalf("unexpected zip unpack result: typ=%s err=%v files=%d", typ, err, len(files))
+	}
+
+	var tarPayload bytes.Buffer
+	gzw := gzip.NewWriter(&tarPayload)
+	tw := tar.NewWriter(gzw)
+	body := []byte("---\nname: y\ndescription: z\n---\n")
+	_ = tw.WriteHeader(&tar.Header{Name: "SKILL.md", Mode: 0o644, Size: int64(len(body))})
+	_, _ = tw.Write(body)
+	_ = tw.Close()
+	_ = gzw.Close()
+	files, typ, err = unpackArchive("skill.tar.gz", tarPayload.Bytes())
+	if err != nil || typ != "tar.gz" || len(files) == 0 {
+		t.Fatalf("unexpected tar unpack result: typ=%s err=%v files=%d", typ, err, len(files))
+	}
+}
+
+func TestDownloadSkillArchiveWithMockTransport(t *testing.T) {
+	origTransport := http.DefaultTransport
+	defer func() { http.DefaultTransport = origTransport }()
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewBufferString("abc")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+	cfg := config.DefaultConfig()
+	cfg.Skills.LinkPolicy.Mode = "allowlist"
+	cfg.Skills.LinkPolicy.AllowDomains = []string{"clawhub.ai"}
+	out, finalURL, err := downloadSkillArchive(context.Background(), "https://clawhub.ai/skills/x.zip", cfg)
+	if err != nil {
+		t.Fatalf("downloadSkillArchive failed: %v", err)
+	}
+	if string(out) != "abc" {
+		t.Fatalf("unexpected payload: %q", string(out))
+	}
+	if finalURL != "https://clawhub.ai/skills/x.zip" {
+		t.Fatalf("unexpected final URL: %s", finalURL)
+	}
+}
+
+func TestDownloadSkillArchiveBlocksPolicyViolatingRedirect(t *testing.T) {
+	origTransport := http.DefaultTransport
+	defer func() { http.DefaultTransport = origTransport }()
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Host {
+		case "clawhub.ai":
+			return &http.Response{
+				StatusCode: http.StatusFound,
+				Header:     http.Header{"Location": []string{"https://evil.example/skills/x.zip"}},
+				Body:       io.NopCloser(bytes.NewBuffer(nil)),
+				Request:    req,
+			}, nil
+		case "evil.example":
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString("abc")),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		default:
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(bytes.NewBufferString("not found")),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}
+	})
+	cfg := config.DefaultConfig()
+	cfg.Skills.LinkPolicy.Mode = "allowlist"
+	cfg.Skills.LinkPolicy.AllowDomains = []string{"clawhub.ai"}
+	_, _, err := downloadSkillArchive(context.Background(), "https://clawhub.ai/skills/x.zip", cfg)
+	if err == nil {
+		t.Fatal("expected redirect to be blocked by policy")
+	}
+}
+
+func TestInstallAndUpdateSkill(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KAFCLAW_HOME", home)
+	t.Setenv("KAFCLAW_CONFIG", filepath.Join(home, ".kafclaw", "config.json"))
+
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("---\nname: updatable\ndescription: updater\n---\n"), 0o644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "notes.txt"), []byte("v1"), 0o644); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	cfg := config.DefaultConfig()
+	cfg.Skills.Enabled = true
+	cfg.Skills.ExternalInstalls = true
+	cfg.Skills.LinkPolicy.Mode = "open"
+
+	installed, err := InstallSkill(cfg, src, true)
+	if err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+	if !strings.Contains(installed.InstallPath, "updatable") {
+		t.Fatalf("unexpected install path: %s", installed.InstallPath)
+	}
+
+	if err := os.WriteFile(filepath.Join(src, "notes.txt"), []byte("v2"), 0o644); err != nil {
+		t.Fatalf("update payload: %v", err)
+	}
+	updated, err := UpdateSkills(cfg, "updatable", true)
+	if err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+	if len(updated) != 1 {
+		t.Fatalf("expected one update result, got %d", len(updated))
+	}
+	data, err := os.ReadFile(filepath.Join(installed.InstallPath, "notes.txt"))
+	if err != nil {
+		t.Fatalf("read installed payload: %v", err)
+	}
+	if string(data) != "v2" {
+		t.Fatalf("expected installed payload v2, got %q", string(data))
+	}
+
+	state, err := EnsureStateDirs()
+	if err != nil {
+		t.Fatalf("ensure state dirs: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(state.AuditDir, "install-decisions.jsonl")); err != nil {
+		t.Fatalf("expected install audit log: %v", err)
+	}
+	snapshotsRoot := filepath.Join(state.Snapshots, "updatable")
+	entries, err := os.ReadDir(snapshotsRoot)
+	if err != nil {
+		t.Fatalf("read snapshots: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("expected at least one snapshot after update")
+	}
+}
+
+func TestUpdateSkillsFailureKeepsExistingInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KAFCLAW_HOME", home)
+	t.Setenv("KAFCLAW_CONFIG", filepath.Join(home, ".kafclaw", "config.json"))
+
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("---\nname: rollback-skill\ndescription: updater\n---\n"), 0o644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "notes.txt"), []byte("v1"), 0o644); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	cfg := config.DefaultConfig()
+	cfg.Skills.Enabled = true
+	cfg.Skills.ExternalInstalls = true
+	cfg.Skills.LinkPolicy.Mode = "open"
+
+	installed, err := InstallSkill(cfg, src, true)
+	if err != nil {
+		t.Fatalf("initial install failed: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Join(installed.InstallPath, "notes.txt"))
+	if err != nil {
+		t.Fatalf("read v1 payload: %v", err)
+	}
+	if string(before) != "v1" {
+		t.Fatalf("expected v1 payload before update, got %q", string(before))
+	}
+
+	if err := os.Remove(filepath.Join(src, "SKILL.md")); err != nil {
+		t.Fatalf("remove skill manifest: %v", err)
+	}
+	if _, err := UpdateSkills(cfg, "rollback-skill", true); err == nil {
+		t.Fatalf("expected update failure for invalid source")
+	}
+
+	after, err := os.ReadFile(filepath.Join(installed.InstallPath, "notes.txt"))
+	if err != nil {
+		t.Fatalf("read payload after failed update: %v", err)
+	}
+	if string(after) != "v1" {
+		t.Fatalf("expected installed payload to remain v1 after failed update, got %q", string(after))
+	}
+}

--- a/internal/tools/oauth_readonly.go
+++ b/internal/tools/oauth_readonly.go
@@ -1,0 +1,319 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+	"github.com/KafClaw/KafClaw/internal/skills"
+)
+
+// GoogleWorkspaceReadTool provides read-only Gmail/Calendar access.
+type GoogleWorkspaceReadTool struct{}
+
+// M365ReadTool provides read-only Outlook/Calendar access via Microsoft Graph.
+type M365ReadTool struct{}
+
+func NewGoogleWorkspaceReadTool() *GoogleWorkspaceReadTool { return &GoogleWorkspaceReadTool{} }
+func NewM365ReadTool() *M365ReadTool                       { return &M365ReadTool{} }
+
+func (t *GoogleWorkspaceReadTool) Name() string { return "google_workspace_read" }
+func (t *GoogleWorkspaceReadTool) Tier() int    { return TierHighRisk }
+
+func (t *M365ReadTool) Name() string { return "m365_read" }
+func (t *M365ReadTool) Tier() int    { return TierHighRisk }
+
+func (t *GoogleWorkspaceReadTool) Description() string {
+	return "Read-only Google Workspace operations (Gmail and Calendar) using enrolled OAuth token."
+}
+
+func (t *M365ReadTool) Description() string {
+	return "Read-only Microsoft 365 operations (mail and calendar) using enrolled OAuth token."
+}
+
+func (t *GoogleWorkspaceReadTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"operation": map[string]any{
+				"type":        "string",
+				"description": "Operation to run: gmail_list_messages | calendar_list_events | drive_list_files",
+			},
+			"profile": map[string]any{
+				"type":        "string",
+				"description": "OAuth profile name (default: default)",
+			},
+			"max_results": map[string]any{
+				"type":        "integer",
+				"description": "Maximum number of records to return (default 10, max 50)",
+			},
+			"query": map[string]any{
+				"type":        "string",
+				"description": "Optional Gmail search query (q=...)",
+			},
+			"calendar_id": map[string]any{
+				"type":        "string",
+				"description": "Calendar id (default: primary)",
+			},
+			"time_min": map[string]any{
+				"type":        "string",
+				"description": "Optional RFC3339 lower bound for calendar events",
+			},
+			"time_max": map[string]any{
+				"type":        "string",
+				"description": "Optional RFC3339 upper bound for calendar events",
+			},
+			"drive_query": map[string]any{
+				"type":        "string",
+				"description": "Optional Google Drive q= filter (defaults to non-trashed files)",
+			},
+		},
+		"required": []string{"operation"},
+	}
+}
+
+func (t *M365ReadTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"operation": map[string]any{
+				"type":        "string",
+				"description": "Operation to run: mail_list_messages | calendar_list_events | onedrive_list_children",
+			},
+			"profile": map[string]any{
+				"type":        "string",
+				"description": "OAuth profile name (default: default)",
+			},
+			"max_results": map[string]any{
+				"type":        "integer",
+				"description": "Maximum number of records to return (default 10, max 50)",
+			},
+			"select": map[string]any{
+				"type":        "string",
+				"description": "Optional Graph $select projection fields",
+			},
+			"time_min": map[string]any{
+				"type":        "string",
+				"description": "Optional RFC3339 lower bound for calendar events",
+			},
+			"time_max": map[string]any{
+				"type":        "string",
+				"description": "Optional RFC3339 upper bound for calendar events",
+			},
+			"drive_item_id": map[string]any{
+				"type":        "string",
+				"description": "Optional OneDrive item id (default: root)",
+			},
+		},
+		"required": []string{"operation"},
+	}
+}
+
+func (t *GoogleWorkspaceReadTool) Execute(ctx context.Context, params map[string]any) (string, error) {
+	if err := ensureSkillEnabled("google-workspace"); err != nil {
+		return err.Error(), nil
+	}
+	op := strings.ToLower(strings.TrimSpace(GetString(params, "operation", "")))
+	if op == "" {
+		return "Error: operation is required", nil
+	}
+	profile := strings.TrimSpace(GetString(params, "profile", "default"))
+	if profile == "" {
+		profile = "default"
+	}
+	token, err := skills.GetOAuthAccessToken(skills.ProviderGoogleWorkspace, profile)
+	if err != nil {
+		return fmt.Sprintf("Error: %v", err), nil
+	}
+	maxResults := clamp(GetInt(params, "max_results", 10), 1, 50)
+	client := &http.Client{Timeout: 30 * time.Second}
+	switch op {
+	case "gmail_list_messages":
+		if !scopeHasAny(token.Scope, "https://www.googleapis.com/auth/gmail.readonly", "https://www.googleapis.com/auth/gmail.modify", "https://mail.google.com/") {
+			return "Error: oauth scope missing Gmail read access; re-enroll with gmail.readonly or stronger scope", nil
+		}
+		q := strings.TrimSpace(GetString(params, "query", ""))
+		u := "https://gmail.googleapis.com/gmail/v1/users/me/messages?maxResults=" + strconv.Itoa(maxResults)
+		if q != "" {
+			u += "&q=" + url.QueryEscape(q)
+		}
+		return oauthGETJSON(ctx, client, u, token.AccessToken)
+	case "calendar_list_events":
+		if !scopeHasAny(token.Scope, "https://www.googleapis.com/auth/calendar.readonly", "https://www.googleapis.com/auth/calendar") {
+			return "Error: oauth scope missing Calendar read access; re-enroll with calendar.readonly or stronger scope", nil
+		}
+		calendarID := strings.TrimSpace(GetString(params, "calendar_id", "primary"))
+		if calendarID == "" {
+			calendarID = "primary"
+		}
+		query := url.Values{}
+		query.Set("singleEvents", "true")
+		query.Set("orderBy", "startTime")
+		query.Set("maxResults", strconv.Itoa(maxResults))
+		if v := strings.TrimSpace(GetString(params, "time_min", "")); v != "" {
+			query.Set("timeMin", v)
+		}
+		if v := strings.TrimSpace(GetString(params, "time_max", "")); v != "" {
+			query.Set("timeMax", v)
+		}
+		u := "https://www.googleapis.com/calendar/v3/calendars/" + url.PathEscape(calendarID) + "/events?" + query.Encode()
+		return oauthGETJSON(ctx, client, u, token.AccessToken)
+	case "drive_list_files":
+		if !scopeHasAny(token.Scope,
+			"https://www.googleapis.com/auth/drive.readonly",
+			"https://www.googleapis.com/auth/drive.metadata.readonly",
+			"https://www.googleapis.com/auth/drive") {
+			return "Error: oauth scope missing Drive read access; re-enroll with drive.readonly or drive.metadata.readonly", nil
+		}
+		query := url.Values{}
+		query.Set("pageSize", strconv.Itoa(maxResults))
+		query.Set("fields", "nextPageToken,files(id,name,mimeType,modifiedTime,webViewLink,size)")
+		driveQ := strings.TrimSpace(GetString(params, "drive_query", "trashed=false"))
+		if driveQ != "" {
+			query.Set("q", driveQ)
+		}
+		u := "https://www.googleapis.com/drive/v3/files?" + query.Encode()
+		return oauthGETJSON(ctx, client, u, token.AccessToken)
+	default:
+		return "Error: unsupported operation; use gmail_list_messages, calendar_list_events, or drive_list_files", nil
+	}
+}
+
+func (t *M365ReadTool) Execute(ctx context.Context, params map[string]any) (string, error) {
+	if err := ensureSkillEnabled("m365"); err != nil {
+		return err.Error(), nil
+	}
+	op := strings.ToLower(strings.TrimSpace(GetString(params, "operation", "")))
+	if op == "" {
+		return "Error: operation is required", nil
+	}
+	profile := strings.TrimSpace(GetString(params, "profile", "default"))
+	if profile == "" {
+		profile = "default"
+	}
+	token, err := skills.GetOAuthAccessToken(skills.ProviderM365, profile)
+	if err != nil {
+		return fmt.Sprintf("Error: %v", err), nil
+	}
+	maxResults := clamp(GetInt(params, "max_results", 10), 1, 50)
+	client := &http.Client{Timeout: 30 * time.Second}
+	switch op {
+	case "mail_list_messages":
+		if !scopeHasAny(token.Scope, "Mail.Read", "https://graph.microsoft.com/Mail.Read") {
+			return "Error: oauth scope missing Mail.Read access; re-enroll with Mail.Read", nil
+		}
+		query := url.Values{}
+		query.Set("$top", strconv.Itoa(maxResults))
+		selectFields := strings.TrimSpace(GetString(params, "select", "id,subject,from,receivedDateTime,isRead"))
+		if selectFields != "" {
+			query.Set("$select", selectFields)
+		}
+		u := "https://graph.microsoft.com/v1.0/me/messages?" + query.Encode()
+		return oauthGETJSON(ctx, client, u, token.AccessToken)
+	case "calendar_list_events":
+		if !scopeHasAny(token.Scope, "Calendars.Read", "https://graph.microsoft.com/Calendars.Read") {
+			return "Error: oauth scope missing Calendars.Read access; re-enroll with Calendars.Read", nil
+		}
+		query := url.Values{}
+		query.Set("$top", strconv.Itoa(maxResults))
+		query.Set("$orderby", "start/dateTime")
+		selectFields := strings.TrimSpace(GetString(params, "select", "id,subject,start,end,organizer"))
+		if selectFields != "" {
+			query.Set("$select", selectFields)
+		}
+		if v := strings.TrimSpace(GetString(params, "time_min", "")); v != "" {
+			query.Set("$filter", "start/dateTime ge '"+v+"'")
+		}
+		u := "https://graph.microsoft.com/v1.0/me/events?" + query.Encode()
+		return oauthGETJSON(ctx, client, u, token.AccessToken)
+	case "onedrive_list_children":
+		if !scopeHasAny(token.Scope, "Files.Read", "https://graph.microsoft.com/Files.Read") {
+			return "Error: oauth scope missing Files.Read access; re-enroll with Files.Read", nil
+		}
+		itemID := strings.TrimSpace(GetString(params, "drive_item_id", ""))
+		query := url.Values{}
+		query.Set("$top", strconv.Itoa(maxResults))
+		query.Set("$select", "id,name,folder,file,size,lastModifiedDateTime,webUrl")
+		u := "https://graph.microsoft.com/v1.0/me/drive/root/children?" + query.Encode()
+		if itemID != "" && !strings.EqualFold(itemID, "root") {
+			u = "https://graph.microsoft.com/v1.0/me/drive/items/" + url.PathEscape(itemID) + "/children?" + query.Encode()
+		}
+		return oauthGETJSON(ctx, client, u, token.AccessToken)
+	default:
+		return "Error: unsupported operation; use mail_list_messages, calendar_list_events, or onedrive_list_children", nil
+	}
+}
+
+func ensureSkillEnabled(name string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	if !skills.EffectiveSkillEnabled(cfg, name) {
+		return fmt.Errorf("skill %q is disabled; run `kafclaw skills enable-skill %s`", name, name)
+	}
+	return nil
+}
+
+func oauthGETJSON(ctx context.Context, client *http.Client, rawURL string, accessToken string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(accessToken))
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Sprintf("Error: provider API status %d: %s", resp.StatusCode, strings.TrimSpace(string(body))), nil
+	}
+	var pretty any
+	if err := json.Unmarshal(body, &pretty); err != nil {
+		return string(body), nil
+	}
+	out, err := json.MarshalIndent(pretty, "", "  ")
+	if err != nil {
+		return string(body), nil
+	}
+	return string(out), nil
+}
+
+func scopeHasAny(scopeRaw string, accepted ...string) bool {
+	if len(accepted) == 0 {
+		return true
+	}
+	scopes := strings.Fields(strings.TrimSpace(scopeRaw))
+	if len(scopes) == 0 {
+		return false
+	}
+	have := map[string]struct{}{}
+	for _, s := range scopes {
+		have[strings.ToLower(strings.TrimSpace(s))] = struct{}{}
+	}
+	for _, a := range accepted {
+		if _, ok := have[strings.ToLower(strings.TrimSpace(a))]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func clamp(v, minV, maxV int) int {
+	if v < minV {
+		return minV
+	}
+	if v > maxV {
+		return maxV
+	}
+	return v
+}

--- a/internal/tools/oauth_readonly_test.go
+++ b/internal/tools/oauth_readonly_test.go
@@ -1,0 +1,27 @@
+package tools
+
+import "testing"
+
+func TestScopeHasAny(t *testing.T) {
+	if !scopeHasAny("openid https://www.googleapis.com/auth/gmail.readonly", "https://www.googleapis.com/auth/gmail.readonly") {
+		t.Fatal("expected scope match")
+	}
+	if !scopeHasAny("Mail.Read Calendars.Read", "mail.read") {
+		t.Fatal("expected case-insensitive scope match")
+	}
+	if scopeHasAny("openid email", "Calendars.Read") {
+		t.Fatal("unexpected scope match")
+	}
+}
+
+func TestClamp(t *testing.T) {
+	if got := clamp(0, 1, 50); got != 1 {
+		t.Fatalf("expected min clamp, got %d", got)
+	}
+	if got := clamp(100, 1, 50); got != 50 {
+		t.Fatalf("expected max clamp, got %d", got)
+	}
+	if got := clamp(10, 1, 50); got != 10 {
+		t.Fatalf("expected unchanged value, got %d", got)
+	}
+}

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -62,6 +62,8 @@ var PathPatterns = []string{
 	`\\\.\.`, // \..
 }
 
+var destructiveRMRootRegex = regexp.MustCompile(`(^|[^a-z])rm\s+-r[f]?\s+[/~]`)
+
 // ExecTool executes shell commands.
 type ExecTool struct {
 	Timeout             time.Duration
@@ -219,6 +221,9 @@ func (t *ExecTool) guardCommand(command, workingDir string) error {
 	}
 
 	// Check deny patterns
+	if destructiveRMRootRegex.MatchString(normalized) {
+		return fmt.Errorf(blockedAttackMessage)
+	}
 	for _, re := range t.denyRegexes {
 		if re.MatchString(normalized) {
 			return fmt.Errorf(blockedAttackMessage)

--- a/internal/tools/shell_guard_test.go
+++ b/internal/tools/shell_guard_test.go
@@ -30,6 +30,9 @@ func TestGuardCommandDenyAndTraversalBranches(t *testing.T) {
 	if err := tool.guardCommand("Rm -rf /", workspace); err == nil {
 		t.Fatal("expected mixed-case deny-pattern command blocked")
 	}
+	if err := tool.guardCommand("0rm -rf /", workspace); err == nil {
+		t.Fatal("expected prefixed destructive rm command blocked")
+	}
 	if err := tool.guardCommand("cat ../../../etc/passwd", workspace); err == nil {
 		t.Fatal("expected traversal command blocked")
 	}

--- a/scripts/check_bundled_skills.sh
+++ b/scripts/check_bundled_skills.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+go test -count=1 -run TestBundledArtifactsPresent ./internal/skills
+
+echo "Bundled skills artifact validation passed."

--- a/scripts/check_critical_coverage.sh
+++ b/scripts/check_critical_coverage.sh
@@ -88,4 +88,57 @@ if [[ "$run_gateway_pct" != "100.0" ]]; then
   exit 1
 fi
 
+echo ""
+echo "==> skills hardening regression suite"
+go test -count=1 -run "TestScannerSeverityMapping|TestValidatePolicyURLMatrix|TestArchiveExtractionGuards|TestEnforceRuntimePolicyMatrix|TestInstallAndUpdateSkill|TestUpdateSkillsFailureKeepsExistingInstall" ./internal/skills
+go test -count=1 -run "TestSkillsEnableDisableLifecycleConfigPersistence|TestOnboardNonInteractiveRequiresAcceptRisk|TestOnboardJSONSummary|TestOnboardSkillsBootstrapPath" ./internal/cli
+
+echo ""
+echo "==> skills critical function coverage (must be 100%)"
+go test -count=1 -coverprofile=/tmp/skills_critical.cover.out ./internal/skills >/tmp/skills_critical.cover.log
+cat /tmp/skills_critical.cover.log
+
+check_skills_func_100() {
+  local file_re="$1"
+  local fn="$2"
+  local pct
+  pct="$(go tool cover -func=/tmp/skills_critical.cover.out | awk -v file_re="$file_re" -v fn="$fn" '$1 ~ file_re && $2==fn {gsub("%","",$3); print $3}' | head -n 1)"
+  if [[ -z "$pct" ]]; then
+    echo "ERROR: could not find skills function coverage for $fn" >&2
+    exit 1
+  fi
+  if [[ "$pct" != "100.0" ]]; then
+    echo "ERROR: skills critical function $fn coverage is $pct%, expected 100.0%" >&2
+    exit 1
+  fi
+}
+
+check_skills_func_100 "internal/skills/runtime.go:" enforceRuntimePolicy
+check_skills_func_100 "internal/skills/verify.go:" validatePolicyURL
+check_skills_func_100 "internal/skills/verify.go:" isSafeRelativePath
+
+echo ""
+echo "==> non-critical touched package coverage (must be >80%)"
+check_pkg_min() {
+  local pkg="$1"
+  local min="$2"
+  local out
+  out="$(go test -count=1 -cover "$pkg")"
+  echo "$out"
+  local pct
+  pct="$(echo "$out" | sed -n 's/.*coverage: \([0-9.]*\)% of statements.*/\1/p' | tail -n 1)"
+  if [[ -z "$pct" ]]; then
+    echo "ERROR: failed to parse coverage for $pkg" >&2
+    exit 1
+  fi
+  awk -v p="$pct" -v m="$min" 'BEGIN { if (p <= m) exit 1 }' || {
+    echo "ERROR: non-critical package $pkg coverage is $pct%, expected >$min%" >&2
+    exit 1
+  }
+}
+
+check_pkg_min ./internal/config 80
+check_pkg_min ./internal/cliconfig 80
+check_pkg_min ./internal/agent 80
+
 echo "Critical coverage gate passed."

--- a/scripts/test_smoke.sh
+++ b/scripts/test_smoke.sh
@@ -16,6 +16,10 @@ run() {
 run "core policy + approvals + transport" \
   go test -count=1 ./internal/policy ./internal/approval ./internal/bus ./internal/session
 
+# Bundled skills must be shipped with valid artifacts.
+run "bundled skills artifact gate" \
+  bash scripts/check_bundled_skills.sh
+
 # Hard gate: critical logic must stay fully covered.
 run "critical coverage gate" \
   bash scripts/check_critical_coverage.sh

--- a/skills/channel-onboarding/SKILL.md
+++ b/skills/channel-onboarding/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: channel-onboarding
+description: Guide setup and verification for Slack, Teams, and WhatsApp channel integrations.
+---
+
+# channel-onboarding
+
+Use during initial channel setup or when channel health is degraded.
+
+## Workflow
+- Validate required credentials and policy fields.
+- Run verification checks per channel.
+- Produce exact remediation steps when checks fail.
+
+## Safety
+- Enabled by default as setup helper.
+- No destructive actions without explicit approval.

--- a/skills/gh-issues/SKILL.md
+++ b/skills/gh-issues/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: gh-issues
+description: Triage and execute GitHub issues with controlled agent workflows.
+---
+
+# gh-issues
+
+Use for issue-driven development loops.
+
+## Workflow
+- Select issues by label/priority.
+- Implement minimal safe change set.
+- Open/update PR and address review feedback.
+
+## Safety
+- Explicit approval required for PR creation/merge.
+- Explicit approval required for spawning delegated coding agents.

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: github
+description: Operate GitHub workflows (issues, PRs, checks, releases) using approved tooling.
+---
+
+# github
+
+Use when managing repository workflows.
+
+## Workflow
+- Query issues/PRs/checks.
+- Propose and apply targeted changes.
+- Report status with links/IDs and concrete outcomes.
+
+## Safety
+- Require explicit approval before merge/release/destructive operations.
+- Keep token scope minimal.

--- a/skills/google-cli/SKILL.md
+++ b/skills/google-cli/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: google-cli
+description: Install and operate Google Cloud CLI for cloud project/operator workflows.
+---
+
+# google-cli
+
+Use for Google Cloud operator tasks that require `gcloud`.
+
+## Workflow
+- Check `gcloud` availability.
+- Install via approved OS routine when missing.
+- Validate active account/project before executing operations.
+
+## Safety
+- Disabled by default.
+- Requires explicit install confirmation for privileged package operations.

--- a/skills/google-workspace/SKILL.md
+++ b/skills/google-workspace/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: google-workspace
+description: Integrate with Google Workspace services under tenant policy and least privilege.
+---
+
+# google-workspace
+
+Use for Gmail, Calendar, Drive, and Docs workflows.
+
+## Workflow
+- Validate requested action against tenant policy.
+- Use minimal scopes required for the task.
+- Return clear action log (resource, operation, result).
+
+## Safety
+- Disabled by default.
+- Explicit approval for write/send/delete actions.

--- a/skills/incident-comms/SKILL.md
+++ b/skills/incident-comms/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: incident-comms
+description: Create and send standardized incident updates with controlled approvals.
+---
+
+# incident-comms
+
+Use for incident status updates and stakeholder communications.
+
+## Workflow
+- Build message from template: impact, scope, timeline, next update.
+- Keep channel-specific formatting concise and consistent.
+- Track update cadence and send history.
+
+## Safety
+- Explicit approval required before sending outbound incident messages.

--- a/skills/m365/SKILL.md
+++ b/skills/m365/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: m365
+description: Integrate with Microsoft 365 services under tenant policy and least privilege.
+---
+
+# m365
+
+Use for Outlook, Calendar, OneDrive, and Teams-related workflows.
+
+## Workflow
+- Validate operation against tenant policy.
+- Apply least-privilege scope.
+- Return action log with IDs/outcomes.
+
+## Safety
+- Disabled by default.
+- Explicit approval for write/send/delete actions.

--- a/skills/session-logs/SKILL.md
+++ b/skills/session-logs/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: session-logs
+description: Inspect and summarize session logs to troubleshoot behavior and regressions.
+---
+
+# session-logs
+
+Use when debugging behavior across previous runs.
+
+## Workflow
+- Locate relevant session/task logs.
+- Extract timeline, errors, and repeated failure patterns.
+- Produce a concise root-cause summary and remediation steps.
+
+## Safety
+- Redact secrets/tokens from output.
+- Avoid exporting raw logs unless explicitly requested.

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: skill-creator
+description: Create or update KafClaw skills with consistent structure and safety guidance.
+---
+
+# skill-creator
+
+Use when creating a new skill or improving an existing one.
+
+## Workflow
+- Define clear trigger conditions.
+- Keep instructions minimal and deterministic.
+- Document required binaries, tokens, and approval gates.
+- Add/update matching operator docs in `docs/skills/`.
+
+## Safety
+- Do not add implicit privileged actions.
+- Require explicit confirmation for destructive/external actions.

--- a/skills/summarize/SKILL.md
+++ b/skills/summarize/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: summarize
+description: Produce concise, accurate summaries of files, logs, and long technical content.
+---
+
+# summarize
+
+Use for long artifacts that need actionable summaries.
+
+## Workflow
+- Identify objective and audience.
+- Preserve key technical details and decisions.
+- Output: findings, risks, next actions.
+
+## Safety
+- Do not fabricate missing details.
+- Mark uncertainty explicitly.

--- a/skills/weather/SKILL.md
+++ b/skills/weather/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: weather
+description: Provide weather lookups and short forecasts for requested locations.
+---
+
+# weather
+
+Use for current weather or short forecast requests.
+
+## Workflow
+- Resolve location clearly.
+- Return concise forecast with units and time window.
+
+## Safety
+- If location ambiguity exists, ask before proceeding.


### PR DESCRIPTION
# PR: feat: harden skills runtime, secure secrets, and add OAuth capability selection

## Summary
- add hardened skills runtime flow with sandbox staging and enablement wiring
- add secret storage hardening and doctor checks/fixes for permissions and env migration
- add OAuth capability-selection flow for Google Workspace and Microsoft 365 in configure/onboarding
- add read-only Google/M365 API tooling with token refresh wiring
- add CI/security guardrails (`make commit-check`, fuzz, CodeQL gates) and bundle-skill artifacts
- update docs for skills, operations, and security behavior

## Validation
- `make commit-check`
- `go test ./...`
- `go test -race ./...`

## Notes
- includes npm install hardening via `--ignore-scripts` in skill install paths
- keeps secrets in local config with restrictive permissions and doctor remediation
