### PR TITLE
Multi-provider LLM support with middleware, models CLI, and FinOps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ docs/vendor/bundle/
 # Keep Node version pins tracked
 !.nvmrc
 !.node-version
+_tasks/provider-support.md

--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,3 @@ docs/vendor/bundle/
 # Keep Node version pins tracked
 !.nvmrc
 !.node-version
-_tasks/provider-support.md

--- a/_tasks/provider-support.md
+++ b/_tasks/provider-support.md
@@ -1,0 +1,610 @@
+# Provider Support Execution Board
+
+Updated: 2026-02-20
+Branch: `modelsupport`
+
+## Goal
+
+Implement a clean, runtime-wired provider layer with:
+
+- canonical provider identifier per backend (used in config and model strings)
+- per-agent and per-subagent configurable model path with `primary` + `fallbacks`
+- model string format: `<provider-id>/<model-id>` (e.g. `claude/claude-opus-4-6`)
+- CLI OAuth flows for Gemini and Codex (install CLI if absent, delegate auth, read credential cache)
+- API key flows for OpenAI, Anthropic/Claude, xAI, Gemini (key path), OpenRouter, DeepSeek, Groq, vLLM
+- ScalyticsCopilot as OpenAI-compatible provider with bearer token + configurable base URL
+- provider resolver replacing all hardcoded `NewOpenAIProvider` calls in `agent` and `gateway`
+- token consumption stats per request, per session, per day — with per-provider breakdown
+- rate limit / quota remaining surfaced from provider response headers where available
+- chat middleware chain between agent loop and LLM provider
+- content classification → model routing (PII → private model, coding → coding model)
+- prompt guard (PII/secret/keyword scan pre-LLM: block / redact / reroute)
+- output sanitization (PII/secret redaction post-LLM before channel delivery)
+- FinOps cost attribution ($/token per provider, daily/monthly budgets, per-agent/channel breakdown)
+- task-type model routing (security → strong model, quick-answer → fast model)
+
+> **Related:** Non-model enterprise features (OTEL, DLQ/Replay, HITL, Registry, Multi-tenancy, etc.)
+> are tracked in `_tasks/enterprise-features.md`.
+
+---
+
+## Documentation Contract (applies to every item in this file)
+
+Every feature that ships must update docs **as part of the same PR** — not after. No exceptions.
+
+| Trigger | Required doc update |
+|---------|-------------------|
+| New or changed CLI command / flag | `docs/reference/cli-reference.md` |
+| New or changed config key | `docs/reference/config-keys.md` |
+| New provider added | `docs/reference/config-keys.md` (provider block) + `docs/operations-admin/admin-guide.md` (setup steps) |
+| New `kafclaw models auth` flow | `docs/start-here/getting-started.md` (user) + `docs/operations-admin/admin-guide.md` (admin) |
+| New onboarding preset | `docs/start-here/getting-started.md` |
+| Token stats / `kafclaw models stats` | `docs/reference/cli-reference.md` + `docs/operations-admin/operations-guide.md` |
+| Doctor / status surface changes | `docs/reference/cli-reference.md` + `docs/operations-admin/operations-guide.md` |
+| Security / credential changes | `docs/architecture-security/security-for-ops.md` |
+| Gateway API change | `docs/reference/api-endpoints.md` |
+| Middleware chain / prompt guard / sanitizer | `docs/architecture-security/security-for-ops.md` + `docs/operations-admin/admin-guide.md` |
+| Content classification / model routing | `docs/reference/config-keys.md` + `docs/operations-admin/admin-guide.md` |
+| FinOps / cost attribution | `docs/reference/config-keys.md` + `docs/operations-admin/operations-guide.md` |
+| Task-type routing | `docs/reference/config-keys.md` |
+
+**Rule of thumb:** if a user or admin would need to know about it to configure, operate, or
+troubleshoot KafClaw, it goes in `docs/`. If it only affects internal code structure, it does not.
+
+---
+
+## Provider Identifier Matrix
+
+These are the canonical IDs used in `model:` strings and config keys.
+
+### OAuth / CLI-delegated (no static key in config)
+
+| Provider ID    | Auth method           | Model string example              | API surface                         |
+|----------------|-----------------------|-----------------------------------|-------------------------------------|
+| `gemini-cli`   | CLI OAuth (Gemini CLI)| `gemini-cli/gemini-2.0-flash`     | Gemini REST, OAuth bearer           |
+| `openai-codex` | CLI OAuth (Codex CLI) | `openai-codex/gpt-5.3-codex`     | OpenAI REST, OAuth bearer           |
+
+### API key (static key in `providers.<id>.apiKey`)
+
+| Provider ID         | Auth method    | Model string example                   | API surface               | Notes                        |
+|---------------------|----------------|----------------------------------------|---------------------------|------------------------------|
+| `claude`            | API key        | `claude/claude-opus-4-6`               | Anthropic REST            | native Anthropic API         |
+| `openai`            | API key        | `openai/gpt-4o`                        | OpenAI REST               | ChatGPT models, API key only |
+| `gemini`            | API key        | `gemini/gemini-2.0-flash`              | Gemini REST               | Google AI Studio key         |
+| `xai`               | API key        | `xai/grok-3`                           | OpenAI-compat (xAI)       | API key only                 |
+| `scalytics-copilot` | Bearer + URL   | `scalytics-copilot/default`            | OpenAI-compat             | configurable base URL        |
+| `openrouter`        | API key        | `openrouter/anthropic/claude-opus-4-6` | OpenAI-compat proxy       | routes to any backend        |
+| `deepseek`          | API key        | `deepseek/deepseek-chat`               | OpenAI-compat             |                              |
+| `groq`              | API key        | `groq/llama-3.3-70b-versatile`         | OpenAI-compat             |                              |
+| `vllm`              | API key / none | `vllm/llama-3.1-8b-instruct`           | OpenAI-compat             | self-hosted                  |
+
+### Auth capability summary
+
+| Provider        | API key | CLI OAuth | Notes                                              |
+|-----------------|---------|-----------|----------------------------------------------------|
+| `claude`        | ✓       | —         | Anthropic API key                                  |
+| `openai`        | ✓       | —         | ChatGPT/GPT models, no OAuth path                  |
+| `openai-codex`  | —       | ✓         | Codex CLI OAuth only; same OpenAI API endpoint     |
+| `gemini`        | ✓       | —         | Google AI Studio key, Gemini REST                  |
+| `gemini-cli`    | —       | ✓         | Gemini CLI OAuth only; same Gemini REST endpoint   |
+| `xai`           | ✓       | —         | xAI/Grok, API key only                             |
+| `scalytics-copilot` | ✓  | —         | Bearer token + user-configurable base URL          |
+| `openrouter`    | ✓       | —         |                                                    |
+| `deepseek`      | ✓       | —         |                                                    |
+| `groq`          | ✓       | —         |                                                    |
+| `vllm`          | ✓       | —         | key optional for local deployments                 |
+
+**Aliases** recognized by the resolver (normalized at parse time):
+- `google` → `gemini-cli` (OAuth path preferred when no key configured; `gemini` if API key present)
+- `codex` → `openai-codex`
+- `anthropic` → `claude`
+- `copilot` → `scalytics-copilot`
+- `grok` → `xai`
+
+---
+
+## Per-Agent Model Config (config.json schema)
+
+```json
+{
+  "agents": {
+    "list": [
+      {
+        "id": "main",
+        "default": true,
+        "model": {
+          "primary": "claude/claude-opus-4-6",
+          "fallbacks": ["openai/gpt-4o", "openrouter/anthropic/claude-sonnet-4-5"]
+        },
+        "subagents": {
+          "model": "claude/claude-sonnet-4-6"
+        }
+      },
+      {
+        "id": "coder",
+        "model": {
+          "primary": "openai-codex/gpt-5.3-codex",
+          "fallbacks": ["openai/gpt-4o"]
+        }
+      }
+    ]
+  }
+}
+```
+
+Resolution order for an agent's model:
+1. `agents.list[agentId].model.primary`
+2. `agents.list[agentId].model.fallbacks[0..n]` (tried in order on transient errors)
+3. `model.name` (global fallback, same `provider/model` format)
+4. `providers.openai` with `model.name` as bare model name (legacy compat)
+
+Resolution order for subagents spawned by an agent:
+1. `agents.list[agentId].subagents.model`
+2. `tools.subagents.model` (global subagent default)
+3. Inherit parent agent's resolved model
+
+---
+
+## Done (Context Confirmed)
+
+- [x] Runtime uses `OpenAIProvider` as single LLM path (`internal/provider/openai.go`)
+- [x] Onboarding writes through `providers.openai` only (`cli-token` / `openai-compatible`)
+- [x] Config schema has `anthropic`, `openrouter`, `deepseek`, `groq`, `gemini`, `vllm` blocks (unwired; no `xai` or `scalyticsCopilot` yet)
+- [x] `AgentListEntry` exists but has no `model` or `subagents` fields
+- [x] Local Whisper available for transcription (`internal/provider/whisper_local.go`)
+- [x] Two provider injection points confirmed: `cli/agent.go:52` and `cli/gateway.go:128`
+- [x] ScalyticsCopilot API confirmed: OpenAI-compat, bearer auth, configurable base URL, `/v1/chat/completions` + `/v1/models`
+- [x] Gemini CLI OAuth: credentials at `~/.gemini/oauth_creds.json`, CLI `@google/gemini-cli` (npm)
+- [x] Codex CLI OAuth: credentials at `~/.codex/auth.json`, CLI `@openai/codex` (npm)
+- [x] Encrypted keystore already exists: `internal/skills/oauth_crypto.go` — AES-256-GCM, master key via OS keyring → local tomb (`~/.config/kafclaw/tomb.rr`) → key file; `encryptOAuthStateBlob`/`decryptOAuthStateBlob` unexported
+- [x] `StoreEnvSecretsInLocalTomb`/`LoadEnvSecretsFromLocalTomb` already available for encrypted key-value secrets (static API keys can use this)
+- [x] `cliconfig/security.go` already audits `auth/*/token.json` for encryption coverage (`gap_oauth_encryption` check)
+- [x] `internal/skills` does not import `internal/provider` — no import cycle risk
+- [x] Token tracking already exists: `AgentTask` has `prompt_tokens`/`completion_tokens`/`total_tokens`; `UpdateTaskTokens` accumulates per-task; `GetDailyTokenUsage()` sums today; `checkTokenQuota()` enforces configurable daily limit; agent loop calls `trackTokens()` after every LLM call
+- [x] `tasks` table has no `provider` or `model` column — per-provider breakdown not yet possible
+- [x] No rate limit / quota header parsing in current `OpenAIProvider`
+- [x] No `kafclaw models stats` command exists
+
+---
+
+## Implementation Scope
+
+### 1 — Config schema (`internal/config/config.go`)
+
+- [x] Add `AgentModelSpec` type: `{ Primary string; Fallbacks []string }`
+- [x] Add `AgentSubagentSpec` type: `{ Model string }`
+- [x] Extend `AgentListEntry` with `Model *AgentModelSpec` and `Subagents *AgentSubagentSpec`
+- [x] Add `ScalyticsCopilot ProviderConfig` to `ProvidersConfig` (`apiKey` + `apiBase`)
+- [x] Add `XAI ProviderConfig` to `ProvidersConfig` (`apiKey`; base fixed to `api.x.ai/v1`)
+- [x] Keep existing `Gemini ProviderConfig` for API key path (`providers.gemini.apiKey`)
+- [x] `gemini-cli` auth path uses credential cache only — no config block needed
+
+### 2 — Shared secrets package (`internal/secrets/`)
+
+The encryption layer already exists in `internal/skills/oauth_crypto.go` (AES-256-GCM, master key via OS keyring → local tomb → key file). The crypto functions are currently unexported and skills-private. Extract them to a shared package so both `internal/skills` and `internal/provider` can use them without an import cycle.
+
+- [x] Create `internal/secrets/blob.go` — move `encryptOAuthStateBlob`/`decryptOAuthStateBlob`/`loadOrCreateOAuthMasterKey` here as exported `EncryptBlob`/`DecryptBlob`/`LoadOrCreateMasterKey`; keep three key backends (keyring → tomb → file)
+- [x] Update `internal/skills/oauth_crypto.go` to call `secrets.EncryptBlob`/`secrets.DecryptBlob` instead of local functions (no behaviour change)
+- [x] `StoreEnvSecretsInLocalTomb` / `LoadEnvSecretsFromLocalTomb` stay in `internal/skills` — they are used for skill env secrets, not provider credentials
+
+**Static API keys** (claude, openai, xai, scalytics-copilot, etc.) are stored via the **tomb's env secret map**, keyed as `provider.apikey.<provider-id>`. This keeps them out of config.json plaintext.
+
+### 3 — Provider credential store (`internal/provider/credentials/store.go`)
+
+Uses `internal/secrets` for encryption. Token files land at `<ToolsDir>/auth/providers/<provider-id>/token.json` — inside the existing `auth/*/token.json` tree already audited by `cliconfig/security.go`'s `gap_oauth_encryption` check, so encryption coverage is automatic.
+
+- [x] `OAuthToken` struct: `{ Access, Refresh string; Expires int64; Email string }`
+- [x] `LoadToken(providerID string) (*OAuthToken, error)` — reads and decrypts `<ToolsDir>/auth/providers/<id>/token.json`
+- [x] `SaveToken(providerID string, t *OAuthToken) error` — encrypts via `secrets.EncryptBlob`, writes 0600
+- [x] `IsExpired(t *OAuthToken) bool` — 60s grace margin
+- [x] `LoadAPIKey(providerID string) (string, error)` — reads from tomb env map key `provider.apikey.<id>`
+- [x] `SaveAPIKey(providerID string, key string) error` — writes to tomb env map
+
+### 4 — CLI credential cache readers
+
+- [x] `internal/provider/clicache/gemini.go`: `ReadGeminiCLICredential()` — reads `~/.gemini/oauth_creds.json`, shells to `gemini auth` on expiry, returns `*credentials.OAuthToken`
+- [x] `internal/provider/clicache/codex.go`: `ReadCodexCLICredential()` — reads `~/.codex/auth.json`, shells to `codex auth` on expiry, returns `*credentials.OAuthToken`
+
+### 5 — CLI installer (`internal/provider/clinst/install.go`)
+
+- [x] `EnsureGeminiCLI() error` — check PATH, install via `npm install -g @google/gemini-cli`, fallback build from source
+- [x] `EnsureCodexCLI() error` — check PATH, install via `npm install -g @openai/codex`, fallback build from source
+
+### 6 — Provider implementations
+
+- [x] `internal/provider/gemini.go` — `GeminiProvider` calling Gemini REST (`generativelanguage.googleapis.com/v1beta`); two auth modes: static `apiKey` (query param) for `gemini` ID, OAuth bearer from CLI cache for `gemini-cli` ID; same request/response conversion for both
+- [x] `internal/provider/codex.go` — `CodexProvider` wrapping `OpenAIProvider` with OAuth bearer token from Codex CLI cache instead of static key
+- [x] `internal/provider/xai.go` — `XAIProvider` wrapping `OpenAIProvider` with fixed base `https://api.x.ai/v1` and `providers.xai.apiKey`; no OAuth path
+
+### 7 — Provider resolver (`internal/provider/resolver.go`)
+
+- [x] `Resolve(cfg *config.Config, agentID string) (LLMProvider, error)` — reads per-agent model spec, parses `provider/model`, dispatches to correct provider
+- [x] `ResolveSubagent(cfg *config.Config, agentID string) (LLMProvider, error)` — reads `subagents.model` first, delegates to `Resolve` on miss
+- [x] Normalize provider aliases at parse time (`google`→`gemini`, `codex`→`openai-codex`, etc.)
+- [x] Return structured error with provider ID and remediation hint on config/credential miss
+
+### 8 — Wire resolver into runtime
+
+- [x] `internal/cli/agent.go` — replace hardcoded `NewOpenAIProvider` with `provider.Resolve(cfg, agentID)`
+- [x] `internal/cli/gateway.go` — same replacement
+
+### 9 — Models CLI command (`internal/cli/models.go`)
+
+- [x] `kafclaw models auth login --provider gemini` — install Gemini CLI if absent, run `gemini auth login` (interactive TTY), verify credential written
+- [x] `kafclaw models auth login --provider openai-codex` — install Codex CLI if absent, run `codex auth` (interactive TTY), verify credential written
+- [x] `kafclaw models auth set-key --provider <id> --key <token> [--base <url>]` — writes to config for API-key providers; `--base` required for `scalytics-copilot`; accepted providers: `claude`, `openai`, `gemini`, `xai`, `scalytics-copilot`, `openrouter`, `deepseek`, `groq`, `vllm`
+- [x] `kafclaw models list` — print configured providers, active model per agent, credential status
+
+### 10 — Onboarding (`internal/onboarding/profile.go`)
+
+- [ ] Add LLM presets to `resolveLLMPreset` and interactive menu:
+  - `gemini` (API key), `gemini-cli` (OAuth), `openai-codex` (OAuth), `scalytics-copilot` (key + URL), `xai` (API key), `claude` (API key)
+- [ ] `applyLLM` handlers for each new preset: OAuth presets trigger `models auth login`; API key presets prompt for key (and base URL where applicable)
+- [ ] Include active provider in `BuildProfileSummary` output
+
+### 11 — Doctor + Status
+
+- [ ] `internal/cli/doctor.go` — add per-provider readiness checks: credential file present, not expired, optional live ping
+- [ ] `internal/cli/status.go` — surface active provider ID and model per agent in status output
+- [ ] Remediation hints per failure type (missing CLI, expired token, bad URL, wrong key)
+
+### 13 — Token Stats & Quota (`internal/provider/`, `internal/timeline/`, `internal/cli/`)
+
+#### What each provider actually returns
+
+| Provider        | Consumed tokens (body)                                        | Rate limit remaining (headers)                                        | Reset time (headers)                        |
+|-----------------|---------------------------------------------------------------|-----------------------------------------------------------------------|---------------------------------------------|
+| `claude`        | `usage.input_tokens` + `output_tokens`                        | `anthropic-ratelimit-tokens-remaining`                                | `anthropic-ratelimit-tokens-reset` (RFC3339) |
+| `openai`        | `usage.prompt_tokens` + `completion_tokens`                   | `x-ratelimit-remaining-tokens`, `x-ratelimit-remaining-requests`      | `x-ratelimit-reset-tokens`                  |
+| `openai-codex`  | same as openai                                                | same as openai                                                        | same as openai                              |
+| `gemini`        | `usageMetadata.promptTokenCount` + `candidatesTokenCount`     | — (Google Cloud quota, no header)                                     | —                                           |
+| `gemini-cli`    | same as gemini                                                | —                                                                     | —                                           |
+| `xai`           | `usage.prompt_tokens` + `completion_tokens` (OpenAI-compat)   | `x-ratelimit-remaining-tokens` (OpenAI-compat)                       | `x-ratelimit-reset-tokens`                  |
+| `scalytics-copilot` | `usage.prompt_tokens` + `completion_tokens` (OpenAI-compat) | exposed if server sets headers                                      | exposed if server sets headers              |
+| `openrouter`    | `usage.prompt_tokens` + `completion_tokens`                   | `x-ratelimit-remaining-requests`                                      | `x-ratelimit-reset-requests`                |
+| `deepseek`      | `usage.*` (OpenAI-compat)                                     | `x-ratelimit-remaining-tokens`                                        | `x-ratelimit-reset-tokens`                  |
+| `groq`          | `usage.*` (OpenAI-compat)                                     | `x-ratelimit-remaining-tokens`                                        | `x-ratelimit-reset-tokens`                  |
+| `vllm`          | `usage.*` (OpenAI-compat)                                     | varies by deployment                                                  | varies                                      |
+
+#### `Usage` struct extension (`internal/provider/provider.go`)
+
+```go
+type Usage struct {
+    PromptTokens     int `json:"prompt_tokens"`
+    CompletionTokens int `json:"completion_tokens"`
+    TotalTokens      int `json:"total_tokens"`
+    // Populated from HTTP response headers where the provider exposes them.
+    // nil means the provider did not report this value.
+    RemainingTokens   *int       `json:"remaining_tokens,omitempty"`
+    RemainingRequests *int       `json:"remaining_requests,omitempty"`
+    LimitTokens       *int       `json:"limit_tokens,omitempty"`
+    ResetAt           *time.Time `json:"reset_at,omitempty"`
+}
+```
+
+#### Tasks
+
+- [x] Extend `Usage` struct with `RemainingTokens *int`, `RemainingRequests *int`, `LimitTokens *int`, `ResetAt *time.Time`
+- [x] Parse rate limit headers in `OpenAIProvider.Chat()` and populate `Usage` fields (covers openai, openai-codex, xai, scalytics-copilot, openrouter, deepseek, groq)
+- [x] Parse `anthropic-ratelimit-*` headers in the `claude` provider implementation
+- [x] Parse Gemini `usageMetadata` body fields and normalize to `Usage` (no rate limit headers available for Gemini)
+- [x] Add `provider TEXT` and `model TEXT` columns to `tasks` table via migration in `timeline/service.go` (best-effort `ALTER TABLE`)
+- [x] Pass `providerID` and `model` into `UpdateTaskTokens` (or a new `UpdateTaskTokensWithProvider` variant); write them on first update for a task
+- [x] Add `GetDailyTokenUsageByProvider() (map[string]int, error)` to timeline service — query `SELECT provider, SUM(total_tokens) FROM tasks WHERE created_at >= date('now') GROUP BY provider`
+- [x] Add `GetTokenUsageSummary(days int) ([]ProviderDayStat, error)` — per-provider per-day totals for trend data
+- [x] In-memory rate limit cache in resolver/provider: store last `RemainingTokens`/`RemainingRequests`/`ResetAt` per provider ID, updated on every successful `Chat()` response; safe for concurrent reads
+- [x] `kafclaw models stats` command — print table: provider | today tokens | today requests | remaining tokens | remaining requests | reset at
+- [x] `kafclaw models stats --days 7` — print per-day per-provider trend from timeline DB
+- [x] `kafclaw models stats --json` — machine-readable output
+- [ ] Doctor check: warn if `RemainingTokens < 10%` of `LimitTokens` for any provider (using cached last-seen value)
+- [ ] `status` output: include today's total tokens + active provider rate limit remaining inline
+
+### 12 — Security + Tests
+
+- [ ] Ensure credentials never appear in logs or status output (mask/redact) — both API keys (tomb) and OAuth tokens (encrypted blob)
+- [ ] `security check` already covers `auth/*/token.json` encryption — extend walk to include `auth/providers/*/token.json`
+- [ ] Unit tests for resolver: selection, alias normalization, fallback chain, error on missing config
+- [ ] Unit tests for credential store: encrypt/decrypt roundtrip, expiry, missing file
+- [ ] Unit tests for per-agent model spec parsing
+- [ ] Unit tests for `secrets.EncryptBlob`/`DecryptBlob` after extraction (verify no regression in skills OAuth)
+- [ ] Unit tests for rate limit header parsing: present, missing, malformed values
+- [ ] Unit tests for `GetDailyTokenUsageByProvider` and `GetTokenUsageSummary`
+- [ ] Unit test for in-memory rate limit cache: concurrent update + read safety
+
+### 14 — Chat Middleware Chain (`internal/provider/middleware/`)
+
+The agent loop currently calls `provider.Chat()` directly (`agent/loop.go:1113`). There is no hook to inspect, transform, reroute, or filter messages before or after the LLM call. All four model-adjacent enterprise features (classification routing, prompt guard, output sanitization, FinOps tagging) need a middleware chain inserted at this call site.
+
+#### Architecture
+
+```
+Agent Loop
+  → checkTokenQuota()            (existing)
+  → middleware.Chain.Process()    (NEW)
+      ├─ ContentClassifier        (tag sensitivity, task type)
+      ├─ PromptGuard              (PII/secret scan → block / redact / reroute)
+      ├─ ModelRouter              (override provider based on tags)
+      ├─ provider.Chat()          (actual LLM call)
+      ├─ OutputSanitizer          (strip PII/secrets from response)
+      └─ FinOpsRecorder           (attach cost metadata)
+  → trackTokens()                (existing)
+```
+
+#### `ChatMiddleware` interface (`internal/provider/middleware/middleware.go`)
+
+```go
+// ChatMiddleware intercepts LLM requests and/or responses.
+type ChatMiddleware interface {
+    // Name returns a short identifier for logging/metrics.
+    Name() string
+    // ProcessRequest is called before the LLM call. It may modify the request,
+    // replace the provider (reroute), or return an error to abort.
+    ProcessRequest(ctx context.Context, req *provider.ChatRequest, meta *RequestMeta) error
+    // ProcessResponse is called after the LLM call. It may modify the response
+    // or return an error to suppress delivery.
+    ProcessResponse(ctx context.Context, req *provider.ChatRequest, resp *provider.ChatResponse, meta *RequestMeta) error
+}
+
+// RequestMeta carries mutable context through the chain.
+type RequestMeta struct {
+    ProviderID      string            // resolved provider; middleware can override
+    ModelName       string            // resolved model; middleware can override
+    SenderID        string
+    Channel         string
+    MessageType     string            // "internal" / "external"
+    Tags            map[string]string // classification tags (e.g. "sensitivity":"pii", "task":"coding")
+    Blocked         bool              // set by PromptGuard to abort
+    BlockReason     string
+    CostUSD         float64           // populated by FinOpsRecorder post-call
+}
+
+// Chain holds an ordered list of middleware and the underlying provider.
+type Chain struct {
+    Middlewares []ChatMiddleware
+    Provider    provider.LLMProvider
+}
+```
+
+#### Tasks
+
+- [ ] Create `internal/provider/middleware/middleware.go` — `ChatMiddleware` interface, `RequestMeta`, `Chain` with `Process(ctx, req) (*ChatResponse, error)` that runs pre/post hooks in order
+- [ ] Wire `Chain` into `agent/loop.go:runAgentLoop` — replace direct `l.provider.Chat()` with `l.chain.Process()`; pass `RequestMeta` with sender/channel/messageType from loop context
+- [ ] Wire `Chain` into `cli/gateway.go` — same replacement for the gateway LLM path
+- [ ] `Chain.Process()` must pass original `provider.LLMProvider` to the call site but allow middleware to swap `meta.ProviderID`/`meta.ModelName` (triggering re-resolve)
+- [ ] No-op when no middleware is configured — zero-overhead passthrough
+
+### 15 — Content Classification & Model Routing (`internal/provider/middleware/classifier.go`)
+
+Classifies message content and routes to the appropriate provider/model based on sensitivity level and task type. The existing `agent.AssessTask()` (`agent/context.go:360`) already does keyword-based task classification — extend it with sensitivity detection and wire it into routing decisions.
+
+#### Config schema additions (`internal/config/config.go`)
+
+```json
+{
+  "contentClassification": {
+    "enabled": false,
+    "sensitivityLevels": {
+      "pii": {
+        "patterns": ["\\b\\d{3}-\\d{2}-\\d{4}\\b", "\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}\\b"],
+        "keywords": ["social security", "credit card", "passport"],
+        "routeTo": "vllm/llama-3.1-70b-instruct"
+      },
+      "confidential": {
+        "keywords": ["internal only", "confidential", "restricted"],
+        "routeTo": "scalytics-copilot/default"
+      }
+    },
+    "taskRouting": {
+      "coding": {
+        "keywords": ["implement", "refactor", "debug", "fix bug", "write code", "function", "class"],
+        "routeTo": "openai-codex/gpt-5.3-codex"
+      },
+      "creative": {
+        "keywords": ["brainstorm", "idea", "design", "propose"],
+        "routeTo": "claude/claude-opus-4-6"
+      }
+    },
+    "defaultSensitivity": "standard"
+  }
+}
+```
+
+#### Tasks
+
+- [ ] Add `ContentClassificationConfig` struct to `internal/config/config.go`: `Enabled`, `SensitivityLevels map[string]SensitivityLevel`, `TaskRouting map[string]TaskRoute`, `DefaultSensitivity`
+- [ ] `SensitivityLevel` struct: `Patterns []string` (regex), `Keywords []string`, `RouteTo string` (provider/model)
+- [ ] `TaskRoute` struct: `Keywords []string`, `RouteTo string`
+- [ ] Add `ContentClassification ContentClassificationConfig` to root `Config`
+- [ ] Create `internal/provider/middleware/classifier.go` — implements `ChatMiddleware`; `ProcessRequest` scans message content against configured patterns/keywords, sets `meta.Tags["sensitivity"]` and `meta.Tags["task"]`, overrides `meta.ProviderID`/`meta.ModelName` when a routing rule matches
+- [ ] Integrate `agent.AssessTask()` categories into the classifier — reuse existing keyword detection, extend with configurable rules
+- [ ] Classification result stored in `meta.Tags` — available to downstream middleware and for timeline audit
+
+### 16 — Prompt Guard (`internal/provider/middleware/promptguard.go`)
+
+Pre-LLM middleware that scans inbound messages for PII, secrets, and prohibited content. Can block, redact, or reroute.
+
+#### Config schema additions
+
+```json
+{
+  "promptGuard": {
+    "enabled": false,
+    "mode": "warn",
+    "pii": {
+      "detect": ["email", "phone", "ssn", "credit_card", "ip_address"],
+      "action": "redact",
+      "customPatterns": [
+        {"name": "employee_id", "pattern": "EMP-\\d{6}"}
+      ]
+    },
+    "secrets": {
+      "detect": ["api_key", "bearer_token", "private_key", "password_literal"],
+      "action": "block"
+    },
+    "denyKeywords": {
+      "keywords": [],
+      "action": "block"
+    },
+    "onViolation": "log"
+  }
+}
+```
+
+**Modes:** `block` (reject message, return error), `redact` (replace matched content with `[REDACTED:<type>]`), `warn` (log warning, allow), `reroute` (send to private provider from `contentClassification.sensitivityLevels.pii.routeTo`)
+
+#### Tasks
+
+- [ ] Add `PromptGuardConfig` struct to `internal/config/config.go`: `Enabled`, `Mode`, `PII PIIDetectConfig`, `Secrets SecretDetectConfig`, `DenyKeywords DenyKeywordsConfig`, `OnViolation`
+- [ ] `PIIDetectConfig`: `Detect []string` (built-in detector names), `Action string`, `CustomPatterns []NamedPattern`
+- [ ] `SecretDetectConfig`: `Detect []string`, `Action string`
+- [ ] `DenyKeywordsConfig`: `Keywords []string`, `Action string`
+- [ ] Add `PromptGuard PromptGuardConfig` to root `Config`
+- [ ] Create `internal/provider/middleware/promptguard.go` — implements `ChatMiddleware`
+- [ ] Built-in PII detectors: `email` (RFC5322 regex), `phone` (E.164 + common formats), `ssn` (XXX-XX-XXXX), `credit_card` (Luhn-validated digit groups), `ip_address` (IPv4/v6)
+- [ ] Built-in secret detectors: `api_key` (common prefixes: `sk-`, `pk_`, `AKIA`, `ghp_`, `gho_`), `bearer_token` (`Bearer [A-Za-z0-9\-._~+/]+=*`), `private_key` (`-----BEGIN .* PRIVATE KEY-----`), `password_literal` (`password\s*[:=]\s*\S+`)
+- [ ] `ProcessRequest`: scan all user-role messages in `req.Messages`, apply action per match type; set `meta.Blocked`/`meta.BlockReason` on block; mutate message content on redact
+- [ ] Log violations to timeline as security events (reuse `LogSecurityEvent` if available)
+- [ ] `ProcessResponse`: no-op (output scanning is in OutputSanitizer)
+
+### 17 — Output Sanitization (`internal/provider/middleware/sanitizer.go`)
+
+Post-LLM middleware that scans the response content before it reaches the channel delivery path.
+
+#### Config schema additions
+
+```json
+{
+  "outputSanitization": {
+    "enabled": false,
+    "redactPII": true,
+    "redactSecrets": true,
+    "customRedactPatterns": [],
+    "denyPatterns": [],
+    "maxOutputLength": 0
+  }
+}
+```
+
+#### Tasks
+
+- [ ] Add `OutputSanitizationConfig` struct to `internal/config/config.go`: `Enabled`, `RedactPII`, `RedactSecrets`, `CustomRedactPatterns []NamedPattern`, `DenyPatterns []string`, `MaxOutputLength int`
+- [ ] `NamedPattern` struct (shared with PromptGuard): `Name string`, `Pattern string`
+- [ ] Add `OutputSanitization OutputSanitizationConfig` to root `Config`
+- [ ] Create `internal/provider/middleware/sanitizer.go` — implements `ChatMiddleware`
+- [ ] `ProcessRequest`: no-op
+- [ ] `ProcessResponse`: scan `resp.Content` for PII/secrets using same detectors as PromptGuard (shared detector package); redact matches; optionally truncate to `MaxOutputLength`; if `DenyPatterns` match, replace response with generic "response filtered" message
+- [ ] Shared detector logic extracted to `internal/provider/middleware/detectors.go` — reused by both PromptGuard and OutputSanitizer
+
+### 18 — FinOps Cost Attribution (`internal/provider/middleware/finops.go`)
+
+Post-LLM middleware that attaches dollar cost per request based on provider pricing and records attribution metadata.
+
+#### Config schema additions
+
+```json
+{
+  "finops": {
+    "enabled": false,
+    "pricing": {
+      "claude": {"promptPer1kTokens": 0.015, "completionPer1kTokens": 0.075},
+      "openai": {"promptPer1kTokens": 0.005, "completionPer1kTokens": 0.015},
+      "gemini": {"promptPer1kTokens": 0.00025, "completionPer1kTokens": 0.001},
+      "xai":    {"promptPer1kTokens": 0.003, "completionPer1kTokens": 0.015},
+      "openrouter": {"promptPer1kTokens": 0.0, "completionPer1kTokens": 0.0},
+      "deepseek": {"promptPer1kTokens": 0.00014, "completionPer1kTokens": 0.00028},
+      "groq":   {"promptPer1kTokens": 0.00005, "completionPer1kTokens": 0.00008}
+    },
+    "budgets": {
+      "daily": 10.00,
+      "monthly": 200.00
+    },
+    "attribution": {
+      "tagBy": ["provider", "model", "agent", "channel", "sender"]
+    }
+  }
+}
+```
+
+#### Tasks
+
+- [ ] Add `FinOpsConfig` struct to `internal/config/config.go`: `Enabled`, `Pricing map[string]ModelPricing`, `Budgets BudgetConfig`, `Attribution AttributionConfig`
+- [ ] `ModelPricing`: `PromptPer1kTokens float64`, `CompletionPer1kTokens float64`
+- [ ] `BudgetConfig`: `Daily float64`, `Monthly float64`
+- [ ] `AttributionConfig`: `TagBy []string`
+- [ ] Add `FinOps FinOpsConfig` to root `Config`
+- [ ] Create `internal/provider/middleware/finops.go` — implements `ChatMiddleware`
+- [ ] `ProcessRequest`: no-op
+- [ ] `ProcessResponse`: calculate `costUSD = (promptTokens * promptPrice + completionTokens * completionPrice) / 1000`; set `meta.CostUSD`; check against daily/monthly budgets; log warning if approaching limit
+- [ ] Add `cost_usd REAL DEFAULT 0` column to `tasks` table (best-effort migration)
+- [ ] Extend `UpdateTaskTokensWithProvider` (or new variant) to write `cost_usd`
+- [ ] `kafclaw models stats` — add cost column to output when finops is enabled
+- [ ] `kafclaw models stats --days 7` — include cost per day per provider
+
+### 19 — Task-Type Model Routing in Resolver (`internal/provider/resolver.go`)
+
+Extend the resolver to dynamically select a model based on `TaskAssessment.Category` when the agent has no explicit per-agent model override. This bridges the existing `AssessTask()` classification with the provider layer.
+
+#### Config schema additions
+
+```json
+{
+  "model": {
+    "name": "claude/claude-sonnet-4-6",
+    "taskRouting": {
+      "security":     "claude/claude-opus-4-6",
+      "tool-heavy":   "openai-codex/gpt-5.3-codex",
+      "creative":     "claude/claude-opus-4-6",
+      "multi-step":   "claude/claude-sonnet-4-6",
+      "quick-answer": "groq/llama-3.3-70b-versatile"
+    }
+  }
+}
+```
+
+#### Tasks
+
+- [ ] Add `TaskRouting map[string]string` to `ModelConfig` (`internal/config/config.go`)
+- [ ] Add `ResolveWithTaskType(cfg *config.Config, agentID string, taskCategory string) (LLMProvider, error)` to `internal/provider/resolver.go` — if `cfg.Model.TaskRouting[taskCategory]` exists and agent has no explicit model override, use it; otherwise fall through to normal `Resolve`
+- [ ] Wire into `agent/loop.go`: call `agent.AssessTask(message)` early (already happens for cognitive prompt), pass `assessment.Category` to `ResolveWithTaskType` on first iteration
+- [ ] Log task-type routing decisions to timeline span metadata for observability
+
+---
+
+## Execution Queue (ordered, no-discussion)
+
+1. `internal/secrets/blob.go` — extract `EncryptBlob`/`DecryptBlob`/`LoadOrCreateMasterKey` from `skills/oauth_crypto.go`; update `skills/oauth_crypto.go` to delegate; no behaviour change
+2. `config.go` — schema additions (AgentModelSpec, AgentSubagentSpec, XAI, ScalyticsCopilot)
+   - **Docs:** `docs/reference/config-keys.md` (new provider blocks + per-agent model spec)
+3. `provider/provider.go` — extend `Usage` with rate limit fields (`RemainingTokens`, `RemainingRequests`, `LimitTokens`, `ResetAt`)
+4. `provider/credentials/store.go` — `LoadToken`/`SaveToken` (encrypted blob via `secrets`) + `LoadAPIKey`/`SaveAPIKey` (tomb env map)
+   - **Docs:** `docs/architecture-security/security-for-ops.md` (credential storage model)
+5. `provider/clicache/gemini.go` + `provider/clicache/codex.go`
+6. `provider/clinst/install.go`
+7. `provider/gemini.go` + `provider/codex.go` + `provider/xai.go` — each parses their own usage + rate limit headers/body and populates `Usage`
+8. `provider/openai.go` — add rate limit header parsing to existing `Chat()` (covers openai, openai-codex, xai, scalytics-copilot, openrouter, deepseek, groq in one shot)
+9. `provider/resolver.go` — including in-memory rate limit cache updated on every `Chat()` response
+10. `timeline/service.go` — add `provider`/`model` columns (migration), `UpdateTaskTokensWithProvider`, `GetDailyTokenUsageByProvider`, `GetTokenUsageSummary`
+11. Wire `cli/agent.go` + `cli/gateway.go` — pass `providerID` + `model` through to token tracking
+12. `cli/models.go` — `auth login`, `auth set-key`, `list`, `stats` commands
+    - **Docs:** `docs/reference/cli-reference.md` (all new `kafclaw models` subcommands) · `docs/start-here/getting-started.md` (provider setup for users) · `docs/operations-admin/admin-guide.md` (provider setup for admins)
+13. `onboarding/profile.go` additions
+    - **Docs:** `docs/start-here/getting-started.md` (new onboarding presets)
+14. `cliconfig/doctor.go` + `cliconfig/security.go` — rate limit warn check + extend `auth/providers/*/token.json` walk
+    - **Docs:** `docs/reference/cli-reference.md` (new doctor checks) · `docs/operations-admin/operations-guide.md` (troubleshooting provider issues)
+15. Tests
+16. `provider/middleware/middleware.go` — `ChatMiddleware` interface, `RequestMeta`, `Chain`; wire into `agent/loop.go` and `cli/gateway.go` replacing direct `provider.Chat()` calls
+    - **Docs:** `docs/architecture-security/security-for-ops.md` (middleware chain overview)
+17. `config.go` — add `ContentClassificationConfig`, `PromptGuardConfig`, `OutputSanitizationConfig`, `FinOpsConfig` structs; add `TaskRouting` to `ModelConfig`; add `NamedPattern` shared type
+    - **Docs:** `docs/reference/config-keys.md` (all new config blocks)
+18. `provider/middleware/detectors.go` — shared PII + secret detection (regex-based, used by both PromptGuard and OutputSanitizer)
+19. `provider/middleware/classifier.go` — content classification + model routing middleware; integrates with `agent.AssessTask()`
+    - **Docs:** `docs/operations-admin/admin-guide.md` (classification rules setup)
+20. `provider/middleware/promptguard.go` — PII/secret/deny-keyword scan on inbound messages; block / redact / reroute / warn modes
+    - **Docs:** `docs/architecture-security/security-for-ops.md` (prompt guard config) · `docs/operations-admin/admin-guide.md` (PII/secret patterns)
+21. `provider/middleware/sanitizer.go` — output redaction post-LLM; shared detectors
+    - **Docs:** `docs/architecture-security/security-for-ops.md` (output sanitization)
+22. `provider/middleware/finops.go` — cost calculation, budget enforcement, attribution tagging; `cost_usd` column migration
+    - **Docs:** `docs/operations-admin/operations-guide.md` (FinOps cost tracking) · `docs/reference/cli-reference.md` (`kafclaw models stats` cost columns)
+23. `provider/resolver.go` — add `ResolveWithTaskType()` for task-category → model routing
+    - **Docs:** `docs/reference/config-keys.md` (`model.taskRouting` block)
+24. Tests for middleware chain: classifier, promptguard, sanitizer, finops, task-type routing

--- a/_tasks/provider-support.md
+++ b/_tasks/provider-support.md
@@ -461,7 +461,7 @@ Pre-LLM middleware that scans inbound messages for PII, secrets, and prohibited 
 - [x] Built-in PII detectors: `email`, `phone`, `ssn`, `credit_card`, `ip_address`
 - [x] Built-in secret detectors: `api_key`, `bearer_token`, `private_key`, `password_literal`
 - [x] `ProcessRequest`: scan user-role messages, apply action per match type; block/redact/warn modes
-- [ ] Log violations to timeline as security events (reuse `LogSecurityEvent` if available)
+- [x] Log violations to timeline as security events (reuse `LogSecurityEvent` if available)
 - [x] `ProcessResponse`: no-op (output scanning is in OutputSanitizer)
 
 ### 17 — Output Sanitization (`internal/provider/middleware/sanitizer.go`)
@@ -562,7 +562,7 @@ Extend the resolver to dynamically select a model based on `TaskAssessment.Categ
 - [x] Add `TaskRouting map[string]string` to `ModelConfig` (`internal/config/config.go`)
 - [x] Add `ResolveWithTaskType(cfg *config.Config, agentID string, taskCategory string) (LLMProvider, error)` to `internal/provider/resolver.go`
 - [x] Wire into `agent/loop.go`: call `agent.AssessTask(message)` early, pass `assessment.Category` to `ResolveWithTaskType` on first iteration
-- [ ] Log task-type routing decisions to timeline span metadata for observability
+- [x] Log task-type routing decisions to timeline span metadata for observability
 
 ---
 

--- a/_tasks/provider-support.md
+++ b/_tasks/provider-support.md
@@ -245,8 +245,8 @@ Uses `internal/secrets` for encryption. Token files land at `<ToolsDir>/auth/pro
 ### 11 — Doctor + Status
 
 - [x] `internal/cliconfig/doctor.go` — add per-provider readiness checks: credential configured, CLI tools present
-- [ ] `internal/cli/status.go` — surface active provider ID and model per agent in status output
-- [ ] Remediation hints per failure type (missing CLI, expired token, bad URL, wrong key)
+- [x] `internal/cli/status.go` — surface active provider ID and model per agent in status output
+- [x] Remediation hints per failure type (missing CLI, expired token, bad URL, wrong key)
 
 ### 13 — Token Stats & Quota (`internal/provider/`, `internal/timeline/`, `internal/cli/`)
 
@@ -296,19 +296,19 @@ type Usage struct {
 - [x] `kafclaw models stats` command — print table: provider | today tokens | today requests | remaining tokens | remaining requests | reset at
 - [x] `kafclaw models stats --days 7` — print per-day per-provider trend from timeline DB
 - [x] `kafclaw models stats --json` — machine-readable output
-- [ ] Doctor check: warn if `RemainingTokens < 10%` of `LimitTokens` for any provider (using cached last-seen value)
-- [ ] `status` output: include today's total tokens + active provider rate limit remaining inline
+- [x] Doctor check: warn if `RemainingTokens < 10%` of `LimitTokens` for any provider (using cached last-seen value)
+- [x] `status` output: include today's total tokens + active provider rate limit remaining inline
 
 ### 12 — Security + Tests
 
-- [ ] Ensure credentials never appear in logs or status output (mask/redact) — both API keys (tomb) and OAuth tokens (encrypted blob)
-- [ ] `security check` already covers `auth/*/token.json` encryption — extend walk to include `auth/providers/*/token.json`
+- [x] Ensure credentials never appear in logs or status output (mask/redact) — both API keys (tomb) and OAuth tokens (encrypted blob)
+- [x] `security check` already covers `auth/*/token.json` encryption — extend walk to include `auth/providers/*/token.json`
 - [x] Unit tests for resolver: selection, alias normalization, fallback chain, error on missing config
-- [ ] Unit tests for credential store: encrypt/decrypt roundtrip, expiry, missing file
-- [ ] Unit tests for per-agent model spec parsing
-- [ ] Unit tests for `secrets.EncryptBlob`/`DecryptBlob` after extraction (verify no regression in skills OAuth)
-- [ ] Unit tests for rate limit header parsing: present, missing, malformed values
-- [ ] Unit tests for `GetDailyTokenUsageByProvider` and `GetTokenUsageSummary`
+- [x] Unit tests for credential store: encrypt/decrypt roundtrip, expiry, missing file
+- [x] Unit tests for per-agent model spec parsing
+- [x] Unit tests for `secrets.EncryptBlob`/`DecryptBlob` after extraction (verify no regression in skills OAuth)
+- [x] Unit tests for rate limit header parsing: present, missing, malformed values
+- [x] Unit tests for `GetDailyTokenUsageByProvider` and `GetTokenUsageSummary`
 - [x] Unit test for in-memory rate limit cache: concurrent update + read safety
 
 ### 14 — Chat Middleware Chain (`internal/provider/middleware/`)
@@ -531,10 +531,10 @@ Post-LLM middleware that attaches dollar cost per request based on provider pric
 - [x] Create `internal/provider/middleware/finops.go` — implements `ChatMiddleware`
 - [x] `ProcessRequest`: no-op
 - [x] `ProcessResponse`: calculate cost, set `meta.CostUSD`, budget warnings
-- [ ] Add `cost_usd REAL DEFAULT 0` column to `tasks` table (best-effort migration)
-- [ ] Extend `UpdateTaskTokensWithProvider` to write `cost_usd`
-- [ ] `kafclaw models stats` — add cost column to output when finops is enabled
-- [ ] `kafclaw models stats --days 7` — include cost per day per provider
+- [x] Add `cost_usd REAL DEFAULT 0` column to `tasks` table (best-effort migration)
+- [x] Extend `UpdateTaskTokensWithProvider` to write `cost_usd`
+- [x] `kafclaw models stats` — add cost column to output when finops is enabled
+- [x] `kafclaw models stats --days 7` — include cost per day per provider
 
 ### 19 — Task-Type Model Routing in Resolver (`internal/provider/resolver.go`)
 
@@ -561,7 +561,7 @@ Extend the resolver to dynamically select a model based on `TaskAssessment.Categ
 
 - [x] Add `TaskRouting map[string]string` to `ModelConfig` (`internal/config/config.go`)
 - [x] Add `ResolveWithTaskType(cfg *config.Config, agentID string, taskCategory string) (LLMProvider, error)` to `internal/provider/resolver.go`
-- [ ] Wire into `agent/loop.go`: call `agent.AssessTask(message)` early, pass `assessment.Category` to `ResolveWithTaskType` on first iteration
+- [x] Wire into `agent/loop.go`: call `agent.AssessTask(message)` early, pass `assessment.Category` to `ResolveWithTaskType` on first iteration
 - [ ] Log task-type routing decisions to timeline span metadata for observability
 
 ---

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -11,6 +11,7 @@ Primary command groups:
 - `kafclaw status` - runtime/config health snapshot
 - `kafclaw doctor` - diagnostics and setup checks
 - `kafclaw security` - security checks, deep audit, and safe remediation (`check|audit|fix`)
+- `kafclaw models` - manage LLM providers and models (`list|stats|auth login|auth set-key`)
 - `kafclaw config` / `kafclaw configure` - low-level and guided config changes
 - `kafclaw agent -m` - one-shot interaction
 - `kafclaw skills` - bundled/external skill lifecycle and auth/prereq flows (`enable|disable|list|status|enable-skill|disable-skill|verify|install|update|exec|prereq|auth`)
@@ -37,6 +38,7 @@ Detailed command examples:
 - [Getting Started](../start-here/getting-started/)
 - [User Manual - CLI Reference section](../start-here/user-manual/#3-cli-reference)
 - [Manage KafClaw](../operations-admin/manage-kafclaw/)
+- [Models CLI Reference](models-cli/) - provider management, auth, usage stats
 
 Skills execution example:
 - `kafclaw skills exec <skill-id> --input '{"text":"..."}'`

--- a/docs/reference/config-keys.md
+++ b/docs/reference/config-keys.md
@@ -61,11 +61,92 @@ kafclaw status
 kafclaw doctor
 ```
 
+## Model Configuration
+
+```json
+{
+  "model": {
+    "name": "claude/claude-sonnet-4-5",
+    "maxTokens": 8192,
+    "temperature": 0.7,
+    "maxToolIterations": 20,
+    "taskRouting": {
+      "security": "claude/claude-opus-4-6",
+      "coding": "openai-codex/gpt-5.3-codex"
+    }
+  }
+}
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `model.name` | string | Global default model in `provider/model` format |
+| `model.maxTokens` | int | Max output tokens per LLM call |
+| `model.temperature` | float | Sampling temperature (0.0 - 1.0) |
+| `model.maxToolIterations` | int | Max tool-call rounds per request |
+| `model.taskRouting` | map | Category to model string overrides (`security`, `coding`, `tool-heavy`, `creative`) |
+
+## Provider Configuration
+
+```json
+{
+  "providers": {
+    "anthropic": { "apiKey": "sk-ant-...", "apiBase": "" },
+    "openai": { "apiKey": "sk-...", "apiBase": "" },
+    "gemini": { "apiKey": "AIza..." },
+    "xai": { "apiKey": "xai-..." },
+    "openrouter": { "apiKey": "sk-or-...", "apiBase": "https://openrouter.ai/api/v1" },
+    "deepseek": { "apiKey": "sk-...", "apiBase": "https://api.deepseek.com/v1" },
+    "groq": { "apiKey": "gsk_...", "apiBase": "https://api.groq.com/openai/v1" },
+    "vllm": { "apiKey": "", "apiBase": "http://localhost:8000/v1" },
+    "scalyticsCopilot": { "apiKey": "<token>", "apiBase": "https://copilot.scalytics.io/v1" }
+  }
+}
+```
+
+Each provider entry accepts `apiKey` and `apiBase`. See [LLM Providers](providers/) for details.
+
+## Per-Agent Model Configuration
+
+```json
+{
+  "agents": {
+    "list": [
+      {
+        "id": "main",
+        "model": {
+          "primary": "claude/claude-opus-4-6",
+          "fallbacks": ["openai/gpt-4o"]
+        },
+        "subagents": {
+          "model": "groq/llama-3.3-70b"
+        }
+      }
+    ]
+  }
+}
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `agents.list[].model.primary` | string | Primary model for this agent |
+| `agents.list[].model.fallbacks` | []string | Fallback models tried on transient errors |
+| `agents.list[].subagents.model` | string | Model for subagents spawned by this agent |
+
+## Middleware Configuration
+
+| Section | Reference |
+|---------|-----------|
+| `contentClassification` | [Content Classification](middleware/#content-classification) |
+| `promptGuard` | [Prompt Guard](middleware/#prompt-guard) |
+| `outputSanitization` | [Output Sanitizer](middleware/#output-sanitizer) |
+| `finops` | [FinOps Cost Attribution](middleware/#finops-cost-attribution) |
+
 ## Common Environment Variables
 
 - `OPENAI_API_KEY`
 - `OPENROUTER_API_KEY`
-- `KAFCLAW_AGENTS_MODEL`
+- `KAFCLAW_MODEL` — global model (e.g. `claude/claude-sonnet-4-5`)
 - `KAFCLAW_AGENTS_WORKSPACE`
 - `KAFCLAW_AGENTS_WORK_REPO_PATH`
 - `KAFCLAW_GATEWAY_HOST`
@@ -82,6 +163,9 @@ kafclaw doctor
 
 ## Related Docs
 
+- [LLM Providers](providers/)
+- [Models CLI](models-cli/)
+- [Chat Middleware](middleware/)
 - [Getting Started Guide](../start-here/getting-started/)
 - [KafClaw Administration Guide](../operations-admin/admin-guide/)
 - [Workspace Policy](../architecture-security/workspace-policy/)

--- a/docs/reference/middleware.md
+++ b/docs/reference/middleware.md
@@ -1,0 +1,245 @@
+---
+title: Chat Middleware
+parent: Reference
+nav_order: 5
+---
+
+# Chat Middleware
+
+KafClaw runs a configurable middleware chain between the agent loop and the LLM provider. Middleware can inspect, transform, reroute, or block messages before and after each LLM call.
+
+## Architecture
+
+```
+User Message
+    |
+    v
+[Content Classifier] --> tags: sensitivity, task type; may reroute provider
+[Prompt Guard]       --> scans for PII/secrets; may warn, redact, or block
+    |
+    v
+  LLM Provider (Chat)
+    |
+    v
+[Output Sanitizer]   --> redacts PII/secrets in response; enforces deny patterns
+[FinOps Recorder]    --> calculates per-request cost; budget warnings
+    |
+    v
+Channel Delivery
+```
+
+Each middleware implements `ProcessRequest` (pre-LLM) and `ProcessResponse` (post-LLM). The chain is zero-overhead when no middleware is configured.
+
+## Content Classification
+
+Classifies messages by sensitivity level and task type. Can reroute to a different model based on content.
+
+### Config
+
+```json
+{
+  "contentClassification": {
+    "enabled": true,
+    "sensitivityLevels": {
+      "pii": {
+        "keywords": ["social security", "passport number"],
+        "patterns": ["\\b\\d{3}-\\d{2}-\\d{4}\\b"],
+        "routeTo": "claude/claude-opus-4-6"
+      },
+      "confidential": {
+        "keywords": ["confidential", "internal only"],
+        "routeTo": "vllm/private-model"
+      }
+    },
+    "taskTypeRoutes": {
+      "security": "claude/claude-opus-4-6",
+      "coding": "openai-codex/gpt-5.3-codex"
+    }
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `enabled` | bool | Enable content classification |
+| `sensitivityLevels` | map | Named sensitivity classes with keywords, patterns, and optional model reroute |
+| `taskTypeRoutes` | map | Task category to model string routing (`security`, `coding`, `tool-heavy`, `creative`) |
+
+## Prompt Guard
+
+Scans inbound user messages for PII, secrets, and deny-listed keywords before they reach the LLM. Three action modes: `warn` (tag only), `redact` (replace matches with `[REDACTED]`), or `block` (abort the request).
+
+### Config
+
+```json
+{
+  "promptGuard": {
+    "enabled": true,
+    "mode": "redact",
+    "pii": {
+      "detect": ["email", "phone", "ssn", "credit_card", "ip_address"],
+      "action": "redact",
+      "customPatterns": [
+        {"name": "employee_id", "pattern": "EMP-\\d{6}"}
+      ]
+    },
+    "secrets": {
+      "detect": ["api_key", "bearer_token", "private_key", "password_literal"],
+      "action": "block"
+    },
+    "denyKeywords": ["DROP TABLE", "rm -rf"],
+    "customPatterns": [
+      {"name": "internal_url", "pattern": "https://internal\\.corp\\.\\S+"}
+    ]
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `enabled` | bool | Enable prompt guard |
+| `mode` | string | Default action: `warn`, `redact`, or `block` |
+| `pii.detect` | []string | PII types to scan: `email`, `phone`, `ssn`, `credit_card`, `ip_address` |
+| `pii.action` | string | Override action for PII matches (default: inherits `mode`) |
+| `pii.customPatterns` | []NamedPattern | Additional PII patterns |
+| `secrets.detect` | []string | Secret types: `api_key`, `bearer_token`, `private_key`, `password_literal` |
+| `secrets.action` | string | Override action for secret matches |
+| `secrets.customPatterns` | []NamedPattern | Additional secret patterns |
+| `denyKeywords` | []string | Keywords that always block (case-insensitive) |
+| `customPatterns` | []NamedPattern | Additional patterns for both PII and secrets |
+
+### Behavior
+
+- **Deny keywords** are checked first and always block, regardless of `mode`.
+- **PII action** overrides `mode` for PII matches. **Secret action** overrides for secret matches.
+- When `mode` is `redact`, matched content is replaced with `[REDACTED:<type>]` before the LLM sees it.
+- Blocked requests return a `[blocked by prompt-guard]` response to the user.
+- All prompt guard actions are logged as `SECURITY` events in the timeline.
+
+## Output Sanitizer
+
+Scans LLM responses for PII, secrets, and deny patterns before channel delivery.
+
+### Config
+
+```json
+{
+  "outputSanitization": {
+    "enabled": true,
+    "redactPII": true,
+    "redactSecrets": true,
+    "customRedactPatterns": [
+      {"name": "internal_ip", "pattern": "10\\.\\d+\\.\\d+\\.\\d+"}
+    ],
+    "denyPatterns": [
+      "(?i)BEGIN\\s+(RSA|EC|DSA|OPENSSH)\\s+PRIVATE\\s+KEY"
+    ],
+    "maxOutputLength": 50000
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `enabled` | bool | Enable output sanitization |
+| `redactPII` | bool | Redact PII types (email, phone, SSN, credit card, IP) in responses |
+| `redactSecrets` | bool | Redact secrets (API keys, bearer tokens, private keys) in responses |
+| `customRedactPatterns` | []NamedPattern | Additional patterns to redact |
+| `denyPatterns` | []string | Regex patterns that cause the entire response to be replaced with a filter message |
+| `maxOutputLength` | int | Truncate responses exceeding this character count (0 = unlimited) |
+
+### Behavior
+
+- **Deny patterns** are checked first. If any match, the entire response is replaced with `[Response filtered by output sanitizer]`.
+- **Redaction** replaces matched substrings with `[REDACTED:<type>]`.
+- **Truncation** appends `[truncated by output sanitizer]` when the response exceeds `maxOutputLength`.
+- All sanitizer actions are logged as `SECURITY` events in the timeline.
+
+## FinOps Cost Attribution
+
+Calculates per-request USD cost from token usage and provider-specific pricing. Logs budget warnings.
+
+### Config
+
+```json
+{
+  "finops": {
+    "enabled": true,
+    "pricing": {
+      "claude": {
+        "promptPer1kTokens": 0.003,
+        "completionPer1kTokens": 0.015
+      },
+      "openai": {
+        "promptPer1kTokens": 0.005,
+        "completionPer1kTokens": 0.015
+      },
+      "groq": {
+        "promptPer1kTokens": 0.0001,
+        "completionPer1kTokens": 0.0002
+      }
+    },
+    "dailyBudget": 10.00,
+    "monthlyBudget": 200.00
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `enabled` | bool | Enable cost tracking |
+| `pricing` | map | Provider ID to per-1k-token pricing |
+| `pricing[].promptPer1kTokens` | float | USD per 1,000 prompt tokens |
+| `pricing[].completionPer1kTokens` | float | USD per 1,000 completion tokens |
+| `dailyBudget` | float | Max USD per day (0 = unlimited). Logs warnings when a single request exceeds 10% of budget. |
+| `monthlyBudget` | float | Max USD per month (0 = unlimited) |
+
+### Cost Formula
+
+```
+cost = (promptTokens * promptPer1kTokens + completionTokens * completionPer1kTokens) / 1000
+```
+
+### Viewing Costs
+
+```bash
+# Today's cost by provider
+kafclaw models stats
+
+# Multi-day cost trend
+kafclaw models stats --days 7
+
+# JSON output for automation
+kafclaw models stats --json
+```
+
+## Observability
+
+All middleware actions are logged to the timeline as events:
+
+| Event Type | Classification | When |
+|---|---|---|
+| `SECURITY` | `BLOCKED` | Prompt guard blocks a request |
+| `SECURITY` | `GUARD` | Prompt guard detects but doesn't block (warn/redact mode) |
+| `SECURITY` | `SANITIZED` | Output sanitizer redacts or filters a response |
+| `SYSTEM` | `ROUTING` | Task-type routing selects a different model |
+
+View events:
+
+```bash
+kafclaw status
+```
+
+## Related Docs
+
+- [LLM Providers](providers/)
+- [Models CLI Reference](models-cli/)
+- [Configuration Keys](config-keys/)

--- a/docs/reference/models-cli.md
+++ b/docs/reference/models-cli.md
@@ -1,0 +1,163 @@
+---
+title: Models CLI
+parent: Reference
+nav_order: 6
+---
+
+# kafclaw models
+
+Manage LLM providers, authentication, and usage statistics.
+
+## Subcommands
+
+| Command | Description |
+|---|---|
+| `kafclaw models list` | Show configured providers and active model per agent |
+| `kafclaw models stats` | Show token usage and cost statistics |
+| `kafclaw models auth login` | Authenticate with an OAuth-based provider |
+| `kafclaw models auth set-key` | Store an API key for a provider |
+
+---
+
+## kafclaw models list
+
+Shows all supported providers, their configuration status, the global model, and per-agent model assignments.
+
+```bash
+kafclaw models list
+```
+
+Example output:
+
+```
+Configured Providers:
+
+  claude               configured
+  openai               configured
+  gemini               not configured
+  gemini-cli           OAuth
+  openai-codex         OAuth
+  xai                  not configured
+  scalytics-copilot    not configured
+  openrouter           configured  base: https://openrouter.ai/api/v1
+  deepseek             not configured
+  groq                 configured
+  vllm                 not configured
+
+Global model: claude/claude-sonnet-4-5
+Agent main         model: claude/claude-opus-4-6
+  fallback[0]: openai/gpt-4o
+  subagent model: groq/llama-3.3-70b
+```
+
+---
+
+## kafclaw models stats
+
+Shows today's token usage and cost per provider, rate limit snapshots, and optionally a multi-day trend.
+
+```bash
+# Today's usage
+kafclaw models stats
+
+# 7-day per-provider trend
+kafclaw models stats --days 7
+
+# JSON output
+kafclaw models stats --json
+```
+
+### Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--days` | int | 0 | Show per-day per-provider trend for N days |
+| `--json` | bool | false | Output in JSON format |
+
+### Example output (today)
+
+```
+Today's token usage: 12450
+
+PROVIDER             TOKENS     COST
+claude               8200       $0.1640
+openai               3500       $0.0700
+groq                 750        $0.0002
+
+PROVIDER             REMAINING TOK   REMAINING REQ   LIMIT TOK       RESET
+claude               42000           98              50000           14:30:00
+openai               87000           450             100000          15:00:00
+```
+
+### Example output (--days 7)
+
+```
+PROVIDER        DAY          TOKENS     COST
+claude          2026-02-22   8200       $0.1640
+claude          2026-02-21   15300      $0.3060
+openai          2026-02-22   3500       $0.0700
+openai          2026-02-21   6200       $0.1240
+groq            2026-02-22   750        $0.0002
+```
+
+---
+
+## kafclaw models auth login
+
+Authenticates with providers that use CLI-based OAuth flows. Installs the provider CLI if not already present.
+
+```bash
+kafclaw models auth login --provider <provider>
+```
+
+### Supported providers
+
+| Provider | CLI installed | Auth flow |
+|---|---|---|
+| `gemini` | Gemini CLI (`gemini`) | `gemini auth login` |
+| `openai-codex` | Codex CLI (`codex`) | `codex auth` |
+
+### Example
+
+```bash
+kafclaw models auth login --provider gemini
+```
+
+---
+
+## kafclaw models auth set-key
+
+Stores an API key or bearer token for a provider in the encrypted credential store.
+
+```bash
+kafclaw models auth set-key --provider <provider> --key <token> [--base <url>]
+```
+
+### Flags
+
+| Flag | Required | Description |
+|---|---|---|
+| `--provider` | yes | Provider ID: `claude`, `openai`, `gemini`, `xai`, `scalytics-copilot`, `openrouter`, `deepseek`, `groq`, `vllm` |
+| `--key` | yes | API key or bearer token |
+| `--base` | for `scalytics-copilot`, `vllm` | Base URL for the provider API |
+
+### Examples
+
+```bash
+# Anthropic / Claude
+kafclaw models auth set-key --provider claude --key sk-ant-api03-...
+
+# Self-hosted vLLM
+kafclaw models auth set-key --provider vllm --key optional-key --base http://gpu-server:8000/v1
+
+# ScalyticsCopilot
+kafclaw models auth set-key --provider scalytics-copilot --key <bearer-token> --base https://copilot.scalytics.io/v1
+```
+
+---
+
+## Related Docs
+
+- [LLM Providers](providers/)
+- [Chat Middleware](middleware/)
+- [Configuration Keys](config-keys/)

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -1,0 +1,200 @@
+---
+title: LLM Providers
+parent: Reference
+nav_order: 4
+---
+
+# LLM Providers
+
+KafClaw supports multiple LLM backends through a unified provider layer. Each provider is identified by a canonical ID and accessed via a model string in the format `<provider-id>/<model-name>`.
+
+## Provider Matrix
+
+| Provider ID | Auth Method | Default API Base | Example Model String |
+|---|---|---|---|
+| `claude` | API key | `https://api.anthropic.com/v1` | `claude/claude-sonnet-4-5` |
+| `openai` | API key | _(must be set)_ | `openai/gpt-4o` |
+| `gemini` | API key | Google AI Studio | `gemini/gemini-2.5-pro` |
+| `gemini-cli` | OAuth (CLI) | _(via Gemini CLI)_ | `gemini-cli/gemini-2.5-pro` |
+| `openai-codex` | OAuth (CLI) | _(via Codex CLI)_ | `openai-codex/gpt-5.3-codex` |
+| `xai` | API key | `https://api.x.ai/v1` | `xai/grok-3` |
+| `scalytics-copilot` | API key + base URL | _(must be set)_ | `scalytics-copilot/default` |
+| `openrouter` | API key | `https://openrouter.ai/api/v1` | `openrouter/anthropic/claude-sonnet-4-5` |
+| `deepseek` | API key | `https://api.deepseek.com/v1` | `deepseek/deepseek-chat` |
+| `groq` | API key | `https://api.groq.com/openai/v1` | `groq/llama-3.3-70b` |
+| `vllm` | API key (optional) + base URL | _(must be set)_ | `vllm/my-model` |
+
+### Provider Aliases
+
+These shorthand names resolve automatically:
+
+| Alias | Resolves To |
+|---|---|
+| `anthropic` | `claude` |
+| `google` | `gemini-cli` (or `gemini` if an API key is configured) |
+| `codex` | `openai-codex` |
+| `copilot` | `scalytics-copilot` |
+| `grok` | `xai` |
+
+## Model String Format
+
+All model references use the format `provider-id/model-name`:
+
+```
+claude/claude-opus-4-6
+openai/gpt-4o
+groq/llama-3.3-70b
+openrouter/anthropic/claude-sonnet-4-5   # three segments for OpenRouter
+```
+
+A bare model name without a provider prefix (e.g. `gpt-4o`) falls back to the legacy OpenAI provider path.
+
+## Authentication
+
+### API Key Providers
+
+Store an API key:
+
+```bash
+kafclaw models auth set-key --provider claude --key sk-ant-...
+kafclaw models auth set-key --provider openai --key sk-...
+kafclaw models auth set-key --provider gemini --key AIza...
+kafclaw models auth set-key --provider xai --key xai-...
+kafclaw models auth set-key --provider openrouter --key sk-or-...
+kafclaw models auth set-key --provider deepseek --key sk-...
+kafclaw models auth set-key --provider groq --key gsk_...
+```
+
+For providers that need a custom base URL:
+
+```bash
+kafclaw models auth set-key --provider scalytics-copilot --key <token> --base https://copilot.scalytics.io/v1
+kafclaw models auth set-key --provider vllm --key <optional> --base http://localhost:8000/v1
+```
+
+API keys can also be set via config:
+
+```bash
+kafclaw config set providers.anthropic.apiKey sk-ant-...
+kafclaw config set providers.openai.apiKey sk-...
+```
+
+### OAuth Providers
+
+Gemini and Codex use CLI-based OAuth:
+
+```bash
+kafclaw models auth login --provider gemini
+kafclaw models auth login --provider openai-codex
+```
+
+This installs the provider CLI if absent, then delegates to its auth flow. Credentials are cached by the respective CLI and read at runtime.
+
+## Provider Resolution
+
+When KafClaw needs an LLM provider, it resolves in this order:
+
+1. **Per-agent model** (`agents.list[].model.primary`) — highest priority
+2. **Task-type routing** (`model.taskRouting[category]`) — if no per-agent model is set
+3. **Global model** (`model.name`) — default fallback
+4. **Legacy OpenAI** (`providers.openai`) — backward compatibility
+
+### Per-Agent Configuration
+
+```json
+{
+  "agents": {
+    "list": [
+      {
+        "id": "main",
+        "model": {
+          "primary": "claude/claude-opus-4-6",
+          "fallbacks": ["openai/gpt-4o", "groq/llama-3.3-70b"]
+        },
+        "subagents": {
+          "model": "groq/llama-3.3-70b"
+        }
+      }
+    ]
+  }
+}
+```
+
+### Task-Type Routing
+
+Route messages to different models based on content classification:
+
+```json
+{
+  "model": {
+    "name": "claude/claude-sonnet-4-5",
+    "taskRouting": {
+      "security": "claude/claude-opus-4-6",
+      "coding": "openai-codex/gpt-5.3-codex",
+      "creative": "openai/gpt-4o",
+      "tool-heavy": "openai-codex/gpt-5.3-codex"
+    }
+  }
+}
+```
+
+Task categories are detected automatically from message content: `security`, `coding`, `tool-heavy`, `creative`.
+
+### Fallback Chains
+
+When the primary provider returns a transient error, fallbacks are tried in order:
+
+```json
+{
+  "model": {
+    "primary": "claude/claude-opus-4-6",
+    "fallbacks": [
+      "openai/gpt-4o",
+      "deepseek/deepseek-chat"
+    ]
+  }
+}
+```
+
+### Subagent Model Inheritance
+
+Subagents resolve their model in this order:
+
+1. `agents.list[parentID].subagents.model`
+2. `tools.subagents.model` (global subagent default)
+3. Inherit parent agent's resolved model
+
+## Rate Limits
+
+Rate limit data is extracted from provider response headers (both OpenAI-style `x-ratelimit-*` and Anthropic-style `anthropic-ratelimit-*` headers) and cached in memory per provider.
+
+View current rate limit snapshots:
+
+```bash
+kafclaw models stats
+kafclaw status
+```
+
+`kafclaw doctor` warns when any provider's remaining tokens drop below 10% of its limit.
+
+## Verifying Setup
+
+```bash
+# List all configured providers
+kafclaw models list
+
+# Check provider health
+kafclaw doctor
+
+# View today's usage per provider
+kafclaw models stats
+
+# Multi-day trend
+kafclaw models stats --days 7
+```
+
+## Related Docs
+
+- [Models CLI Reference](models-cli/)
+- [Middleware Configuration](middleware/)
+- [Configuration Keys](config-keys/)

--- a/docs/start-here/getting-started.md
+++ b/docs/start-here/getting-started.md
@@ -106,7 +106,7 @@ Onboarding does three things:
 You will be asked for:
 
 - runtime mode: `local`, `local-kafka`, or `remote`
-- LLM setup: `cli-token`, `openai-compatible`, or `skip`
+- LLM setup: `claude`, `openai`, `gemini`, `gemini-cli`, `openai-codex`, `xai`, `scalytics-copilot`, `openrouter`, `deepseek`, `groq`, `openai-compatible`, `cli-token`, or `skip`
 
 Before writing config, onboarding shows a summary and asks for confirmation.
 
@@ -161,26 +161,52 @@ Remote + Ollama/vLLM:
 
 ### LLM Provider Setup (Interactive)
 
-Yes, token setup is supported interactively via onboarding.
-
 Run:
 
 ```bash
 ./kafclaw onboard
 ```
 
-Then choose one of:
+Then choose your LLM provider:
 
-- `cli-token`:
-  - prompts for API token (interactive)
-  - uses OpenAI-compatible provider path
-  - defaults API base to `https://openrouter.ai/api/v1`
-- `openai-compatible`:
-  - prompts for API base (required)
-  - prompts for API token (optional)
-  - useful for Ollama/vLLM/self-hosted gateways
-- `skip`:
-  - keeps current provider settings
+**API key providers** — prompts for API key, sets model and base URL automatically:
+- `claude` — Anthropic Claude (default model: `claude/claude-sonnet-4-5`)
+- `openai` — OpenAI (default model: `openai/gpt-4o`)
+- `gemini` — Google Gemini via API key (default model: `gemini/gemini-2.5-pro`)
+- `xai` — xAI/Grok (default model: `xai/grok-3`)
+- `openrouter` — OpenRouter (default model: `openrouter/anthropic/claude-sonnet-4-5`)
+- `deepseek` — DeepSeek (default model: `deepseek/deepseek-chat`)
+- `groq` — Groq (default model: `groq/llama-3.3-70b-versatile`)
+- `scalytics-copilot` — Scalytics Copilot (prompts for base URL)
+
+**OAuth providers** — delegates to CLI auth flow:
+- `gemini-cli` — Google Gemini via CLI OAuth
+- `openai-codex` — OpenAI Codex via CLI OAuth
+
+**Generic / Legacy:**
+- `cli-token` — prompts for API token, defaults to OpenRouter base
+- `openai-compatible` — prompts for API base and token (Ollama/vLLM/self-hosted)
+- `skip` — keeps current provider settings
+
+### Post-Onboarding Provider Management
+
+After onboarding, manage providers with the `models` command:
+
+```bash
+# List configured providers
+kafclaw models list
+
+# Add another provider
+kafclaw models auth set-key --provider groq --key gsk_...
+
+# OAuth login
+kafclaw models auth login --provider gemini
+
+# Check usage
+kafclaw models stats
+```
+
+See [LLM Providers](../reference/providers/) and [Models CLI](../reference/models-cli/) for full details.
 
 To reconfigure provider/token later, run onboarding again (interactive) or use:
 

--- a/electron/src/main/remote-client.ts
+++ b/electron/src/main/remote-client.ts
@@ -6,6 +6,8 @@ export interface RemoteConnection {
   name: string;
   url: string;
   token: string;
+  /** Set to true only for self-signed dev servers. Default: false (certs verified). */
+  allowInsecureTLS?: boolean;
 }
 
 export class RemoteClient {
@@ -62,7 +64,7 @@ export class RemoteClient {
           'Accept': 'application/json',
         },
         timeout: 10000,
-        rejectUnauthorized: false,
+        rejectUnauthorized: conn.allowInsecureTLS !== true,
       }, (res) => {
         let body = '';
         res.on('data', (chunk: Buffer) => { body += chunk.toString(); });

--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -164,7 +164,7 @@ func (b *ContextBuilder) loadMemory() string {
 		base = filepath.Join(home, base[1:])
 	}
 
-	path := filepath.Join(base, "memory", "MEMORY.md")
+	path := filepath.Clean(filepath.Join(base, "memory", "MEMORY.md"))
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return ""

--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -165,6 +165,9 @@ func (b *ContextBuilder) loadMemory() string {
 	}
 
 	path := filepath.Clean(filepath.Join(base, "memory", "MEMORY.md"))
+	if strings.Contains(path, "..") {
+		return ""
+	}
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return ""

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -49,17 +49,16 @@ func runAgent(cmd *cobra.Command, args []string) {
 
 	// Setup components
 	msgBus := bus.NewMessageBus()
-	oaProv := provider.NewOpenAIProvider(cfg.Providers.OpenAI.APIKey, cfg.Providers.OpenAI.APIBase, cfg.Model.Name)
-	var prov provider.LLMProvider = oaProv
-
-	if cfg.Providers.LocalWhisper.Enabled {
-		prov = provider.NewLocalWhisperProvider(cfg.Providers.LocalWhisper, oaProv)
+	prov, err := provider.Resolve(cfg, "main")
+	if err != nil {
+		fmt.Printf("Provider error: %v\n", err)
+		os.Exit(1)
 	}
 
-	// Check API Key
-	if cfg.Providers.OpenAI.APIKey == "" {
-		fmt.Println("Error: API key not found. Set KAFCLAW_OPENAI_API_KEY / OPENROUTER_API_KEY (legacy: MIKROBOT_OPENAI_API_KEY) or use config.json")
-		os.Exit(1)
+	if cfg.Providers.LocalWhisper.Enabled {
+		if oaProv, ok := prov.(*provider.OpenAIProvider); ok {
+			prov = provider.NewLocalWhisperProvider(cfg.Providers.LocalWhisper, oaProv)
+		}
 	}
 
 	loop := agent.NewLoop(agent.LoopOptions{

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -79,6 +79,7 @@ func runAgent(cmd *cobra.Command, args []string) {
 		SubagentThinking:      cfg.Tools.Subagents.Thinking,
 		SubagentToolsAllow:    cfg.Tools.Subagents.Tools.Allow,
 		SubagentToolsDeny:     cfg.Tools.Subagents.Tools.Deny,
+		Config:                cfg,
 	})
 
 	fmt.Printf("🤖 KafClaw (%s)\n", cfg.Model.Name)

--- a/internal/cli/gateway.go
+++ b/internal/cli/gateway.go
@@ -422,6 +422,7 @@ func runGatewayMain(cmd *cobra.Command, args []string) {
 		SubagentThinking:      cfg.Tools.Subagents.Thinking,
 		SubagentToolsAllow:    cfg.Tools.Subagents.Tools.Allow,
 		SubagentToolsDeny:     cfg.Tools.Subagents.Tools.Deny,
+		Config:                cfg,
 	})
 
 	// 5b. Index soul files (non-blocking background)

--- a/internal/cli/gateway.go
+++ b/internal/cli/gateway.go
@@ -125,11 +125,16 @@ func runGatewayMain(cmd *cobra.Command, args []string) {
 	msgBus := bus.NewMessageBus()
 
 	// 4. Setup Providers
-	oaProv := provider.NewOpenAIProvider(cfg.Providers.OpenAI.APIKey, cfg.Providers.OpenAI.APIBase, cfg.Model.Name)
-	var prov provider.LLMProvider = oaProv
+	prov, provErr := provider.Resolve(cfg, "main")
+	if provErr != nil {
+		fmt.Printf("Provider error: %v\n", provErr)
+		os.Exit(1)
+	}
 
 	if cfg.Providers.LocalWhisper.Enabled {
-		prov = provider.NewLocalWhisperProvider(cfg.Providers.LocalWhisper, oaProv)
+		if oaProv, ok := prov.(*provider.OpenAIProvider); ok {
+			prov = provider.NewLocalWhisperProvider(cfg.Providers.LocalWhisper, oaProv)
+		}
 	}
 
 	// 4b. Setup Policy Engine

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -1,0 +1,337 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+	"github.com/KafClaw/KafClaw/internal/provider"
+	"github.com/KafClaw/KafClaw/internal/provider/clinst"
+	"github.com/KafClaw/KafClaw/internal/provider/credentials"
+	"github.com/KafClaw/KafClaw/internal/timeline"
+	"github.com/spf13/cobra"
+)
+
+var modelsCmd = &cobra.Command{
+	Use:   "models",
+	Short: "Manage LLM providers and models",
+}
+
+// --- auth subgroup ---
+
+var modelsAuthCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Manage provider authentication",
+}
+
+var (
+	authLoginProvider string
+)
+
+var modelsAuthLoginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Authenticate with an OAuth-based provider",
+	Run:   runModelsAuthLogin,
+}
+
+var (
+	setKeyProvider string
+	setKeyValue    string
+	setKeyBase     string
+)
+
+var modelsAuthSetKeyCmd = &cobra.Command{
+	Use:   "set-key",
+	Short: "Store an API key for a provider",
+	Run:   runModelsAuthSetKey,
+}
+
+// --- list ---
+
+var modelsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Show configured providers and active model per agent",
+	Run:   runModelsList,
+}
+
+// --- stats ---
+
+var (
+	statsDays int
+	statsJSON bool
+)
+
+var modelsStatsCmd = &cobra.Command{
+	Use:   "stats",
+	Short: "Show token usage statistics",
+	Run:   runModelsStats,
+}
+
+func init() {
+	modelsAuthLoginCmd.Flags().StringVar(&authLoginProvider, "provider", "", "Provider to authenticate with (gemini, openai-codex)")
+	_ = modelsAuthLoginCmd.MarkFlagRequired("provider")
+
+	modelsAuthSetKeyCmd.Flags().StringVar(&setKeyProvider, "provider", "", "Provider ID (claude, openai, gemini, xai, scalytics-copilot, openrouter, deepseek, groq, vllm)")
+	modelsAuthSetKeyCmd.Flags().StringVar(&setKeyValue, "key", "", "API key or bearer token")
+	modelsAuthSetKeyCmd.Flags().StringVar(&setKeyBase, "base", "", "Base URL (required for scalytics-copilot, vllm)")
+	_ = modelsAuthSetKeyCmd.MarkFlagRequired("provider")
+	_ = modelsAuthSetKeyCmd.MarkFlagRequired("key")
+
+	modelsAuthCmd.AddCommand(modelsAuthLoginCmd)
+	modelsAuthCmd.AddCommand(modelsAuthSetKeyCmd)
+
+	modelsStatsCmd.Flags().IntVar(&statsDays, "days", 0, "Show per-day per-provider trend for N days")
+	modelsStatsCmd.Flags().BoolVar(&statsJSON, "json", false, "Output in JSON format")
+
+	modelsCmd.AddCommand(modelsAuthCmd)
+	modelsCmd.AddCommand(modelsListCmd)
+	modelsCmd.AddCommand(modelsStatsCmd)
+
+	rootCmd.AddCommand(modelsCmd)
+}
+
+// --- auth login ---
+
+func runModelsAuthLogin(_ *cobra.Command, _ []string) {
+	provID := strings.ToLower(strings.TrimSpace(authLoginProvider))
+	switch provID {
+	case "gemini", "gemini-cli":
+		if err := clinst.EnsureGeminiCLI(); err != nil {
+			fmt.Printf("Error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Running: gemini auth login")
+		cmd := exec.Command("gemini", "auth", "login")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Error: gemini auth login failed: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Gemini CLI authentication complete.")
+
+	case "openai-codex", "codex":
+		if err := clinst.EnsureCodexCLI(); err != nil {
+			fmt.Printf("Error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Running: codex auth")
+		cmd := exec.Command("codex", "auth")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Error: codex auth failed: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Codex CLI authentication complete.")
+
+	default:
+		fmt.Printf("Error: OAuth login is only supported for gemini and openai-codex. For API key providers, use: kafclaw models auth set-key --provider %s --key <token>\n", provID)
+		os.Exit(1)
+	}
+}
+
+// --- auth set-key ---
+
+var apiKeyProviders = map[string]bool{
+	"claude": true, "openai": true, "gemini": true, "xai": true,
+	"scalytics-copilot": true, "openrouter": true, "deepseek": true,
+	"groq": true, "vllm": true,
+}
+
+func runModelsAuthSetKey(_ *cobra.Command, _ []string) {
+	provID := strings.ToLower(strings.TrimSpace(setKeyProvider))
+	provID = provider.NormalizeProviderID(provID, nil)
+
+	if !apiKeyProviders[provID] {
+		fmt.Printf("Error: unknown or non-API-key provider %q\n", provID)
+		os.Exit(1)
+	}
+
+	if (provID == "scalytics-copilot" || provID == "vllm") && setKeyBase == "" {
+		fmt.Printf("Error: --base is required for provider %s\n", provID)
+		os.Exit(1)
+	}
+
+	if err := credentials.SaveAPIKey(provID, setKeyValue); err != nil {
+		fmt.Printf("Error storing API key: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Also write base URL to config if provided.
+	if setKeyBase != "" {
+		cfg, err := config.Load()
+		if err != nil {
+			fmt.Printf("Warning: could not load config to set base URL: %v\n", err)
+		} else {
+			switch provID {
+			case "scalytics-copilot":
+				cfg.Providers.ScalyticsCopilot.APIBase = setKeyBase
+			case "vllm":
+				cfg.Providers.VLLM.APIBase = setKeyBase
+			}
+			if saveErr := config.Save(cfg); saveErr != nil {
+				fmt.Printf("Warning: could not save config: %v\n", saveErr)
+			}
+		}
+	}
+
+	fmt.Printf("API key for %s stored successfully.\n", provID)
+}
+
+// --- list ---
+
+func runModelsList(_ *cobra.Command, _ []string) {
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Printf("Config warning: %v\n", err)
+	}
+
+	fmt.Println("Configured Providers:")
+	fmt.Println()
+
+	providerStatus := []struct {
+		ID     string
+		HasKey bool
+		Base   string
+	}{
+		{"claude", cfg.Providers.Anthropic.APIKey != "", cfg.Providers.Anthropic.APIBase},
+		{"openai", cfg.Providers.OpenAI.APIKey != "", cfg.Providers.OpenAI.APIBase},
+		{"gemini", cfg.Providers.Gemini.APIKey != "", ""},
+		{"gemini-cli", false, "(OAuth via CLI)"},
+		{"openai-codex", false, "(OAuth via CLI)"},
+		{"xai", cfg.Providers.XAI.APIKey != "", xaiBase()},
+		{"scalytics-copilot", cfg.Providers.ScalyticsCopilot.APIKey != "", cfg.Providers.ScalyticsCopilot.APIBase},
+		{"openrouter", cfg.Providers.OpenRouter.APIKey != "", cfg.Providers.OpenRouter.APIBase},
+		{"deepseek", cfg.Providers.DeepSeek.APIKey != "", cfg.Providers.DeepSeek.APIBase},
+		{"groq", cfg.Providers.Groq.APIKey != "", cfg.Providers.Groq.APIBase},
+		{"vllm", cfg.Providers.VLLM.APIKey != "" || cfg.Providers.VLLM.APIBase != "", cfg.Providers.VLLM.APIBase},
+	}
+
+	for _, ps := range providerStatus {
+		status := "not configured"
+		if ps.HasKey {
+			status = "configured"
+		}
+		if ps.Base == "(OAuth via CLI)" {
+			status = "OAuth"
+		}
+		base := ""
+		if ps.Base != "" && ps.Base != "(OAuth via CLI)" {
+			base = fmt.Sprintf("  base: %s", ps.Base)
+		}
+		fmt.Printf("  %-20s %s%s\n", ps.ID, status, base)
+	}
+
+	fmt.Println()
+	fmt.Printf("Global model: %s\n", cfg.Model.Name)
+
+	if cfg.Agents != nil {
+		for _, entry := range cfg.Agents.List {
+			if entry.Model != nil && entry.Model.Primary != "" {
+				fmt.Printf("Agent %-12s model: %s\n", entry.ID, entry.Model.Primary)
+				for i, fb := range entry.Model.Fallbacks {
+					fmt.Printf("  fallback[%d]: %s\n", i, fb)
+				}
+			}
+			if entry.Subagents != nil && entry.Subagents.Model != "" {
+				fmt.Printf("  subagent model: %s\n", entry.Subagents.Model)
+			}
+		}
+	}
+}
+
+func xaiBase() string {
+	return "https://api.x.ai/v1"
+}
+
+// --- stats ---
+
+func runModelsStats(_ *cobra.Command, _ []string) {
+	home, _ := os.UserHomeDir()
+	timelinePath := filepath.Join(home, ".kafclaw", "timeline.db")
+	tl, err := timeline.NewTimelineService(timelinePath)
+	if err != nil {
+		fmt.Printf("Error opening timeline: %v\n", err)
+		os.Exit(1)
+	}
+
+	if statsDays > 0 {
+		summary, err := tl.GetTokenUsageSummary(statsDays)
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+			os.Exit(1)
+		}
+		if statsJSON {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(summary)
+			return
+		}
+		fmt.Printf("%-15s %-12s %s\n", "PROVIDER", "DAY", "TOKENS")
+		for _, s := range summary {
+			fmt.Printf("%-15s %-12s %d\n", s.ProviderID, s.Day, s.Tokens)
+		}
+		return
+	}
+
+	// Today's usage by provider.
+	byProvider, err := tl.GetDailyTokenUsageByProvider()
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	totalToday, _ := tl.GetDailyTokenUsage()
+
+	if statsJSON {
+		out := map[string]any{
+			"today_total":       totalToday,
+			"today_by_provider": byProvider,
+			"rate_limits":       provider.AllRateLimitSnapshots(),
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(out)
+		return
+	}
+
+	fmt.Printf("Today's token usage: %d\n\n", totalToday)
+	if len(byProvider) > 0 {
+		fmt.Printf("%-20s %s\n", "PROVIDER", "TOKENS")
+		for prov, tokens := range byProvider {
+			fmt.Printf("%-20s %d\n", prov, tokens)
+		}
+	}
+
+	snapshots := provider.AllRateLimitSnapshots()
+	if len(snapshots) > 0 {
+		fmt.Println()
+		fmt.Printf("%-20s %-15s %-15s %-15s %s\n", "PROVIDER", "REMAINING TOK", "REMAINING REQ", "LIMIT TOK", "RESET")
+		for prov, snap := range snapshots {
+			rt := "-"
+			rr := "-"
+			lt := "-"
+			reset := "-"
+			if snap.RemainingTokens != nil {
+				rt = fmt.Sprintf("%d", *snap.RemainingTokens)
+			}
+			if snap.RemainingRequests != nil {
+				rr = fmt.Sprintf("%d", *snap.RemainingRequests)
+			}
+			if snap.LimitTokens != nil {
+				lt = fmt.Sprintf("%d", *snap.LimitTokens)
+			}
+			if snap.ResetAt != nil {
+				reset = snap.ResetAt.Format("15:04:05")
+			}
+			fmt.Printf("%-20s %-15s %-15s %-15s %s\n", prov, rt, rr, lt, reset)
+		}
+	}
+}

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -274,9 +274,13 @@ func runModelsStats(_ *cobra.Command, _ []string) {
 			_ = enc.Encode(summary)
 			return
 		}
-		fmt.Printf("%-15s %-12s %s\n", "PROVIDER", "DAY", "TOKENS")
+		fmt.Printf("%-15s %-12s %-10s %s\n", "PROVIDER", "DAY", "TOKENS", "COST")
 		for _, s := range summary {
-			fmt.Printf("%-15s %-12s %d\n", s.ProviderID, s.Day, s.Tokens)
+			costStr := "-"
+			if s.CostUSD > 0 {
+				costStr = fmt.Sprintf("$%.4f", s.CostUSD)
+			}
+			fmt.Printf("%-15s %-12s %-10d %s\n", s.ProviderID, s.Day, s.Tokens, costStr)
 		}
 		return
 	}
@@ -290,10 +294,13 @@ func runModelsStats(_ *cobra.Command, _ []string) {
 
 	totalToday, _ := tl.GetDailyTokenUsage()
 
+	costByProvider, _ := tl.GetDailyCostByProvider()
+
 	if statsJSON {
 		out := map[string]any{
 			"today_total":       totalToday,
 			"today_by_provider": byProvider,
+			"today_cost":        costByProvider,
 			"rate_limits":       provider.AllRateLimitSnapshots(),
 		}
 		enc := json.NewEncoder(os.Stdout)
@@ -304,9 +311,13 @@ func runModelsStats(_ *cobra.Command, _ []string) {
 
 	fmt.Printf("Today's token usage: %d\n\n", totalToday)
 	if len(byProvider) > 0 {
-		fmt.Printf("%-20s %s\n", "PROVIDER", "TOKENS")
+		fmt.Printf("%-20s %-10s %s\n", "PROVIDER", "TOKENS", "COST")
 		for prov, tokens := range byProvider {
-			fmt.Printf("%-20s %d\n", prov, tokens)
+			costStr := "-"
+			if c, ok := costByProvider[prov]; ok && c > 0 {
+				costStr = fmt.Sprintf("$%.4f", c)
+			}
+			fmt.Printf("%-20s %-10d %s\n", prov, tokens, costStr)
 		}
 	}
 

--- a/internal/cliconfig/doctor.go
+++ b/internal/cliconfig/doctor.go
@@ -224,6 +224,8 @@ func RunDoctorWithOptions(opts DoctorOptions) (DoctorReport, error) {
 		})
 	}
 
+	appendProviderDoctorChecks(&report, cfg)
+
 	mode := detectRuntimeMode(cfg)
 	report.Checks = append(report.Checks, DoctorCheck{
 		Name:    "runtime_mode",
@@ -765,6 +767,117 @@ func endpointLooksRemote(endpoint string) bool {
 		host = strings.TrimSpace(e)
 	}
 	return !isLoopbackHost(host)
+}
+
+func appendProviderDoctorChecks(report *DoctorReport, cfg *config.Config) {
+	if cfg == nil {
+		return
+	}
+
+	// Determine which provider is needed from model.name
+	modelStr := cfg.Model.Name
+	if modelStr == "" {
+		report.Checks = append(report.Checks, DoctorCheck{
+			Name:    "provider_model",
+			Status:  DoctorWarn,
+			Message: "model.name is empty — using legacy OpenAI fallback",
+		})
+		// Check if legacy OpenAI is configured
+		if cfg.Providers.OpenAI.APIKey == "" {
+			report.Checks = append(report.Checks, DoctorCheck{
+				Name:    "provider_openai",
+				Status:  DoctorFail,
+				Message: "no model configured and providers.openai.apiKey is empty",
+			})
+		} else {
+			report.Checks = append(report.Checks, DoctorCheck{
+				Name:    "provider_openai",
+				Status:  DoctorPass,
+				Message: "legacy OpenAI fallback: API key is configured",
+			})
+		}
+		return
+	}
+
+	report.Checks = append(report.Checks, DoctorCheck{
+		Name:    "provider_model",
+		Status:  DoctorPass,
+		Message: fmt.Sprintf("model.name: %s", modelStr),
+	})
+
+	// Check each configured provider's readiness
+	type provCheck struct {
+		id      string
+		hasKey  bool
+		hasBase bool
+		needKey bool
+	}
+	checks := []provCheck{
+		{"claude", cfg.Providers.Anthropic.APIKey != "", cfg.Providers.Anthropic.APIBase != "", true},
+		{"openai", cfg.Providers.OpenAI.APIKey != "", cfg.Providers.OpenAI.APIBase != "", true},
+		{"gemini", cfg.Providers.Gemini.APIKey != "", false, true},
+		{"xai", cfg.Providers.XAI.APIKey != "", false, true},
+		{"openrouter", cfg.Providers.OpenRouter.APIKey != "", cfg.Providers.OpenRouter.APIBase != "", true},
+		{"deepseek", cfg.Providers.DeepSeek.APIKey != "", cfg.Providers.DeepSeek.APIBase != "", true},
+		{"groq", cfg.Providers.Groq.APIKey != "", cfg.Providers.Groq.APIBase != "", true},
+		{"scalytics-copilot", cfg.Providers.ScalyticsCopilot.APIKey != "", cfg.Providers.ScalyticsCopilot.APIBase != "", true},
+		{"vllm", cfg.Providers.VLLM.APIKey != "", cfg.Providers.VLLM.APIBase != "", false},
+	}
+
+	configured := 0
+	for _, pc := range checks {
+		if pc.hasKey || (pc.id == "vllm" && pc.hasBase) {
+			configured++
+		}
+	}
+
+	if configured == 0 {
+		report.Checks = append(report.Checks, DoctorCheck{
+			Name:    "provider_configured",
+			Status:  DoctorWarn,
+			Message: "no API-key providers configured — only CLI-OAuth providers (gemini-cli, openai-codex) may work",
+		})
+	} else {
+		report.Checks = append(report.Checks, DoctorCheck{
+			Name:    "provider_configured",
+			Status:  DoctorPass,
+			Message: fmt.Sprintf("%d provider(s) with credentials configured", configured),
+		})
+	}
+
+	// Validate scalytics-copilot requires base URL
+	if cfg.Providers.ScalyticsCopilot.APIKey != "" && cfg.Providers.ScalyticsCopilot.APIBase == "" {
+		report.Checks = append(report.Checks, DoctorCheck{
+			Name:    "provider_scalytics_copilot_base",
+			Status:  DoctorFail,
+			Message: "scalytics-copilot has API key but missing apiBase (required)",
+		})
+	}
+
+	// Validate vLLM requires base URL
+	if cfg.Providers.VLLM.APIKey != "" && cfg.Providers.VLLM.APIBase == "" {
+		report.Checks = append(report.Checks, DoctorCheck{
+			Name:    "provider_vllm_base",
+			Status:  DoctorFail,
+			Message: "vllm has API key but missing apiBase (required)",
+		})
+	}
+
+	// Check CLI tools for OAuth providers
+	if skillruntime.HasBinary("gemini") {
+		report.Checks = append(report.Checks, DoctorCheck{
+			Name:    "provider_gemini_cli",
+			Status:  DoctorPass,
+			Message: "gemini CLI found in PATH",
+		})
+	}
+	if skillruntime.HasBinary("codex") {
+		report.Checks = append(report.Checks, DoctorCheck{
+			Name:    "provider_codex_cli",
+			Status:  DoctorPass,
+			Message: "codex CLI found in PATH",
+		})
+	}
 }
 
 func detectRuntimeMode(cfg *config.Config) RuntimeMode {

--- a/internal/cliconfig/doctor.go
+++ b/internal/cliconfig/doctor.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/KafClaw/KafClaw/internal/channels"
 	"github.com/KafClaw/KafClaw/internal/config"
+	"github.com/KafClaw/KafClaw/internal/provider"
 	skillruntime "github.com/KafClaw/KafClaw/internal/skills"
 )
 
@@ -302,6 +303,7 @@ func RunDoctorWithOptions(opts DoctorOptions) (DoctorReport, error) {
 		})
 	}
 
+	appendRateLimitDoctorChecks(&report)
 	appendSkillsDoctorChecks(&report, cfg, opts)
 
 	return report, nil
@@ -877,6 +879,25 @@ func appendProviderDoctorChecks(report *DoctorReport, cfg *config.Config) {
 			Status:  DoctorPass,
 			Message: "codex CLI found in PATH",
 		})
+	}
+}
+
+func appendRateLimitDoctorChecks(report *DoctorReport) {
+	snapshots := provider.AllRateLimitSnapshots()
+	if len(snapshots) == 0 {
+		return
+	}
+	for provID, snap := range snapshots {
+		if snap.RemainingTokens != nil && snap.LimitTokens != nil && *snap.LimitTokens > 0 {
+			pct := float64(*snap.RemainingTokens) / float64(*snap.LimitTokens) * 100
+			if pct < 10 {
+				report.Checks = append(report.Checks, DoctorCheck{
+					Name:    fmt.Sprintf("rate_limit_%s", provID),
+					Status:  DoctorWarn,
+					Message: fmt.Sprintf("%s: only %d/%d tokens remaining (%.0f%%)", provID, *snap.RemainingTokens, *snap.LimitTokens, pct),
+				})
+			}
+		}
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -188,14 +188,16 @@ type MSTeamsAccountConfig struct {
 
 // ProvidersConfig contains LLM provider configurations.
 type ProvidersConfig struct {
-	Anthropic    ProviderConfig     `json:"anthropic"`
-	OpenAI       ProviderConfig     `json:"openai"`
-	LocalWhisper LocalWhisperConfig `json:"localWhisper"`
-	OpenRouter   ProviderConfig     `json:"openrouter"`
-	DeepSeek     ProviderConfig     `json:"deepseek"`
-	Groq         ProviderConfig     `json:"groq"`
-	Gemini       ProviderConfig     `json:"gemini"`
-	VLLM         ProviderConfig     `json:"vllm"`
+	Anthropic       ProviderConfig     `json:"anthropic"`
+	OpenAI          ProviderConfig     `json:"openai"`
+	LocalWhisper    LocalWhisperConfig `json:"localWhisper"`
+	OpenRouter      ProviderConfig     `json:"openrouter"`
+	DeepSeek        ProviderConfig     `json:"deepseek"`
+	Groq            ProviderConfig     `json:"groq"`
+	Gemini          ProviderConfig     `json:"gemini"`
+	VLLM            ProviderConfig     `json:"vllm"`
+	XAI             ProviderConfig     `json:"xai"`
+	ScalyticsCopilot ProviderConfig    `json:"scalyticsCopilot"`
 }
 
 // ProviderConfig contains settings for a single LLM provider.
@@ -289,11 +291,24 @@ type AgentDefaultsConfig struct {
 	Subagents SubagentsToolConfig `json:"subagents"`
 }
 
+// AgentModelSpec configures the primary model and fallbacks for an agent.
+type AgentModelSpec struct {
+	Primary   string   `json:"primary"`
+	Fallbacks []string `json:"fallbacks,omitempty"`
+}
+
+// AgentSubagentSpec configures the model for subagents spawned by an agent.
+type AgentSubagentSpec struct {
+	Model string `json:"model"`
+}
+
 // AgentListEntry describes a configured agent identity.
 type AgentListEntry struct {
-	ID      string `json:"id"`
-	Name    string `json:"name,omitempty"`
-	Default bool   `json:"default,omitempty"`
+	ID        string             `json:"id"`
+	Name      string             `json:"name,omitempty"`
+	Default   bool               `json:"default,omitempty"`
+	Model     *AgentModelSpec    `json:"model,omitempty"`
+	Subagents *AgentSubagentSpec `json:"subagents,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,23 +6,23 @@ import "time"
 // Config is the root configuration struct.
 // Top-level groups: Paths, Model, Channels, Providers, Gateway, Tools.
 type Config struct {
-	Paths                 PathsConfig                `json:"paths"`
-	Model                 ModelConfig                `json:"model"`
-	Agents                *AgentsConfig              `json:"agents,omitempty"`
-	Channels              ChannelsConfig             `json:"channels"`
-	Providers             ProvidersConfig            `json:"providers"`
-	Gateway               GatewayConfig              `json:"gateway"`
-	Tools                 ToolsConfig                `json:"tools"`
-	Skills                SkillsConfig               `json:"skills"`
-	Group                 GroupConfig                `json:"group"`
-	Orchestrator          OrchestratorConfig         `json:"orchestrator"`
-	Scheduler             SchedulerConfig            `json:"scheduler"`
-	ER1                   ER1IntegrationConfig       `json:"er1"`
-	Observer              ObserverMemoryConfig       `json:"observer"`
+	Paths                 PathsConfig                 `json:"paths"`
+	Model                 ModelConfig                 `json:"model"`
+	Agents                *AgentsConfig               `json:"agents,omitempty"`
+	Channels              ChannelsConfig              `json:"channels"`
+	Providers             ProvidersConfig             `json:"providers"`
+	Gateway               GatewayConfig               `json:"gateway"`
+	Tools                 ToolsConfig                 `json:"tools"`
+	Skills                SkillsConfig                `json:"skills"`
+	Group                 GroupConfig                 `json:"group"`
+	Orchestrator          OrchestratorConfig          `json:"orchestrator"`
+	Scheduler             SchedulerConfig             `json:"scheduler"`
+	ER1                   ER1IntegrationConfig        `json:"er1"`
+	Observer              ObserverMemoryConfig        `json:"observer"`
 	ContentClassification ContentClassificationConfig `json:"contentClassification"`
-	PromptGuard           PromptGuardConfig          `json:"promptGuard"`
-	OutputSanitization    OutputSanitizationConfig   `json:"outputSanitization"`
-	FinOps                FinOpsConfig               `json:"finops"`
+	PromptGuard           PromptGuardConfig           `json:"promptGuard"`
+	OutputSanitization    OutputSanitizationConfig    `json:"outputSanitization"`
+	FinOps                FinOpsConfig                `json:"finops"`
 }
 
 // ---------------------------------------------------------------------------
@@ -193,16 +193,16 @@ type MSTeamsAccountConfig struct {
 
 // ProvidersConfig contains LLM provider configurations.
 type ProvidersConfig struct {
-	Anthropic       ProviderConfig     `json:"anthropic"`
-	OpenAI          ProviderConfig     `json:"openai"`
-	LocalWhisper    LocalWhisperConfig `json:"localWhisper"`
-	OpenRouter      ProviderConfig     `json:"openrouter"`
-	DeepSeek        ProviderConfig     `json:"deepseek"`
-	Groq            ProviderConfig     `json:"groq"`
-	Gemini          ProviderConfig     `json:"gemini"`
-	VLLM            ProviderConfig     `json:"vllm"`
-	XAI             ProviderConfig     `json:"xai"`
-	ScalyticsCopilot ProviderConfig    `json:"scalyticsCopilot"`
+	Anthropic        ProviderConfig     `json:"anthropic"`
+	OpenAI           ProviderConfig     `json:"openai"`
+	LocalWhisper     LocalWhisperConfig `json:"localWhisper"`
+	OpenRouter       ProviderConfig     `json:"openrouter"`
+	DeepSeek         ProviderConfig     `json:"deepseek"`
+	Groq             ProviderConfig     `json:"groq"`
+	Gemini           ProviderConfig     `json:"gemini"`
+	VLLM             ProviderConfig     `json:"vllm"`
+	XAI              ProviderConfig     `json:"xai"`
+	ScalyticsCopilot ProviderConfig     `json:"scalyticsCopilot"`
 }
 
 // ProviderConfig contains settings for a single LLM provider.
@@ -462,12 +462,12 @@ type SecretsConfig struct {
 
 // OutputSanitizationConfig controls post-LLM response filtering.
 type OutputSanitizationConfig struct {
-	Enabled             bool           `json:"enabled"`
-	RedactPII           bool           `json:"redactPII"`
-	RedactSecrets       bool           `json:"redactSecrets"`
+	Enabled              bool           `json:"enabled"`
+	RedactPII            bool           `json:"redactPII"`
+	RedactSecrets        bool           `json:"redactSecrets"`
 	CustomRedactPatterns []NamedPattern `json:"customRedactPatterns,omitempty"`
-	DenyPatterns        []string       `json:"denyPatterns,omitempty"`
-	MaxOutputLength     int            `json:"maxOutputLength,omitempty"`
+	DenyPatterns         []string       `json:"denyPatterns,omitempty"`
+	MaxOutputLength      int            `json:"maxOutputLength,omitempty"`
 }
 
 // ProviderPricing holds per-1k-token pricing for a provider.

--- a/internal/config/work_repo.go
+++ b/internal/config/work_repo.go
@@ -14,6 +14,7 @@ func EnsureWorkRepo(path string) (string, error) {
 	if path == "" {
 		return "", fmt.Errorf("work repo path is empty")
 	}
+	path = filepath.Clean(path)
 	if err := os.MkdirAll(path, 0755); err != nil {
 		return "", err
 	}

--- a/internal/config/work_repo.go
+++ b/internal/config/work_repo.go
@@ -14,15 +14,17 @@ func EnsureWorkRepo(path string) (string, error) {
 	if path == "" {
 		return "", fmt.Errorf("work repo path is empty")
 	}
-	path = filepath.Clean(path)
+	path, err := sanitizeRepoPath(path)
+	if err != nil {
+		return "", err
+	}
 	if err := os.MkdirAll(path, 0755); err != nil {
 		return "", err
 	}
 	// Ensure standard artifact directories exist.
-	_ = os.MkdirAll(filepath.Join(path, "requirements"), 0755)
-	_ = os.MkdirAll(filepath.Join(path, "tasks"), 0755)
-	_ = os.MkdirAll(filepath.Join(path, "docs"), 0755)
-	_ = os.MkdirAll(filepath.Join(path, "memory"), 0755)
+	for _, sub := range []string{"requirements", "tasks", "docs", "memory"} {
+		_ = os.MkdirAll(filepath.Join(path, sub), 0755)
+	}
 
 	gitDir := filepath.Join(path, ".git")
 	if _, err := os.Stat(gitDir); err == nil {
@@ -60,4 +62,16 @@ func ResolveArtifactPath(workRepoPath, kind, filename string) (string, error) {
 		filename = "artifact.md"
 	}
 	return filepath.Join(workRepoPath, k, filename), nil
+}
+
+// sanitizeRepoPath resolves the path to an absolute form and rejects traversal.
+func sanitizeRepoPath(p string) (string, error) {
+	abs, err := filepath.Abs(filepath.Clean(p))
+	if err != nil {
+		return "", fmt.Errorf("invalid repo path: %w", err)
+	}
+	if strings.Contains(abs, "..") {
+		return "", fmt.Errorf("path traversal in repo path")
+	}
+	return abs, nil
 }

--- a/internal/group/lfsclient.go
+++ b/internal/group/lfsclient.go
@@ -14,21 +14,33 @@ import (
 
 // LFSClient wraps the KafScale LFS Proxy HTTP API for producing messages to Kafka.
 type LFSClient struct {
-	parsedBase *url.URL
+	baseURL    string // validated http(s) URL, no trailing slash
 	apiKey     string
 	httpClient *http.Client
 }
 
 // NewLFSClient creates a new LFS proxy client.
-// The baseURL is parsed and validated at construction time.
+// The baseURL is parsed and validated at construction time; only http and https
+// schemes are accepted.
 func NewLFSClient(baseURL, apiKey string) *LFSClient {
 	u, err := url.Parse(strings.TrimRight(baseURL, "/"))
-	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
-		u = &url.URL{Scheme: "http", Host: "localhost:0"}
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return &LFSClient{
+			baseURL: "http://localhost:0",
+			apiKey:  apiKey,
+			httpClient: &http.Client{
+				Timeout: 30 * time.Second,
+			},
+		}
+	}
+	// Reconstruct from parsed parts to normalise.
+	safe := u.Scheme + "://" + u.Host
+	if u.Path != "" {
+		safe += u.Path
 	}
 	return &LFSClient{
-		parsedBase: u,
-		apiKey:     apiKey,
+		baseURL: safe,
+		apiKey:  apiKey,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
@@ -51,11 +63,15 @@ type LFSEnvelope struct {
 
 // Produce sends a message to the LFS proxy which produces it to the given Kafka topic.
 func (c *LFSClient) Produce(ctx context.Context, topic string, requestID string, payload []byte) (*LFSEnvelope, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://placeholder/lfs/produce", bytes.NewReader(payload))
+	endpoint := c.baseURL + "/lfs/produce"
+	if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
+		return nil, fmt.Errorf("lfs produce: invalid URL scheme")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
 	if err != nil {
 		return nil, fmt.Errorf("lfs produce: create request: %w", err)
 	}
-	req.URL = c.endpointURL("/lfs/produce")
 
 	req.Header.Set("X-Kafka-Topic", topic)
 	req.Header.Set("Content-Type", "application/json")
@@ -101,11 +117,15 @@ func (c *LFSClient) ProduceEnvelope(ctx context.Context, topic string, env *Grou
 
 // Healthy checks if the LFS proxy is reachable.
 func (c *LFSClient) Healthy(ctx context.Context) bool {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://placeholder/lfs/produce", nil)
+	endpoint := c.baseURL + "/lfs/produce"
+	if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
+		return false
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return false
 	}
-	req.URL = c.endpointURL("/lfs/produce")
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return false
@@ -113,12 +133,4 @@ func (c *LFSClient) Healthy(ctx context.Context) bool {
 	resp.Body.Close()
 	// The proxy returns 400 for GET (method not allowed or missing topic), but that means it's up.
 	return resp.StatusCode < 500
-}
-
-// endpointURL returns a *url.URL for the given API path, derived from the
-// pre-validated parsedBase. The returned URL is a copy, not a reference.
-func (c *LFSClient) endpointURL(path string) *url.URL {
-	u := *c.parsedBase // shallow copy
-	u.Path = strings.TrimRight(u.Path, "/") + path
-	return &u
 }

--- a/internal/group/lfsclient.go
+++ b/internal/group/lfsclient.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 )
 
@@ -19,8 +21,13 @@ type LFSClient struct {
 
 // NewLFSClient creates a new LFS proxy client.
 func NewLFSClient(baseURL, apiKey string) *LFSClient {
+	// Validate URL scheme to prevent request forgery via arbitrary protocols.
+	base := strings.TrimRight(baseURL, "/")
+	if u, err := url.Parse(base); err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		base = "http://localhost:0" // safe fallback — will fail on connect
+	}
 	return &LFSClient{
-		baseURL: baseURL,
+		baseURL: base,
 		apiKey:  apiKey,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,

--- a/internal/onboarding/profile.go
+++ b/internal/onboarding/profile.go
@@ -303,20 +303,20 @@ func applyLLM(cfg *config.Config, preset LLMPreset, reader *bufio.Reader, out io
 
 	case LLMPresetClaude:
 		return applyAPIKeyPreset(cfg, reader, out, p, applyAPIKeyOpts{
-			providerLabel:  "Claude/Anthropic",
-			envVar:         "ANTHROPIC_API_KEY",
-			defaultModel:   "claude/claude-sonnet-4-5-20250514",
-			setKey:         func(c *config.Config, k string) { c.Providers.Anthropic.APIKey = k },
-			modelPrefix:    "claude",
+			providerLabel: "Claude/Anthropic",
+			envVar:        "ANTHROPIC_API_KEY",
+			defaultModel:  "claude/claude-sonnet-4-5-20250514",
+			setKey:        func(c *config.Config, k string) { c.Providers.Anthropic.APIKey = k },
+			modelPrefix:   "claude",
 		})
 
 	case LLMPresetGemini:
 		return applyAPIKeyPreset(cfg, reader, out, p, applyAPIKeyOpts{
-			providerLabel:  "Gemini",
-			envVar:         "GEMINI_API_KEY",
-			defaultModel:   "gemini/gemini-2.5-pro",
-			setKey:         func(c *config.Config, k string) { c.Providers.Gemini.APIKey = k },
-			modelPrefix:    "gemini",
+			providerLabel: "Gemini",
+			envVar:        "GEMINI_API_KEY",
+			defaultModel:  "gemini/gemini-2.5-pro",
+			setKey:        func(c *config.Config, k string) { c.Providers.Gemini.APIKey = k },
+			modelPrefix:   "gemini",
 		})
 
 	case LLMPresetGeminiCLI:
@@ -331,38 +331,38 @@ func applyLLM(cfg *config.Config, preset LLMPreset, reader *bufio.Reader, out io
 
 	case LLMPresetXAI:
 		return applyAPIKeyPreset(cfg, reader, out, p, applyAPIKeyOpts{
-			providerLabel:  "xAI/Grok",
-			envVar:         "XAI_API_KEY",
-			defaultModel:   "xai/grok-3",
-			setKey:         func(c *config.Config, k string) { c.Providers.XAI.APIKey = k },
-			modelPrefix:    "xai",
+			providerLabel: "xAI/Grok",
+			envVar:        "XAI_API_KEY",
+			defaultModel:  "xai/grok-3",
+			setKey:        func(c *config.Config, k string) { c.Providers.XAI.APIKey = k },
+			modelPrefix:   "xai",
 		})
 
 	case LLMPresetOpenRouter:
 		return applyAPIKeyPreset(cfg, reader, out, p, applyAPIKeyOpts{
-			providerLabel:  "OpenRouter",
-			envVar:         "OPENROUTER_API_KEY",
-			defaultModel:   "openrouter/anthropic/claude-sonnet-4-5",
-			setKey:         func(c *config.Config, k string) { c.Providers.OpenRouter.APIKey = k },
-			modelPrefix:    "openrouter",
+			providerLabel: "OpenRouter",
+			envVar:        "OPENROUTER_API_KEY",
+			defaultModel:  "openrouter/anthropic/claude-sonnet-4-5",
+			setKey:        func(c *config.Config, k string) { c.Providers.OpenRouter.APIKey = k },
+			modelPrefix:   "openrouter",
 		})
 
 	case LLMPresetDeepSeek:
 		return applyAPIKeyPreset(cfg, reader, out, p, applyAPIKeyOpts{
-			providerLabel:  "DeepSeek",
-			envVar:         "DEEPSEEK_API_KEY",
-			defaultModel:   "deepseek/deepseek-chat",
-			setKey:         func(c *config.Config, k string) { c.Providers.DeepSeek.APIKey = k },
-			modelPrefix:    "deepseek",
+			providerLabel: "DeepSeek",
+			envVar:        "DEEPSEEK_API_KEY",
+			defaultModel:  "deepseek/deepseek-chat",
+			setKey:        func(c *config.Config, k string) { c.Providers.DeepSeek.APIKey = k },
+			modelPrefix:   "deepseek",
 		})
 
 	case LLMPresetGroq:
 		return applyAPIKeyPreset(cfg, reader, out, p, applyAPIKeyOpts{
-			providerLabel:  "Groq",
-			envVar:         "GROQ_API_KEY",
-			defaultModel:   "groq/llama-3.3-70b-versatile",
-			setKey:         func(c *config.Config, k string) { c.Providers.Groq.APIKey = k },
-			modelPrefix:    "groq",
+			providerLabel: "Groq",
+			envVar:        "GROQ_API_KEY",
+			defaultModel:  "groq/llama-3.3-70b-versatile",
+			setKey:        func(c *config.Config, k string) { c.Providers.Groq.APIKey = k },
+			modelPrefix:   "groq",
 		})
 
 	case LLMPresetScalyticsCopilot:

--- a/internal/onboarding/profile.go
+++ b/internal/onboarding/profile.go
@@ -26,6 +26,15 @@ const (
 	LLMPresetSkip             LLMPreset = "skip"
 	LLMPresetCLIToken         LLMPreset = "cli-token"
 	LLMPresetOpenAICompatible LLMPreset = "openai-compatible"
+	LLMPresetClaude           LLMPreset = "claude"
+	LLMPresetGemini           LLMPreset = "gemini"
+	LLMPresetGeminiCLI        LLMPreset = "gemini-cli"
+	LLMPresetCodex            LLMPreset = "openai-codex"
+	LLMPresetXAI              LLMPreset = "xai"
+	LLMPresetScalyticsCopilot LLMPreset = "scalytics-copilot"
+	LLMPresetOpenRouter       LLMPreset = "openrouter"
+	LLMPresetDeepSeek         LLMPreset = "deepseek"
+	LLMPresetGroq             LLMPreset = "groq"
 )
 
 type WizardParams struct {
@@ -140,23 +149,50 @@ func resolveLLMPreset(reader *bufio.Reader, out io.Writer, p WizardParams) (LLMP
 	if p.NonInteractive {
 		return LLMPresetSkip, nil
 	}
-	fmt.Fprintln(out, "\nSelect LLM setup:")
-	fmt.Fprintln(out, "1) cli-token (OpenRouter/OpenAI-compatible token)")
-	fmt.Fprintln(out, "2) openai-compatible (vLLM/Ollama/custom endpoint)")
-	fmt.Fprintln(out, "3) skip (keep current)")
-	choice, err := prompt(reader, out, "LLM setup [1/2/3]", "3")
+	fmt.Fprintln(out, "\nSelect LLM provider:")
+	fmt.Fprintln(out, " 1) claude          (Anthropic API key)")
+	fmt.Fprintln(out, " 2) openai          (OpenAI API key)")
+	fmt.Fprintln(out, " 3) gemini          (Google Gemini API key)")
+	fmt.Fprintln(out, " 4) gemini-cli      (Google Gemini via OAuth CLI)")
+	fmt.Fprintln(out, " 5) openai-codex    (OpenAI Codex via OAuth CLI)")
+	fmt.Fprintln(out, " 6) xai             (xAI/Grok API key)")
+	fmt.Fprintln(out, " 7) openrouter      (OpenRouter API key)")
+	fmt.Fprintln(out, " 8) deepseek        (DeepSeek API key)")
+	fmt.Fprintln(out, " 9) groq            (Groq API key)")
+	fmt.Fprintln(out, "10) scalytics-copilot (Scalytics Copilot API key + URL)")
+	fmt.Fprintln(out, "11) openai-compatible (vLLM/Ollama/custom endpoint)")
+	fmt.Fprintln(out, "12) skip            (keep current)")
+	choice, err := prompt(reader, out, "LLM provider [1-12]", "12")
 	if err != nil {
 		return "", err
 	}
 	switch strings.TrimSpace(choice) {
 	case "1":
-		return LLMPresetCLIToken, nil
+		return LLMPresetClaude, nil
 	case "2":
-		return LLMPresetOpenAICompatible, nil
+		return LLMPresetCLIToken, nil
 	case "3":
+		return LLMPresetGemini, nil
+	case "4":
+		return LLMPresetGeminiCLI, nil
+	case "5":
+		return LLMPresetCodex, nil
+	case "6":
+		return LLMPresetXAI, nil
+	case "7":
+		return LLMPresetOpenRouter, nil
+	case "8":
+		return LLMPresetDeepSeek, nil
+	case "9":
+		return LLMPresetGroq, nil
+	case "10":
+		return LLMPresetScalyticsCopilot, nil
+	case "11":
+		return LLMPresetOpenAICompatible, nil
+	case "12":
 		return LLMPresetSkip, nil
 	default:
-		return "", fmt.Errorf("invalid llm preset choice: %s", choice)
+		return "", fmt.Errorf("invalid llm provider choice: %s", choice)
 	}
 }
 
@@ -241,33 +277,129 @@ func applyLLM(cfg *config.Config, preset LLMPreset, reader *bufio.Reader, out io
 	switch preset {
 	case LLMPresetSkip:
 		return nil
+
 	case LLMPresetCLIToken:
 		token := strings.TrimSpace(p.LLMToken)
-		base := strings.TrimSpace(p.LLMAPIBase)
 		model := strings.TrimSpace(p.LLMModel)
 		if token == "" && !p.NonInteractive {
-			val, err := prompt(reader, out, "API token", os.Getenv("OPENROUTER_API_KEY"))
+			val, err := prompt(reader, out, "OpenAI API key", os.Getenv("OPENAI_API_KEY"))
 			if err != nil {
 				return err
 			}
 			token = strings.TrimSpace(val)
 		}
-		if base == "" {
-			base = "https://openrouter.ai/api/v1"
-		}
 		if model == "" && !p.NonInteractive {
-			val, err := prompt(reader, out, "Model", cfg.Model.Name)
+			val, err := prompt(reader, out, "Model", "openai/gpt-4.1")
 			if err != nil {
 				return err
 			}
 			model = strings.TrimSpace(val)
 		}
 		cfg.Providers.OpenAI.APIKey = token
-		cfg.Providers.OpenAI.APIBase = base
 		if model != "" {
 			cfg.Model.Name = model
 		}
 		return nil
+
+	case LLMPresetClaude:
+		return applyAPIKeyPreset(cfg, reader, out, p, applyAPIKeyOpts{
+			providerLabel:  "Claude/Anthropic",
+			envVar:         "ANTHROPIC_API_KEY",
+			defaultModel:   "claude/claude-sonnet-4-5-20250514",
+			setKey:         func(c *config.Config, k string) { c.Providers.Anthropic.APIKey = k },
+			modelPrefix:    "claude",
+		})
+
+	case LLMPresetGemini:
+		return applyAPIKeyPreset(cfg, reader, out, p, applyAPIKeyOpts{
+			providerLabel:  "Gemini",
+			envVar:         "GEMINI_API_KEY",
+			defaultModel:   "gemini/gemini-2.5-pro",
+			setKey:         func(c *config.Config, k string) { c.Providers.Gemini.APIKey = k },
+			modelPrefix:    "gemini",
+		})
+
+	case LLMPresetGeminiCLI:
+		cfg.Model.Name = firstNonEmpty(strings.TrimSpace(p.LLMModel), "gemini-cli/gemini-2.5-pro")
+		fmt.Fprintln(out, "Gemini CLI uses OAuth — run 'kafclaw models auth login --provider gemini' to authenticate.")
+		return nil
+
+	case LLMPresetCodex:
+		cfg.Model.Name = firstNonEmpty(strings.TrimSpace(p.LLMModel), "openai-codex/gpt-5.3-codex")
+		fmt.Fprintln(out, "Codex uses OAuth — run 'kafclaw models auth login --provider openai-codex' to authenticate.")
+		return nil
+
+	case LLMPresetXAI:
+		return applyAPIKeyPreset(cfg, reader, out, p, applyAPIKeyOpts{
+			providerLabel:  "xAI/Grok",
+			envVar:         "XAI_API_KEY",
+			defaultModel:   "xai/grok-3",
+			setKey:         func(c *config.Config, k string) { c.Providers.XAI.APIKey = k },
+			modelPrefix:    "xai",
+		})
+
+	case LLMPresetOpenRouter:
+		return applyAPIKeyPreset(cfg, reader, out, p, applyAPIKeyOpts{
+			providerLabel:  "OpenRouter",
+			envVar:         "OPENROUTER_API_KEY",
+			defaultModel:   "openrouter/anthropic/claude-sonnet-4-5",
+			setKey:         func(c *config.Config, k string) { c.Providers.OpenRouter.APIKey = k },
+			modelPrefix:    "openrouter",
+		})
+
+	case LLMPresetDeepSeek:
+		return applyAPIKeyPreset(cfg, reader, out, p, applyAPIKeyOpts{
+			providerLabel:  "DeepSeek",
+			envVar:         "DEEPSEEK_API_KEY",
+			defaultModel:   "deepseek/deepseek-chat",
+			setKey:         func(c *config.Config, k string) { c.Providers.DeepSeek.APIKey = k },
+			modelPrefix:    "deepseek",
+		})
+
+	case LLMPresetGroq:
+		return applyAPIKeyPreset(cfg, reader, out, p, applyAPIKeyOpts{
+			providerLabel:  "Groq",
+			envVar:         "GROQ_API_KEY",
+			defaultModel:   "groq/llama-3.3-70b-versatile",
+			setKey:         func(c *config.Config, k string) { c.Providers.Groq.APIKey = k },
+			modelPrefix:    "groq",
+		})
+
+	case LLMPresetScalyticsCopilot:
+		token := strings.TrimSpace(p.LLMToken)
+		base := strings.TrimSpace(p.LLMAPIBase)
+		model := strings.TrimSpace(p.LLMModel)
+		if token == "" && !p.NonInteractive {
+			val, err := prompt(reader, out, "Scalytics Copilot API key", "")
+			if err != nil {
+				return err
+			}
+			token = strings.TrimSpace(val)
+		}
+		if base == "" && !p.NonInteractive {
+			val, err := prompt(reader, out, "Scalytics Copilot API base URL", "https://copilot.scalytics.io/v1")
+			if err != nil {
+				return err
+			}
+			base = strings.TrimSpace(val)
+		}
+		if base == "" {
+			return fmt.Errorf("scalytics-copilot requires API base URL")
+		}
+		if model == "" && !p.NonInteractive {
+			val, err := prompt(reader, out, "Model", "scalytics-copilot/default")
+			if err != nil {
+				return err
+			}
+			model = strings.TrimSpace(val)
+		}
+		cfg.Providers.ScalyticsCopilot.APIKey = token
+		cfg.Providers.ScalyticsCopilot.APIBase = base
+		if model != "" {
+			cfg.Model.Name = model
+		}
+		return nil
+
 	case LLMPresetOpenAICompatible:
 		token := strings.TrimSpace(p.LLMToken)
 		base := strings.TrimSpace(p.LLMAPIBase)
@@ -302,9 +434,46 @@ func applyLLM(cfg *config.Config, preset LLMPreset, reader *bufio.Reader, out io
 			cfg.Model.Name = model
 		}
 		return nil
+
 	default:
 		return fmt.Errorf("unsupported llm preset: %s", preset)
 	}
+}
+
+// applyAPIKeyOpts holds parameters for the common API-key preset pattern.
+type applyAPIKeyOpts struct {
+	providerLabel string
+	envVar        string
+	defaultModel  string
+	setKey        func(*config.Config, string)
+	modelPrefix   string
+}
+
+// applyAPIKeyPreset handles the common flow: prompt for API key, prompt for model, set config.
+func applyAPIKeyPreset(cfg *config.Config, reader *bufio.Reader, out io.Writer, p WizardParams, opts applyAPIKeyOpts) error {
+	token := strings.TrimSpace(p.LLMToken)
+	model := strings.TrimSpace(p.LLMModel)
+	if token == "" && !p.NonInteractive {
+		val, err := prompt(reader, out, opts.providerLabel+" API key", os.Getenv(opts.envVar))
+		if err != nil {
+			return err
+		}
+		token = strings.TrimSpace(val)
+	}
+	if model == "" && !p.NonInteractive {
+		val, err := prompt(reader, out, "Model", opts.defaultModel)
+		if err != nil {
+			return err
+		}
+		model = strings.TrimSpace(val)
+	}
+	if token != "" {
+		opts.setKey(cfg, token)
+	}
+	if model != "" {
+		cfg.Model.Name = model
+	}
+	return nil
 }
 
 func prompt(r *bufio.Reader, out io.Writer, label, def string) (string, error) {
@@ -343,10 +512,28 @@ func normalizeLLMPreset(v string) LLMPreset {
 		return ""
 	case "skip":
 		return LLMPresetSkip
-	case "cli-token", "token":
+	case "cli-token", "token", "openai":
 		return LLMPresetCLIToken
 	case "openai-compatible", "compatible", "vllm", "ollama":
 		return LLMPresetOpenAICompatible
+	case "claude", "anthropic":
+		return LLMPresetClaude
+	case "gemini", "google":
+		return LLMPresetGemini
+	case "gemini-cli":
+		return LLMPresetGeminiCLI
+	case "openai-codex", "codex":
+		return LLMPresetCodex
+	case "xai", "grok":
+		return LLMPresetXAI
+	case "scalytics-copilot", "copilot":
+		return LLMPresetScalyticsCopilot
+	case "openrouter":
+		return LLMPresetOpenRouter
+	case "deepseek":
+		return LLMPresetDeepSeek
+	case "groq":
+		return LLMPresetGroq
 	default:
 		return ""
 	}
@@ -377,19 +564,12 @@ func isAllowedKafkaSASLMechanism(v string) bool {
 
 func BuildProfileSummary(cfg *config.Config) string {
 	mode := detectModeFromConfig(cfg)
-	llmBase := cfg.Providers.OpenAI.APIBase
-	if strings.TrimSpace(llmBase) == "" {
-		llmBase = "(default)"
-	}
-	tokenState := "not set"
-	if strings.TrimSpace(cfg.Providers.OpenAI.APIKey) != "" {
-		tokenState = "set"
-	}
 	authState := "not set"
 	if strings.TrimSpace(cfg.Gateway.AuthToken) != "" {
 		authState = "set"
 	}
-	return strings.Join([]string{
+
+	lines := []string{
 		"",
 		"Planned configuration:",
 		fmt.Sprintf("- mode: %s", mode),
@@ -405,8 +585,35 @@ func BuildProfileSummary(cfg *config.Config) string {
 		fmt.Sprintf("- kafka.tls.certFile: %s", firstNonEmpty(strings.TrimSpace(cfg.Group.KafkaTLSCertFile), "(none)")),
 		fmt.Sprintf("- kafka.tls.keyFile: %s", firstNonEmpty(strings.TrimSpace(cfg.Group.KafkaTLSKeyFile), "(none)")),
 		fmt.Sprintf("- llm.model: %s", firstNonEmpty(strings.TrimSpace(cfg.Model.Name), "(empty)")),
-		fmt.Sprintf("- llm.apiBase: %s", llmBase),
-		fmt.Sprintf("- llm.apiKey: %s", tokenState),
+	}
+
+	// Show configured providers
+	providerEntries := []struct {
+		id     string
+		hasKey bool
+	}{
+		{"anthropic/claude", cfg.Providers.Anthropic.APIKey != ""},
+		{"openai", cfg.Providers.OpenAI.APIKey != ""},
+		{"gemini", cfg.Providers.Gemini.APIKey != ""},
+		{"xai", cfg.Providers.XAI.APIKey != ""},
+		{"openrouter", cfg.Providers.OpenRouter.APIKey != ""},
+		{"deepseek", cfg.Providers.DeepSeek.APIKey != ""},
+		{"groq", cfg.Providers.Groq.APIKey != ""},
+		{"scalytics-copilot", cfg.Providers.ScalyticsCopilot.APIKey != ""},
+		{"vllm", cfg.Providers.VLLM.APIBase != ""},
+	}
+	var configured []string
+	for _, pe := range providerEntries {
+		if pe.hasKey {
+			configured = append(configured, pe.id)
+		}
+	}
+	if len(configured) == 0 {
+		configured = []string{"(none)"}
+	}
+	lines = append(lines, fmt.Sprintf("- llm.providers: %s", strings.Join(configured, ", ")))
+
+	lines = append(lines,
 		fmt.Sprintf("- subagents.maxSpawnDepth: %d", cfg.Tools.Subagents.MaxSpawnDepth),
 		fmt.Sprintf("- subagents.maxChildrenPerAgent: %d", cfg.Tools.Subagents.MaxChildrenPerAgent),
 		fmt.Sprintf("- subagents.maxConcurrent: %d", cfg.Tools.Subagents.MaxConcurrent),
@@ -415,7 +622,8 @@ func BuildProfileSummary(cfg *config.Config) string {
 		fmt.Sprintf("- subagents.model: %s", firstNonEmpty(strings.TrimSpace(cfg.Tools.Subagents.Model), "(inherit main model)")),
 		fmt.Sprintf("- subagents.thinking: %s", firstNonEmpty(strings.TrimSpace(cfg.Tools.Subagents.Thinking), "(inherit/default)")),
 		"",
-	}, "\n")
+	)
+	return strings.Join(lines, "\n")
 }
 
 func parseCSV(raw string) []string {

--- a/internal/provider/clicache/codex.go
+++ b/internal/provider/clicache/codex.go
@@ -1,0 +1,70 @@
+package clicache
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/KafClaw/KafClaw/internal/provider/credentials"
+)
+
+// codexCLICreds mirrors the JSON structure of ~/.codex/auth.json.
+type codexCLICreds struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresAt    int64  `json:"expires_at"`
+	Email        string `json:"email"`
+}
+
+// ReadCodexCLICredential reads the Codex CLI's cached OAuth credential.
+// If the credential is expired, it shells out to `codex auth` to refresh.
+func ReadCodexCLICredential() (*credentials.OAuthToken, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home dir: %w", err)
+	}
+	credsPath := filepath.Join(home, ".codex", "auth.json")
+	tok, err := readCodexCredsFile(credsPath)
+	if err != nil {
+		return nil, err
+	}
+	if !credentials.IsExpired(tok) {
+		return tok, nil
+	}
+	if refreshErr := runCodexAuthRefresh(); refreshErr != nil {
+		return nil, fmt.Errorf("codex credential expired and refresh failed: %w", refreshErr)
+	}
+	return readCodexCredsFile(credsPath)
+}
+
+func readCodexCredsFile(path string) (*credentials.OAuthToken, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read codex credentials at %s: %w (run 'codex auth' first)", path, err)
+	}
+	var creds codexCLICreds
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return nil, fmt.Errorf("parse codex credentials: %w", err)
+	}
+	expires := creds.ExpiresAt
+	if expires == 0 {
+		expires = time.Now().Add(time.Hour).Unix()
+	}
+	return &credentials.OAuthToken{
+		Access:  creds.AccessToken,
+		Refresh: creds.RefreshToken,
+		Expires: expires,
+		Email:   creds.Email,
+	}, nil
+}
+
+func runCodexAuthRefresh() error {
+	cmd := exec.Command("codex", "auth")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	return cmd.Run()
+}

--- a/internal/provider/clicache/gemini.go
+++ b/internal/provider/clicache/gemini.go
@@ -1,0 +1,73 @@
+// Package clicache reads OAuth credentials cached by external CLI tools.
+package clicache
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/KafClaw/KafClaw/internal/provider/credentials"
+)
+
+// geminiCLICreds mirrors the JSON structure of ~/.gemini/oauth_creds.json.
+type geminiCLICreds struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresAt    int64  `json:"expires_at_seconds"`
+	Email        string `json:"email"`
+}
+
+// ReadGeminiCLICredential reads the Gemini CLI's cached OAuth credential.
+// If the credential is expired, it shells out to `gemini auth` to refresh.
+func ReadGeminiCLICredential() (*credentials.OAuthToken, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home dir: %w", err)
+	}
+	credsPath := filepath.Join(home, ".gemini", "oauth_creds.json")
+	tok, err := readGeminiCredsFile(credsPath)
+	if err != nil {
+		return nil, err
+	}
+	if !credentials.IsExpired(tok) {
+		return tok, nil
+	}
+	// Attempt refresh via CLI.
+	if refreshErr := runGeminiAuthRefresh(); refreshErr != nil {
+		return nil, fmt.Errorf("gemini credential expired and refresh failed: %w", refreshErr)
+	}
+	return readGeminiCredsFile(credsPath)
+}
+
+func readGeminiCredsFile(path string) (*credentials.OAuthToken, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read gemini credentials at %s: %w (run 'gemini auth login' first)", path, err)
+	}
+	var creds geminiCLICreds
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return nil, fmt.Errorf("parse gemini credentials: %w", err)
+	}
+	expires := creds.ExpiresAt
+	if expires == 0 {
+		// Some versions use seconds-from-now instead of absolute timestamp.
+		expires = time.Now().Add(time.Hour).Unix()
+	}
+	return &credentials.OAuthToken{
+		Access:  creds.AccessToken,
+		Refresh: creds.RefreshToken,
+		Expires: expires,
+		Email:   creds.Email,
+	}, nil
+}
+
+func runGeminiAuthRefresh() error {
+	cmd := exec.Command("gemini", "auth", "login", "--no-browser")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	return cmd.Run()
+}

--- a/internal/provider/clinst/install.go
+++ b/internal/provider/clinst/install.go
@@ -1,0 +1,43 @@
+// Package clinst provides CLI tool installation helpers for OAuth-based providers.
+package clinst
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// EnsureGeminiCLI checks if the Gemini CLI is available and installs it if absent.
+func EnsureGeminiCLI() error {
+	if _, err := exec.LookPath("gemini"); err == nil {
+		return nil
+	}
+	fmt.Println("Gemini CLI not found. Installing @google/gemini-cli via npm...")
+	cmd := exec.Command("npm", "install", "-g", "@google/gemini-cli")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("install gemini CLI: %w (you can install manually: npm install -g @google/gemini-cli)", err)
+	}
+	if _, err := exec.LookPath("gemini"); err != nil {
+		return fmt.Errorf("gemini CLI installed but not found in PATH")
+	}
+	return nil
+}
+
+// EnsureCodexCLI checks if the Codex CLI is available and installs it if absent.
+func EnsureCodexCLI() error {
+	if _, err := exec.LookPath("codex"); err == nil {
+		return nil
+	}
+	fmt.Println("Codex CLI not found. Installing @openai/codex via npm...")
+	cmd := exec.Command("npm", "install", "-g", "@openai/codex")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("install codex CLI: %w (you can install manually: npm install -g @openai/codex)", err)
+	}
+	if _, err := exec.LookPath("codex"); err != nil {
+		return fmt.Errorf("codex CLI installed but not found in PATH")
+	}
+	return nil
+}

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -1,0 +1,57 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KafClaw/KafClaw/internal/provider/clicache"
+)
+
+// CodexProvider wraps OpenAIProvider with OAuth bearer token from the Codex CLI cache.
+type CodexProvider struct {
+	defaultModel string
+}
+
+// NewCodexProvider creates a provider that uses Codex CLI OAuth credentials.
+func NewCodexProvider(defaultModel string) *CodexProvider {
+	if defaultModel == "" {
+		defaultModel = "gpt-5.3-codex"
+	}
+	return &CodexProvider{defaultModel: defaultModel}
+}
+
+func (p *CodexProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	inner, err := p.resolveInner()
+	if err != nil {
+		return nil, err
+	}
+	return inner.Chat(ctx, req)
+}
+
+func (p *CodexProvider) Transcribe(ctx context.Context, req *AudioRequest) (*AudioResponse, error) {
+	inner, err := p.resolveInner()
+	if err != nil {
+		return nil, err
+	}
+	return inner.Transcribe(ctx, req)
+}
+
+func (p *CodexProvider) Speak(ctx context.Context, req *TTSRequest) (*TTSResponse, error) {
+	inner, err := p.resolveInner()
+	if err != nil {
+		return nil, err
+	}
+	return inner.Speak(ctx, req)
+}
+
+func (p *CodexProvider) DefaultModel() string {
+	return p.defaultModel
+}
+
+func (p *CodexProvider) resolveInner() (*OpenAIProvider, error) {
+	tok, err := clicache.ReadCodexCLICredential()
+	if err != nil {
+		return nil, fmt.Errorf("codex provider: %w", err)
+	}
+	return NewOpenAIProvider(tok.Access, "https://api.openai.com/v1", p.defaultModel), nil
+}

--- a/internal/provider/credentials/store.go
+++ b/internal/provider/credentials/store.go
@@ -1,0 +1,138 @@
+// Package credentials manages provider credential storage and retrieval.
+// OAuth tokens are stored as encrypted blobs in <ToolsDir>/auth/providers/<id>/token.json.
+// Static API keys are stored in the local tomb env map keyed as provider.apikey.<id>.
+package credentials
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+	"github.com/KafClaw/KafClaw/internal/secrets"
+)
+
+// OAuthToken represents a stored OAuth credential.
+type OAuthToken struct {
+	Access  string `json:"access_token"`
+	Refresh string `json:"refresh_token,omitempty"`
+	Expires int64  `json:"expires_at"`
+	Email   string `json:"email,omitempty"`
+}
+
+// IsExpired reports whether the token is expired (with a 60-second grace margin).
+func IsExpired(t *OAuthToken) bool {
+	if t == nil || t.Expires == 0 {
+		return true
+	}
+	return time.Now().Unix() >= t.Expires-60
+}
+
+// providerAuthDir returns the directory for a provider's credential files.
+func providerAuthDir(providerID string) (string, error) {
+	cfgPath, err := config.ConfigPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(filepath.Dir(cfgPath), "skills", "tools", "auth", "providers", providerID), nil
+}
+
+// LoadToken reads and decrypts an OAuth token for the given provider.
+func LoadToken(providerID string) (*OAuthToken, error) {
+	dir, err := providerAuthDir(providerID)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "token.json"))
+	if err != nil {
+		return nil, fmt.Errorf("load token for provider %s: %w", providerID, err)
+	}
+	plain, err := secrets.DecryptBlob(data)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt token for provider %s: %w", providerID, err)
+	}
+	var tok OAuthToken
+	if err := json.Unmarshal(plain, &tok); err != nil {
+		return nil, fmt.Errorf("parse token for provider %s: %w", providerID, err)
+	}
+	return &tok, nil
+}
+
+// SaveToken encrypts and saves an OAuth token for the given provider.
+func SaveToken(providerID string, t *OAuthToken) error {
+	if t == nil {
+		return fmt.Errorf("nil token")
+	}
+	dir, err := providerAuthDir(providerID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	plain, err := json.MarshalIndent(t, "", "  ")
+	if err != nil {
+		return err
+	}
+	sealed, err := secrets.EncryptBlob(append(plain, '\n'))
+	if err != nil {
+		return fmt.Errorf("encrypt token for provider %s: %w", providerID, err)
+	}
+	return os.WriteFile(filepath.Join(dir, "token.json"), sealed, 0o600)
+}
+
+// apiKeyTombKey returns the tomb env map key for a provider's API key.
+func apiKeyTombKey(providerID string) string {
+	return "provider.apikey." + strings.ToLower(providerID)
+}
+
+// LoadAPIKey reads a static API key for the given provider from the tomb env map.
+func LoadAPIKey(providerID string) (string, error) {
+	tombPath, err := secrets.ResolveLocalTombPath()
+	if err != nil {
+		return "", fmt.Errorf("resolve tomb for provider %s: %w", providerID, err)
+	}
+	data, err := os.ReadFile(tombPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("no API key stored for provider %s", providerID)
+		}
+		return "", fmt.Errorf("load tomb for provider %s: %w", providerID, err)
+	}
+	doc, err := secrets.DecodeLocalTomb(data)
+	if err != nil {
+		return "", fmt.Errorf("decode tomb for provider %s: %w", providerID, err)
+	}
+	envMap, err := secrets.LoadEnvSecretsFromTombDoc(doc)
+	if err != nil {
+		return "", fmt.Errorf("load env secrets for provider %s: %w", providerID, err)
+	}
+	key, ok := envMap[apiKeyTombKey(providerID)]
+	if !ok || strings.TrimSpace(key) == "" {
+		return "", fmt.Errorf("no API key stored for provider %s", providerID)
+	}
+	return key, nil
+}
+
+// SaveAPIKey stores a static API key for the given provider in the tomb env map.
+func SaveAPIKey(providerID string, key string) error {
+	tombPath, doc, err := secrets.LoadOrCreateLocalTomb()
+	if err != nil {
+		return fmt.Errorf("load tomb for provider %s: %w", providerID, err)
+	}
+	existing, err := secrets.LoadEnvSecretsFromTombDoc(doc)
+	if err != nil {
+		return fmt.Errorf("load env secrets for provider %s: %w", providerID, err)
+	}
+	existing[apiKeyTombKey(providerID)] = key
+	if err := secrets.SealEnvSecretsIntoTombDoc(doc, existing); err != nil {
+		return fmt.Errorf("seal env secrets for provider %s: %w", providerID, err)
+	}
+	if err := secrets.WriteLocalTomb(tombPath, doc); err != nil {
+		return fmt.Errorf("write tomb for provider %s: %w", providerID, err)
+	}
+	return os.Chmod(tombPath, 0o600)
+}

--- a/internal/provider/credentials/store_test.go
+++ b/internal/provider/credentials/store_test.go
@@ -1,0 +1,69 @@
+package credentials
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsExpired_NilToken(t *testing.T) {
+	if !IsExpired(nil) {
+		t.Fatal("expected nil token to be expired")
+	}
+}
+
+func TestIsExpired_ZeroExpiry(t *testing.T) {
+	tok := &OAuthToken{Access: "tok", Expires: 0}
+	if !IsExpired(tok) {
+		t.Fatal("expected zero-expiry token to be expired")
+	}
+}
+
+func TestIsExpired_FutureExpiry(t *testing.T) {
+	tok := &OAuthToken{
+		Access:  "tok",
+		Expires: time.Now().Unix() + 3600, // 1 hour from now
+	}
+	if IsExpired(tok) {
+		t.Fatal("expected token with future expiry to not be expired")
+	}
+}
+
+func TestIsExpired_PastExpiry(t *testing.T) {
+	tok := &OAuthToken{
+		Access:  "tok",
+		Expires: time.Now().Unix() - 120, // 2 minutes ago
+	}
+	if !IsExpired(tok) {
+		t.Fatal("expected token with past expiry to be expired")
+	}
+}
+
+func TestIsExpired_Within60sGrace(t *testing.T) {
+	// Token expires 30 seconds from now, but the 60-second grace window
+	// means it should already be considered expired.
+	tok := &OAuthToken{
+		Access:  "tok",
+		Expires: time.Now().Unix() + 30,
+	}
+	if !IsExpired(tok) {
+		t.Fatal("expected token within 60s grace window to be expired")
+	}
+}
+
+func TestApiKeyTombKey(t *testing.T) {
+	tests := []struct {
+		providerID string
+		want       string
+	}{
+		{"OpenAI", "provider.apikey.openai"},
+		{"anthropic", "provider.apikey.anthropic"},
+		{"XAI", "provider.apikey.xai"},
+		{"Google-Gemini", "provider.apikey.google-gemini"},
+	}
+	for _, tc := range tests {
+		got := apiKeyTombKey(tc.providerID)
+		if got != tc.want {
+			t.Errorf("apiKeyTombKey(%q) = %q, want %q", tc.providerID, got, tc.want)
+		}
+	}
+}

--- a/internal/provider/gemini.go
+++ b/internal/provider/gemini.go
@@ -122,8 +122,8 @@ func (p *GeminiProvider) setAuth(req *http.Request) error {
 // --- Gemini request/response types ---
 
 type geminiRequest struct {
-	Contents         []geminiContent        `json:"contents"`
-	Tools            []geminiTool           `json:"tools,omitempty"`
+	Contents         []geminiContent         `json:"contents"`
+	Tools            []geminiTool            `json:"tools,omitempty"`
 	GenerationConfig *geminiGenerationConfig `json:"generationConfig,omitempty"`
 }
 

--- a/internal/provider/gemini.go
+++ b/internal/provider/gemini.go
@@ -1,0 +1,283 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/KafClaw/KafClaw/internal/provider/clicache"
+)
+
+const geminiDefaultBase = "https://generativelanguage.googleapis.com/v1beta"
+
+// GeminiProvider implements LLMProvider using the Gemini REST API.
+// It supports two auth modes:
+//   - Static API key (query param) for provider ID "gemini"
+//   - OAuth bearer from CLI cache for provider ID "gemini-cli"
+type GeminiProvider struct {
+	apiKey       string // empty for OAuth mode
+	useOAuth     bool
+	defaultModel string
+	httpClient   *http.Client
+}
+
+// NewGeminiProvider creates a Gemini provider using a static API key.
+func NewGeminiProvider(apiKey, defaultModel string) *GeminiProvider {
+	if defaultModel == "" {
+		defaultModel = "gemini-2.0-flash"
+	}
+	return &GeminiProvider{
+		apiKey:       apiKey,
+		useOAuth:     false,
+		defaultModel: defaultModel,
+		httpClient:   &http.Client{Timeout: 120 * time.Second},
+	}
+}
+
+// NewGeminiCLIProvider creates a Gemini provider using OAuth credentials from the Gemini CLI.
+func NewGeminiCLIProvider(defaultModel string) *GeminiProvider {
+	if defaultModel == "" {
+		defaultModel = "gemini-2.0-flash"
+	}
+	return &GeminiProvider{
+		useOAuth:     true,
+		defaultModel: defaultModel,
+		httpClient:   &http.Client{Timeout: 120 * time.Second},
+	}
+}
+
+func (p *GeminiProvider) DefaultModel() string {
+	return p.defaultModel
+}
+
+func (p *GeminiProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	model := req.Model
+	if model == "" {
+		model = p.defaultModel
+	}
+
+	gemReq := p.buildGeminiRequest(req)
+	jsonBody, err := json.Marshal(gemReq)
+	if err != nil {
+		return nil, fmt.Errorf("marshal gemini request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/models/%s:generateContent", geminiDefaultBase, model)
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("create gemini request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	if err := p.setAuth(httpReq); err != nil {
+		return nil, err
+	}
+
+	resp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("execute gemini request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read gemini response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("gemini API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	return p.parseGeminiResponse(respBody)
+}
+
+func (p *GeminiProvider) Transcribe(_ context.Context, _ *AudioRequest) (*AudioResponse, error) {
+	return nil, fmt.Errorf("gemini provider does not support transcription")
+}
+
+func (p *GeminiProvider) Speak(_ context.Context, _ *TTSRequest) (*TTSResponse, error) {
+	return nil, fmt.Errorf("gemini provider does not support TTS")
+}
+
+func (p *GeminiProvider) setAuth(req *http.Request) error {
+	if p.useOAuth {
+		tok, err := clicache.ReadGeminiCLICredential()
+		if err != nil {
+			return fmt.Errorf("gemini-cli auth: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+tok.Access)
+	} else {
+		q := req.URL.Query()
+		q.Set("key", p.apiKey)
+		req.URL.RawQuery = q.Encode()
+	}
+	return nil
+}
+
+// --- Gemini request/response types ---
+
+type geminiRequest struct {
+	Contents         []geminiContent        `json:"contents"`
+	Tools            []geminiTool           `json:"tools,omitempty"`
+	GenerationConfig *geminiGenerationConfig `json:"generationConfig,omitempty"`
+}
+
+type geminiContent struct {
+	Role  string       `json:"role"`
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiPart struct {
+	Text         string                  `json:"text,omitempty"`
+	FunctionCall *geminiFunctionCall     `json:"functionCall,omitempty"`
+	FunctionResp *geminiFunctionResponse `json:"functionResponse,omitempty"`
+}
+
+type geminiFunctionCall struct {
+	Name string         `json:"name"`
+	Args map[string]any `json:"args"`
+}
+
+type geminiFunctionResponse struct {
+	Name     string         `json:"name"`
+	Response map[string]any `json:"response"`
+}
+
+type geminiTool struct {
+	FunctionDeclarations []geminiFunctionDecl `json:"functionDeclarations"`
+}
+
+type geminiFunctionDecl struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
+}
+
+type geminiGenerationConfig struct {
+	MaxOutputTokens int     `json:"maxOutputTokens,omitempty"`
+	Temperature     float64 `json:"temperature,omitempty"`
+}
+
+type geminiResponse struct {
+	Candidates    []geminiCandidate    `json:"candidates"`
+	UsageMetadata *geminiUsageMetadata `json:"usageMetadata"`
+}
+
+type geminiCandidate struct {
+	Content      geminiContent `json:"content"`
+	FinishReason string        `json:"finishReason"`
+}
+
+type geminiUsageMetadata struct {
+	PromptTokenCount     int `json:"promptTokenCount"`
+	CandidatesTokenCount int `json:"candidatesTokenCount"`
+	TotalTokenCount      int `json:"totalTokenCount"`
+}
+
+func (p *GeminiProvider) buildGeminiRequest(req *ChatRequest) *geminiRequest {
+	gemReq := &geminiRequest{
+		GenerationConfig: &geminiGenerationConfig{
+			MaxOutputTokens: req.MaxTokens,
+			Temperature:     req.Temperature,
+		},
+	}
+
+	for _, msg := range req.Messages {
+		role := msg.Role
+		switch role {
+		case "assistant":
+			role = "model"
+		case "system":
+			role = "user"
+		}
+
+		content := geminiContent{Role: role}
+
+		if msg.Content != "" {
+			content.Parts = append(content.Parts, geminiPart{Text: msg.Content})
+		}
+
+		// Convert tool calls from assistant messages.
+		for _, tc := range msg.ToolCalls {
+			content.Parts = append(content.Parts, geminiPart{
+				FunctionCall: &geminiFunctionCall{
+					Name: tc.Name,
+					Args: tc.Arguments,
+				},
+			})
+		}
+
+		// Convert tool responses.
+		if msg.ToolCallID != "" && msg.Role == "tool" {
+			content.Role = "function"
+			content.Parts = []geminiPart{{
+				FunctionResp: &geminiFunctionResponse{
+					Name:     msg.ToolCallID,
+					Response: map[string]any{"result": msg.Content},
+				},
+			}}
+		}
+
+		gemReq.Contents = append(gemReq.Contents, content)
+	}
+
+	if len(req.Tools) > 0 {
+		var decls []geminiFunctionDecl
+		for _, t := range req.Tools {
+			decls = append(decls, geminiFunctionDecl{
+				Name:        t.Function.Name,
+				Description: t.Function.Description,
+				Parameters:  t.Function.Parameters,
+			})
+		}
+		gemReq.Tools = []geminiTool{{FunctionDeclarations: decls}}
+	}
+
+	return gemReq
+}
+
+func (p *GeminiProvider) parseGeminiResponse(body []byte) (*ChatResponse, error) {
+	var gemResp geminiResponse
+	if err := json.Unmarshal(body, &gemResp); err != nil {
+		return nil, fmt.Errorf("parse gemini response: %w", err)
+	}
+
+	if len(gemResp.Candidates) == 0 {
+		return nil, fmt.Errorf("no candidates in gemini response")
+	}
+
+	candidate := gemResp.Candidates[0]
+	result := &ChatResponse{
+		FinishReason: candidate.FinishReason,
+	}
+
+	// Extract usage.
+	if gemResp.UsageMetadata != nil {
+		result.Usage = Usage{
+			PromptTokens:     gemResp.UsageMetadata.PromptTokenCount,
+			CompletionTokens: gemResp.UsageMetadata.CandidatesTokenCount,
+			TotalTokens:      gemResp.UsageMetadata.TotalTokenCount,
+		}
+	}
+
+	// Extract text and tool calls from parts.
+	for _, part := range candidate.Content.Parts {
+		if part.Text != "" {
+			result.Content += part.Text
+		}
+		if part.FunctionCall != nil {
+			result.ToolCalls = append(result.ToolCalls, ToolCall{
+				ID:        part.FunctionCall.Name,
+				Name:      part.FunctionCall.Name,
+				Arguments: part.FunctionCall.Args,
+			})
+		}
+	}
+
+	return result, nil
+}

--- a/internal/provider/middleware/classifier.go
+++ b/internal/provider/middleware/classifier.go
@@ -1,0 +1,150 @@
+package middleware
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+	"github.com/KafClaw/KafClaw/internal/provider"
+)
+
+// ContentClassifier is a middleware that classifies message content by
+// sensitivity level and task type, optionally rerouting to a different model.
+type ContentClassifier struct {
+	cfg              config.ContentClassificationConfig
+	sensitivityRules []sensitivityRule
+}
+
+type sensitivityRule struct {
+	name     string
+	patterns []*regexp.Regexp
+	keywords []string
+	routeTo  string
+}
+
+// NewContentClassifier builds a classifier from config.
+func NewContentClassifier(cfg config.ContentClassificationConfig) *ContentClassifier {
+	cc := &ContentClassifier{cfg: cfg}
+	for name, level := range cfg.SensitivityLevels {
+		rule := sensitivityRule{
+			name:     name,
+			keywords: level.Keywords,
+			routeTo:  level.RouteTo,
+		}
+		for _, p := range level.Patterns {
+			re, err := regexp.Compile(p)
+			if err != nil {
+				continue
+			}
+			rule.patterns = append(rule.patterns, re)
+		}
+		cc.sensitivityRules = append(cc.sensitivityRules, rule)
+	}
+	return cc
+}
+
+func (c *ContentClassifier) Name() string { return "content-classifier" }
+
+func (c *ContentClassifier) ProcessRequest(_ context.Context, req *provider.ChatRequest, meta *RequestMeta) error {
+	if !c.cfg.Enabled {
+		return nil
+	}
+
+	// Concatenate user messages for scanning.
+	var text strings.Builder
+	for _, msg := range req.Messages {
+		if msg.Role == "user" {
+			text.WriteString(msg.Content)
+			text.WriteString(" ")
+		}
+	}
+	content := text.String()
+
+	// Check sensitivity rules.
+	for _, rule := range c.sensitivityRules {
+		if matchesSensitivity(content, rule) {
+			meta.Tags["sensitivity"] = rule.name
+			if rule.routeTo != "" {
+				provID, model := provider.ParseModelString(rule.routeTo)
+				if provID != "" {
+					meta.ProviderID = provID
+					meta.ModelName = model
+				}
+			}
+			break // first match wins
+		}
+	}
+
+	// Check task-type routing.
+	if len(c.cfg.TaskTypeRoutes) > 0 {
+		taskType := classifyTaskType(content)
+		if taskType != "" {
+			meta.Tags["task"] = taskType
+			if routeTo, ok := c.cfg.TaskTypeRoutes[taskType]; ok {
+				provID, model := provider.ParseModelString(routeTo)
+				if provID != "" {
+					meta.ProviderID = provID
+					meta.ModelName = model
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *ContentClassifier) ProcessResponse(_ context.Context, _ *provider.ChatRequest, _ *provider.ChatResponse, _ *RequestMeta) error {
+	return nil
+}
+
+func matchesSensitivity(text string, rule sensitivityRule) bool {
+	for _, re := range rule.patterns {
+		if re.MatchString(text) {
+			return true
+		}
+	}
+	lower := strings.ToLower(text)
+	for _, kw := range rule.keywords {
+		if strings.Contains(lower, strings.ToLower(kw)) {
+			return true
+		}
+	}
+	return false
+}
+
+// classifyTaskType does basic keyword-based task classification.
+// This mirrors the categories from agent.AssessTask() but is independent.
+func classifyTaskType(text string) string {
+	lower := strings.ToLower(text)
+
+	securityKeywords := []string{"vulnerability", "cve", "exploit", "security", "pentest", "xss", "sql injection", "csrf"}
+	for _, kw := range securityKeywords {
+		if strings.Contains(lower, kw) {
+			return "security"
+		}
+	}
+
+	codingKeywords := []string{"write code", "implement", "refactor", "debug", "function", "class", "method", "api endpoint"}
+	for _, kw := range codingKeywords {
+		if strings.Contains(lower, kw) {
+			return "coding"
+		}
+	}
+
+	toolKeywords := []string{"run command", "execute", "shell", "bash", "terminal", "git ", "docker"}
+	for _, kw := range toolKeywords {
+		if strings.Contains(lower, kw) {
+			return "tool-heavy"
+		}
+	}
+
+	creativeKeywords := []string{"write a story", "poem", "creative", "brainstorm", "imagine"}
+	for _, kw := range creativeKeywords {
+		if strings.Contains(lower, kw) {
+			return "creative"
+		}
+	}
+
+	return ""
+}

--- a/internal/provider/middleware/classifier_test.go
+++ b/internal/provider/middleware/classifier_test.go
@@ -1,0 +1,128 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+	"github.com/KafClaw/KafClaw/internal/provider"
+)
+
+func TestClassifier_Disabled(t *testing.T) {
+	cc := NewContentClassifier(config.ContentClassificationConfig{Enabled: false})
+	meta := NewRequestMeta("openai", "gpt-4")
+	req := &provider.ChatRequest{Messages: []provider.Message{{Role: "user", Content: "123-45-6789"}}}
+	if err := cc.ProcessRequest(context.Background(), req, meta); err != nil {
+		t.Fatalf("ProcessRequest error: %v", err)
+	}
+	if _, ok := meta.Tags["sensitivity"]; ok {
+		t.Error("expected no sensitivity tag when disabled")
+	}
+}
+
+func TestClassifier_SensitivityDetection(t *testing.T) {
+	cc := NewContentClassifier(config.ContentClassificationConfig{
+		Enabled: true,
+		SensitivityLevels: map[string]config.SensitivityLevel{
+			"pii": {
+				Patterns: []string{`\b\d{3}-\d{2}-\d{4}\b`},
+				RouteTo:  "vllm/llama-3.1-70b",
+			},
+		},
+	})
+
+	meta := NewRequestMeta("openai", "gpt-4")
+	req := &provider.ChatRequest{Messages: []provider.Message{{Role: "user", Content: "My SSN is 123-45-6789"}}}
+	if err := cc.ProcessRequest(context.Background(), req, meta); err != nil {
+		t.Fatalf("ProcessRequest error: %v", err)
+	}
+	if meta.Tags["sensitivity"] != "pii" {
+		t.Errorf("expected sensitivity=pii, got %q", meta.Tags["sensitivity"])
+	}
+	if meta.ProviderID != "vllm" {
+		t.Errorf("expected provider reroute to vllm, got %q", meta.ProviderID)
+	}
+	if meta.ModelName != "llama-3.1-70b" {
+		t.Errorf("expected model reroute, got %q", meta.ModelName)
+	}
+}
+
+func TestClassifier_KeywordDetection(t *testing.T) {
+	cc := NewContentClassifier(config.ContentClassificationConfig{
+		Enabled: true,
+		SensitivityLevels: map[string]config.SensitivityLevel{
+			"confidential": {
+				Keywords: []string{"social security", "passport"},
+			},
+		},
+	})
+
+	meta := NewRequestMeta("openai", "gpt-4")
+	req := &provider.ChatRequest{Messages: []provider.Message{{Role: "user", Content: "Need my social security number"}}}
+	if err := cc.ProcessRequest(context.Background(), req, meta); err != nil {
+		t.Fatalf("ProcessRequest error: %v", err)
+	}
+	if meta.Tags["sensitivity"] != "confidential" {
+		t.Errorf("expected sensitivity=confidential, got %q", meta.Tags["sensitivity"])
+	}
+}
+
+func TestClassifier_TaskTypeRouting(t *testing.T) {
+	cc := NewContentClassifier(config.ContentClassificationConfig{
+		Enabled: true,
+		TaskTypeRoutes: map[string]string{
+			"security": "claude/claude-opus-4-6",
+		},
+	})
+
+	meta := NewRequestMeta("openai", "gpt-4")
+	req := &provider.ChatRequest{Messages: []provider.Message{{Role: "user", Content: "Find the XSS vulnerability in this code"}}}
+	if err := cc.ProcessRequest(context.Background(), req, meta); err != nil {
+		t.Fatalf("ProcessRequest error: %v", err)
+	}
+	if meta.Tags["task"] != "security" {
+		t.Errorf("expected task=security, got %q", meta.Tags["task"])
+	}
+	if meta.ProviderID != "claude" {
+		t.Errorf("expected reroute to claude, got %q", meta.ProviderID)
+	}
+}
+
+func TestClassifier_NoMatch(t *testing.T) {
+	cc := NewContentClassifier(config.ContentClassificationConfig{
+		Enabled: true,
+		SensitivityLevels: map[string]config.SensitivityLevel{
+			"pii": {
+				Patterns: []string{`\b\d{3}-\d{2}-\d{4}\b`},
+			},
+		},
+	})
+
+	meta := NewRequestMeta("openai", "gpt-4")
+	req := &provider.ChatRequest{Messages: []provider.Message{{Role: "user", Content: "What is the weather?"}}}
+	if err := cc.ProcessRequest(context.Background(), req, meta); err != nil {
+		t.Fatalf("ProcessRequest error: %v", err)
+	}
+	if _, ok := meta.Tags["sensitivity"]; ok {
+		t.Error("expected no sensitivity tag")
+	}
+}
+
+func TestClassifyTaskType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Find the SQL injection vulnerability", "security"},
+		{"Write code for a REST API endpoint", "coding"},
+		{"Run this bash command", "tool-heavy"},
+		{"Write a story about dragons", "creative"},
+		{"What is the capital of France?", ""},
+	}
+	for _, tt := range tests {
+		got := classifyTaskType(tt.input)
+		if got != tt.want {
+			t.Errorf("classifyTaskType(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/provider/middleware/detectors.go
+++ b/internal/provider/middleware/detectors.go
@@ -1,0 +1,192 @@
+package middleware
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+)
+
+// DetectorMatch represents a single detection hit.
+type DetectorMatch struct {
+	Type    string // e.g. "email", "ssn", "api_key"
+	Value   string // the matched text
+	Start   int    // byte offset in source string
+	End     int    // byte offset end
+}
+
+// Detector scans text for sensitive patterns.
+type Detector struct {
+	piiDetectors    []namedRegex
+	secretDetectors []namedRegex
+	customDetectors []namedRegex
+}
+
+type namedRegex struct {
+	name string
+	re   *regexp.Regexp
+}
+
+// Built-in PII patterns.
+var builtinPII = map[string]string{
+	"email":       `\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b`,
+	"phone":       `(?:\+\d{1,3}[\s\-]?)?\(?\d{2,4}\)?[\s\-]?\d{3,4}[\s\-]?\d{3,4}\b`,
+	"ssn":         `\b\d{3}-\d{2}-\d{4}\b`,
+	"credit_card": `\b(?:\d{4}[\s\-]?){3}\d{4}\b`,
+	"ip_address":  `\b(?:\d{1,3}\.){3}\d{1,3}\b`,
+}
+
+// Built-in secret patterns.
+var builtinSecrets = map[string]string{
+	"api_key":          `\b(?:sk-[A-Za-z0-9]{20,}|pk_[A-Za-z0-9]{20,}|AKIA[A-Z0-9]{16}|ghp_[A-Za-z0-9]{36}|gho_[A-Za-z0-9]{36}|glpat-[A-Za-z0-9\-]{20,})\b`,
+	"bearer_token":     `Bearer\s+[A-Za-z0-9\-._~+/]+=*`,
+	"private_key":      `-----BEGIN\s+[A-Z\s]*PRIVATE\s+KEY-----`,
+	"password_literal": `(?i)(?:password|passwd|pwd)\s*[:=]\s*\S+`,
+}
+
+// NewDetector creates a detector from config settings.
+func NewDetector(piiTypes, secretTypes []string, customPatterns []config.NamedPattern) *Detector {
+	d := &Detector{}
+
+	for _, pt := range piiTypes {
+		pattern, ok := builtinPII[pt]
+		if !ok {
+			continue
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			continue
+		}
+		d.piiDetectors = append(d.piiDetectors, namedRegex{name: pt, re: re})
+	}
+
+	for _, st := range secretTypes {
+		pattern, ok := builtinSecrets[st]
+		if !ok {
+			continue
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			continue
+		}
+		d.secretDetectors = append(d.secretDetectors, namedRegex{name: st, re: re})
+	}
+
+	for _, cp := range customPatterns {
+		re, err := regexp.Compile(cp.Pattern)
+		if err != nil {
+			continue
+		}
+		d.customDetectors = append(d.customDetectors, namedRegex{name: cp.Name, re: re})
+	}
+
+	return d
+}
+
+// NewDefaultDetector creates a detector with all built-in PII and secret patterns.
+func NewDefaultDetector() *Detector {
+	piiTypes := make([]string, 0, len(builtinPII))
+	for k := range builtinPII {
+		piiTypes = append(piiTypes, k)
+	}
+	secretTypes := make([]string, 0, len(builtinSecrets))
+	for k := range builtinSecrets {
+		secretTypes = append(secretTypes, k)
+	}
+	return NewDetector(piiTypes, secretTypes, nil)
+}
+
+// Scan returns all matches found in the text.
+func (d *Detector) Scan(text string) []DetectorMatch {
+	var matches []DetectorMatch
+	for _, nr := range d.piiDetectors {
+		matches = append(matches, findMatches(nr, text)...)
+	}
+	for _, nr := range d.secretDetectors {
+		matches = append(matches, findMatches(nr, text)...)
+	}
+	for _, nr := range d.customDetectors {
+		matches = append(matches, findMatches(nr, text)...)
+	}
+	return matches
+}
+
+// ScanPII returns only PII matches.
+func (d *Detector) ScanPII(text string) []DetectorMatch {
+	var matches []DetectorMatch
+	for _, nr := range d.piiDetectors {
+		matches = append(matches, findMatches(nr, text)...)
+	}
+	return matches
+}
+
+// ScanSecrets returns only secret matches.
+func (d *Detector) ScanSecrets(text string) []DetectorMatch {
+	var matches []DetectorMatch
+	for _, nr := range d.secretDetectors {
+		matches = append(matches, findMatches(nr, text)...)
+	}
+	return matches
+}
+
+// HasMatches returns true if any pattern matches the text.
+func (d *Detector) HasMatches(text string) bool {
+	for _, nr := range d.piiDetectors {
+		if nr.re.MatchString(text) {
+			return true
+		}
+	}
+	for _, nr := range d.secretDetectors {
+		if nr.re.MatchString(text) {
+			return true
+		}
+	}
+	for _, nr := range d.customDetectors {
+		if nr.re.MatchString(text) {
+			return true
+		}
+	}
+	return false
+}
+
+// Redact replaces all detected matches in the text with [REDACTED:<type>].
+func (d *Detector) Redact(text string) string {
+	// Process all detectors
+	allDetectors := make([]namedRegex, 0, len(d.piiDetectors)+len(d.secretDetectors)+len(d.customDetectors))
+	allDetectors = append(allDetectors, d.piiDetectors...)
+	allDetectors = append(allDetectors, d.secretDetectors...)
+	allDetectors = append(allDetectors, d.customDetectors...)
+
+	result := text
+	for _, nr := range allDetectors {
+		replacement := "[REDACTED:" + strings.ToUpper(nr.name) + "]"
+		result = nr.re.ReplaceAllString(result, replacement)
+	}
+	return result
+}
+
+func findMatches(nr namedRegex, text string) []DetectorMatch {
+	locs := nr.re.FindAllStringIndex(text, -1)
+	matches := make([]DetectorMatch, 0, len(locs))
+	for _, loc := range locs {
+		matches = append(matches, DetectorMatch{
+			Type:  nr.name,
+			Value: text[loc[0]:loc[1]],
+			Start: loc[0],
+			End:   loc[1],
+		})
+	}
+	return matches
+}
+
+// ContainsKeywords checks if text contains any of the given keywords (case-insensitive).
+func ContainsKeywords(text string, keywords []string) []string {
+	lower := strings.ToLower(text)
+	var found []string
+	for _, kw := range keywords {
+		if strings.Contains(lower, strings.ToLower(kw)) {
+			found = append(found, kw)
+		}
+	}
+	return found
+}

--- a/internal/provider/middleware/detectors.go
+++ b/internal/provider/middleware/detectors.go
@@ -9,10 +9,10 @@ import (
 
 // DetectorMatch represents a single detection hit.
 type DetectorMatch struct {
-	Type    string // e.g. "email", "ssn", "api_key"
-	Value   string // the matched text
-	Start   int    // byte offset in source string
-	End     int    // byte offset end
+	Type  string // e.g. "email", "ssn", "api_key"
+	Value string // the matched text
+	Start int    // byte offset in source string
+	End   int    // byte offset end
 }
 
 // Detector scans text for sensitive patterns.

--- a/internal/provider/middleware/detectors_test.go
+++ b/internal/provider/middleware/detectors_test.go
@@ -1,0 +1,174 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+)
+
+func TestDetector_Email(t *testing.T) {
+	d := NewDetector([]string{"email"}, nil, nil)
+	matches := d.Scan("Contact us at test@example.com for help.")
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if matches[0].Type != "email" {
+		t.Errorf("expected type 'email', got %q", matches[0].Type)
+	}
+	if matches[0].Value != "test@example.com" {
+		t.Errorf("expected 'test@example.com', got %q", matches[0].Value)
+	}
+}
+
+func TestDetector_SSN(t *testing.T) {
+	d := NewDetector([]string{"ssn"}, nil, nil)
+	matches := d.Scan("SSN is 123-45-6789")
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if matches[0].Value != "123-45-6789" {
+		t.Errorf("expected '123-45-6789', got %q", matches[0].Value)
+	}
+}
+
+func TestDetector_CreditCard(t *testing.T) {
+	d := NewDetector([]string{"credit_card"}, nil, nil)
+	matches := d.Scan("Card: 4111-1111-1111-1111")
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+}
+
+func TestDetector_IPAddress(t *testing.T) {
+	d := NewDetector([]string{"ip_address"}, nil, nil)
+	matches := d.Scan("Server at 192.168.1.100 is down")
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if matches[0].Value != "192.168.1.100" {
+		t.Errorf("expected '192.168.1.100', got %q", matches[0].Value)
+	}
+}
+
+func TestDetector_APIKey(t *testing.T) {
+	d := NewDetector(nil, []string{"api_key"}, nil)
+	matches := d.Scan("Key: sk-abcdefghijklmnopqrstuvwx")
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if matches[0].Type != "api_key" {
+		t.Errorf("expected type 'api_key', got %q", matches[0].Type)
+	}
+}
+
+func TestDetector_BearerToken(t *testing.T) {
+	d := NewDetector(nil, []string{"bearer_token"}, nil)
+	matches := d.Scan("Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.test")
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+}
+
+func TestDetector_PrivateKey(t *testing.T) {
+	d := NewDetector(nil, []string{"private_key"}, nil)
+	matches := d.Scan("-----BEGIN RSA PRIVATE KEY-----\nMIIE...")
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+}
+
+func TestDetector_PasswordLiteral(t *testing.T) {
+	d := NewDetector(nil, []string{"password_literal"}, nil)
+	matches := d.Scan("password=mysecret123")
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+}
+
+func TestDetector_NoMatches(t *testing.T) {
+	d := NewDefaultDetector()
+	matches := d.Scan("This is a perfectly safe message with no sensitive data.")
+	if len(matches) != 0 {
+		t.Errorf("expected 0 matches, got %d: %+v", len(matches), matches)
+	}
+}
+
+func TestDetector_HasMatches(t *testing.T) {
+	d := NewDetector([]string{"email"}, nil, nil)
+	if !d.HasMatches("Email me at test@example.com") {
+		t.Error("expected HasMatches to return true")
+	}
+	if d.HasMatches("No email here") {
+		t.Error("expected HasMatches to return false")
+	}
+}
+
+func TestDetector_Redact(t *testing.T) {
+	d := NewDetector([]string{"email", "ssn"}, nil, nil)
+	result := d.Redact("Email: test@example.com SSN: 123-45-6789")
+	if result != "Email: [REDACTED:EMAIL] SSN: [REDACTED:SSN]" {
+		t.Errorf("unexpected redaction: %q", result)
+	}
+}
+
+func TestDetector_CustomPatterns(t *testing.T) {
+	d := NewDetector(nil, nil, []config.NamedPattern{
+		{Name: "employee_id", Pattern: `EMP-\d{6}`},
+	})
+	matches := d.Scan("Employee EMP-123456 submitted a request")
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if matches[0].Type != "employee_id" {
+		t.Errorf("expected type 'employee_id', got %q", matches[0].Type)
+	}
+}
+
+func TestDetector_ScanPII(t *testing.T) {
+	d := NewDetector([]string{"email"}, []string{"api_key"}, nil)
+	text := "Email: test@example.com Key: sk-abcdefghijklmnopqrstuvwx"
+	pii := d.ScanPII(text)
+	if len(pii) != 1 {
+		t.Fatalf("expected 1 PII match, got %d", len(pii))
+	}
+	if pii[0].Type != "email" {
+		t.Errorf("expected 'email', got %q", pii[0].Type)
+	}
+}
+
+func TestDetector_ScanSecrets(t *testing.T) {
+	d := NewDetector([]string{"email"}, []string{"api_key"}, nil)
+	text := "Email: test@example.com Key: sk-abcdefghijklmnopqrstuvwx"
+	secrets := d.ScanSecrets(text)
+	if len(secrets) != 1 {
+		t.Fatalf("expected 1 secret match, got %d", len(secrets))
+	}
+	if secrets[0].Type != "api_key" {
+		t.Errorf("expected 'api_key', got %q", secrets[0].Type)
+	}
+}
+
+func TestContainsKeywords(t *testing.T) {
+	found := ContainsKeywords("Please share your Social Security number", []string{"social security", "credit card"})
+	if len(found) != 1 {
+		t.Fatalf("expected 1 keyword, got %d", len(found))
+	}
+	if found[0] != "social security" {
+		t.Errorf("expected 'social security', got %q", found[0])
+	}
+
+	none := ContainsKeywords("Hello world", []string{"password", "secret"})
+	if len(none) != 0 {
+		t.Errorf("expected 0 keywords, got %d", len(none))
+	}
+}
+
+func TestNewDefaultDetector(t *testing.T) {
+	d := NewDefaultDetector()
+	if len(d.piiDetectors) == 0 {
+		t.Error("expected non-empty PII detectors")
+	}
+	if len(d.secretDetectors) == 0 {
+		t.Error("expected non-empty secret detectors")
+	}
+}

--- a/internal/provider/middleware/finops.go
+++ b/internal/provider/middleware/finops.go
@@ -1,0 +1,67 @@
+package middleware
+
+import (
+	"context"
+	"log"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+	"github.com/KafClaw/KafClaw/internal/provider"
+)
+
+// FinOpsRecorder calculates per-request cost and records attribution metadata.
+type FinOpsRecorder struct {
+	cfg config.FinOpsConfig
+}
+
+// NewFinOpsRecorder builds a recorder from config.
+func NewFinOpsRecorder(cfg config.FinOpsConfig) *FinOpsRecorder {
+	return &FinOpsRecorder{cfg: cfg}
+}
+
+func (f *FinOpsRecorder) Name() string { return "finops" }
+
+func (f *FinOpsRecorder) ProcessRequest(_ context.Context, _ *provider.ChatRequest, _ *RequestMeta) error {
+	return nil
+}
+
+func (f *FinOpsRecorder) ProcessResponse(_ context.Context, _ *provider.ChatRequest, resp *provider.ChatResponse, meta *RequestMeta) error {
+	if !f.cfg.Enabled {
+		return nil
+	}
+	if resp == nil {
+		return nil
+	}
+
+	provID := meta.ProviderID
+	pricing, ok := f.cfg.Pricing[provID]
+	if !ok {
+		return nil
+	}
+
+	promptTokens := float64(resp.Usage.PromptTokens)
+	completionTokens := float64(resp.Usage.CompletionTokens)
+	cost := (promptTokens*pricing.PromptPer1kTokens + completionTokens*pricing.CompletionPer1kTokens) / 1000.0
+
+	meta.CostUSD = cost
+
+	// Budget warnings (logged only; enforcement is up to the caller).
+	if f.cfg.DailyBudget > 0 && cost > f.cfg.DailyBudget*0.1 {
+		log.Printf("[finops] single request cost $%.4f exceeds 10%% of daily budget $%.2f for provider %s",
+			cost, f.cfg.DailyBudget, provID)
+	}
+
+	return nil
+}
+
+// CalculateCost computes the USD cost for a given usage and provider.
+func (f *FinOpsRecorder) CalculateCost(providerID string, usage provider.Usage) float64 {
+	if !f.cfg.Enabled {
+		return 0
+	}
+	pricing, ok := f.cfg.Pricing[providerID]
+	if !ok {
+		return 0
+	}
+	return (float64(usage.PromptTokens)*pricing.PromptPer1kTokens +
+		float64(usage.CompletionTokens)*pricing.CompletionPer1kTokens) / 1000.0
+}

--- a/internal/provider/middleware/finops_test.go
+++ b/internal/provider/middleware/finops_test.go
@@ -1,0 +1,76 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+	"github.com/KafClaw/KafClaw/internal/provider"
+)
+
+func TestFinOps_Disabled(t *testing.T) {
+	f := NewFinOpsRecorder(config.FinOpsConfig{Enabled: false})
+	meta := NewRequestMeta("openai", "gpt-4")
+	resp := &provider.ChatResponse{
+		Usage: provider.Usage{PromptTokens: 100, CompletionTokens: 50},
+	}
+	if err := f.ProcessResponse(context.Background(), nil, resp, meta); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if meta.CostUSD != 0 {
+		t.Errorf("expected zero cost when disabled, got %f", meta.CostUSD)
+	}
+}
+
+func TestFinOps_CalculatesCost(t *testing.T) {
+	f := NewFinOpsRecorder(config.FinOpsConfig{
+		Enabled: true,
+		Pricing: map[string]config.ProviderPricing{
+			"openai": {PromptPer1kTokens: 0.005, CompletionPer1kTokens: 0.015},
+		},
+	})
+	meta := NewRequestMeta("openai", "gpt-4")
+	resp := &provider.ChatResponse{
+		Usage: provider.Usage{PromptTokens: 1000, CompletionTokens: 500},
+	}
+	if err := f.ProcessResponse(context.Background(), nil, resp, meta); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	// cost = (1000*0.005 + 500*0.015) / 1000 = (5 + 7.5) / 1000 = 0.0125
+	expected := 0.0125
+	if meta.CostUSD < expected-0.0001 || meta.CostUSD > expected+0.0001 {
+		t.Errorf("expected cost ~%f, got %f", expected, meta.CostUSD)
+	}
+}
+
+func TestFinOps_NoPricing(t *testing.T) {
+	f := NewFinOpsRecorder(config.FinOpsConfig{
+		Enabled: true,
+		Pricing: map[string]config.ProviderPricing{},
+	})
+	meta := NewRequestMeta("openai", "gpt-4")
+	resp := &provider.ChatResponse{
+		Usage: provider.Usage{PromptTokens: 100, CompletionTokens: 50},
+	}
+	if err := f.ProcessResponse(context.Background(), nil, resp, meta); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if meta.CostUSD != 0 {
+		t.Errorf("expected zero cost for unknown provider, got %f", meta.CostUSD)
+	}
+}
+
+func TestFinOps_CalculateCostDirect(t *testing.T) {
+	f := NewFinOpsRecorder(config.FinOpsConfig{
+		Enabled: true,
+		Pricing: map[string]config.ProviderPricing{
+			"claude": {PromptPer1kTokens: 0.015, CompletionPer1kTokens: 0.075},
+		},
+	})
+	cost := f.CalculateCost("claude", provider.Usage{PromptTokens: 2000, CompletionTokens: 1000})
+	// (2000*0.015 + 1000*0.075) / 1000 = (30 + 75) / 1000 = 0.105
+	expected := 0.105
+	if cost < expected-0.001 || cost > expected+0.001 {
+		t.Errorf("expected cost ~%f, got %f", expected, cost)
+	}
+}

--- a/internal/provider/middleware/middleware.go
+++ b/internal/provider/middleware/middleware.go
@@ -1,0 +1,108 @@
+// Package middleware provides a chain of interceptors between the agent loop
+// and the LLM provider. Middleware can inspect, transform, reroute, or filter
+// messages before and after the LLM call.
+package middleware
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KafClaw/KafClaw/internal/provider"
+)
+
+// ChatMiddleware intercepts LLM requests and/or responses.
+type ChatMiddleware interface {
+	// Name returns a short identifier for logging/metrics.
+	Name() string
+	// ProcessRequest is called before the LLM call. It may modify the request,
+	// replace the provider (by setting meta.ProviderOverride), or return an
+	// error to abort.
+	ProcessRequest(ctx context.Context, req *provider.ChatRequest, meta *RequestMeta) error
+	// ProcessResponse is called after the LLM call. It may modify the response
+	// or return an error to suppress delivery.
+	ProcessResponse(ctx context.Context, req *provider.ChatRequest, resp *provider.ChatResponse, meta *RequestMeta) error
+}
+
+// RequestMeta carries mutable context through the chain.
+type RequestMeta struct {
+	ProviderID       string            // resolved provider; middleware can override
+	ModelName        string            // resolved model; middleware can override
+	SenderID         string            // who sent the message
+	Channel          string            // e.g. "telegram", "discord", "cli"
+	MessageType      string            // "internal" / "external"
+	Tags             map[string]string // classification tags (e.g. "sensitivity":"pii", "task":"coding")
+	Blocked          bool              // set by PromptGuard to abort
+	BlockReason      string            // reason for blocking
+	ProviderOverride provider.LLMProvider // middleware can swap the provider
+	CostUSD          float64           // set by FinOps recorder
+}
+
+// NewRequestMeta creates a RequestMeta with initialized Tags map.
+func NewRequestMeta(providerID, modelName string) *RequestMeta {
+	return &RequestMeta{
+		ProviderID: providerID,
+		ModelName:  modelName,
+		Tags:       make(map[string]string),
+	}
+}
+
+// Chain holds an ordered list of middleware and a default provider.
+// It runs pre-hooks in order, calls the provider, then runs post-hooks in order.
+type Chain struct {
+	Middlewares []ChatMiddleware
+	Provider    provider.LLMProvider
+}
+
+// NewChain creates a chain with the given provider and no middleware.
+func NewChain(prov provider.LLMProvider) *Chain {
+	return &Chain{
+		Provider: prov,
+	}
+}
+
+// Use appends middleware to the chain.
+func (c *Chain) Use(mw ...ChatMiddleware) {
+	c.Middlewares = append(c.Middlewares, mw...)
+}
+
+// Process runs the middleware chain: pre-hooks → LLM call → post-hooks.
+// If no middleware is configured, it's a zero-overhead passthrough.
+func (c *Chain) Process(ctx context.Context, req *provider.ChatRequest, meta *RequestMeta) (*provider.ChatResponse, error) {
+	if meta == nil {
+		meta = NewRequestMeta("", "")
+	}
+
+	// Run pre-hooks.
+	for _, mw := range c.Middlewares {
+		if err := mw.ProcessRequest(ctx, req, meta); err != nil {
+			return nil, fmt.Errorf("middleware %s pre-hook: %w", mw.Name(), err)
+		}
+		if meta.Blocked {
+			return &provider.ChatResponse{
+				Content:      fmt.Sprintf("[blocked by %s] %s", mw.Name(), meta.BlockReason),
+				FinishReason: "blocked",
+			}, nil
+		}
+	}
+
+	// Determine the provider to use.
+	prov := c.Provider
+	if meta.ProviderOverride != nil {
+		prov = meta.ProviderOverride
+	}
+
+	// Make the LLM call.
+	resp, err := prov.Chat(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Run post-hooks.
+	for _, mw := range c.Middlewares {
+		if err := mw.ProcessResponse(ctx, req, resp, meta); err != nil {
+			return nil, fmt.Errorf("middleware %s post-hook: %w", mw.Name(), err)
+		}
+	}
+
+	return resp, nil
+}

--- a/internal/provider/middleware/middleware.go
+++ b/internal/provider/middleware/middleware.go
@@ -25,16 +25,16 @@ type ChatMiddleware interface {
 
 // RequestMeta carries mutable context through the chain.
 type RequestMeta struct {
-	ProviderID       string            // resolved provider; middleware can override
-	ModelName        string            // resolved model; middleware can override
-	SenderID         string            // who sent the message
-	Channel          string            // e.g. "telegram", "discord", "cli"
-	MessageType      string            // "internal" / "external"
-	Tags             map[string]string // classification tags (e.g. "sensitivity":"pii", "task":"coding")
-	Blocked          bool              // set by PromptGuard to abort
-	BlockReason      string            // reason for blocking
+	ProviderID       string               // resolved provider; middleware can override
+	ModelName        string               // resolved model; middleware can override
+	SenderID         string               // who sent the message
+	Channel          string               // e.g. "telegram", "discord", "cli"
+	MessageType      string               // "internal" / "external"
+	Tags             map[string]string    // classification tags (e.g. "sensitivity":"pii", "task":"coding")
+	Blocked          bool                 // set by PromptGuard to abort
+	BlockReason      string               // reason for blocking
 	ProviderOverride provider.LLMProvider // middleware can swap the provider
-	CostUSD          float64           // set by FinOps recorder
+	CostUSD          float64              // set by FinOps recorder
 }
 
 // NewRequestMeta creates a RequestMeta with initialized Tags map.

--- a/internal/provider/middleware/middleware_test.go
+++ b/internal/provider/middleware/middleware_test.go
@@ -1,0 +1,239 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KafClaw/KafClaw/internal/provider"
+)
+
+// mockProvider is a simple test provider.
+type mockProvider struct {
+	response *provider.ChatResponse
+	err      error
+	called   bool
+}
+
+func (m *mockProvider) Chat(_ context.Context, _ *provider.ChatRequest) (*provider.ChatResponse, error) {
+	m.called = true
+	return m.response, m.err
+}
+
+func (m *mockProvider) Transcribe(_ context.Context, _ *provider.AudioRequest) (*provider.AudioResponse, error) {
+	return nil, nil
+}
+
+func (m *mockProvider) Speak(_ context.Context, _ *provider.TTSRequest) (*provider.TTSResponse, error) {
+	return nil, nil
+}
+
+func (m *mockProvider) DefaultModel() string { return "mock-model" }
+
+// noopMiddleware does nothing.
+type noopMiddleware struct{}
+
+func (n *noopMiddleware) Name() string { return "noop" }
+func (n *noopMiddleware) ProcessRequest(_ context.Context, _ *provider.ChatRequest, _ *RequestMeta) error {
+	return nil
+}
+func (n *noopMiddleware) ProcessResponse(_ context.Context, _ *provider.ChatRequest, _ *provider.ChatResponse, _ *RequestMeta) error {
+	return nil
+}
+
+// tagMiddleware sets a tag in ProcessRequest and reads response in ProcessResponse.
+type tagMiddleware struct {
+	tagKey   string
+	tagValue string
+	postSeen bool
+}
+
+func (t *tagMiddleware) Name() string { return "tagger" }
+func (t *tagMiddleware) ProcessRequest(_ context.Context, _ *provider.ChatRequest, meta *RequestMeta) error {
+	meta.Tags[t.tagKey] = t.tagValue
+	return nil
+}
+func (t *tagMiddleware) ProcessResponse(_ context.Context, _ *provider.ChatRequest, _ *provider.ChatResponse, _ *RequestMeta) error {
+	t.postSeen = true
+	return nil
+}
+
+// blockMiddleware blocks requests.
+type blockMiddleware struct{}
+
+func (b *blockMiddleware) Name() string { return "blocker" }
+func (b *blockMiddleware) ProcessRequest(_ context.Context, _ *provider.ChatRequest, meta *RequestMeta) error {
+	meta.Blocked = true
+	meta.BlockReason = "test block"
+	return nil
+}
+func (b *blockMiddleware) ProcessResponse(_ context.Context, _ *provider.ChatRequest, _ *provider.ChatResponse, _ *RequestMeta) error {
+	return nil
+}
+
+func TestChain_Passthrough(t *testing.T) {
+	mp := &mockProvider{response: &provider.ChatResponse{Content: "hello"}}
+	chain := NewChain(mp)
+
+	req := &provider.ChatRequest{Messages: []provider.Message{{Role: "user", Content: "hi"}}}
+	resp, err := chain.Process(context.Background(), req, nil)
+	if err != nil {
+		t.Fatalf("Process() error: %v", err)
+	}
+	if resp.Content != "hello" {
+		t.Errorf("expected 'hello', got %q", resp.Content)
+	}
+	if !mp.called {
+		t.Error("expected provider to be called")
+	}
+}
+
+func TestChain_NoopMiddleware(t *testing.T) {
+	mp := &mockProvider{response: &provider.ChatResponse{Content: "hello"}}
+	chain := NewChain(mp)
+	chain.Use(&noopMiddleware{})
+
+	req := &provider.ChatRequest{Messages: []provider.Message{{Role: "user", Content: "hi"}}}
+	resp, err := chain.Process(context.Background(), req, NewRequestMeta("test", "model"))
+	if err != nil {
+		t.Fatalf("Process() error: %v", err)
+	}
+	if resp.Content != "hello" {
+		t.Errorf("expected 'hello', got %q", resp.Content)
+	}
+}
+
+func TestChain_TagMiddleware(t *testing.T) {
+	mp := &mockProvider{response: &provider.ChatResponse{Content: "world"}}
+	chain := NewChain(mp)
+	tagger := &tagMiddleware{tagKey: "task", tagValue: "coding"}
+	chain.Use(tagger)
+
+	meta := NewRequestMeta("openai", "gpt-4")
+	req := &provider.ChatRequest{Messages: []provider.Message{{Role: "user", Content: "code"}}}
+	resp, err := chain.Process(context.Background(), req, meta)
+	if err != nil {
+		t.Fatalf("Process() error: %v", err)
+	}
+	if resp.Content != "world" {
+		t.Errorf("expected 'world', got %q", resp.Content)
+	}
+	if meta.Tags["task"] != "coding" {
+		t.Errorf("expected tag 'coding', got %q", meta.Tags["task"])
+	}
+	if !tagger.postSeen {
+		t.Error("expected post-hook to run")
+	}
+}
+
+func TestChain_BlockedRequest(t *testing.T) {
+	mp := &mockProvider{response: &provider.ChatResponse{Content: "should not see"}}
+	chain := NewChain(mp)
+	chain.Use(&blockMiddleware{})
+
+	meta := NewRequestMeta("openai", "gpt-4")
+	req := &provider.ChatRequest{Messages: []provider.Message{{Role: "user", Content: "blocked content"}}}
+	resp, err := chain.Process(context.Background(), req, meta)
+	if err != nil {
+		t.Fatalf("Process() error: %v", err)
+	}
+	if resp.FinishReason != "blocked" {
+		t.Errorf("expected finish_reason 'blocked', got %q", resp.FinishReason)
+	}
+	if mp.called {
+		t.Error("expected provider NOT to be called when blocked")
+	}
+}
+
+func TestChain_ProviderOverride(t *testing.T) {
+	mp1 := &mockProvider{response: &provider.ChatResponse{Content: "from mp1"}}
+	mp2 := &mockProvider{response: &provider.ChatResponse{Content: "from mp2"}}
+
+	// Middleware that swaps the provider
+	swapper := &providerSwapMiddleware{replacement: mp2}
+	chain := NewChain(mp1)
+	chain.Use(swapper)
+
+	meta := NewRequestMeta("original", "model")
+	req := &provider.ChatRequest{Messages: []provider.Message{{Role: "user", Content: "hi"}}}
+	resp, err := chain.Process(context.Background(), req, meta)
+	if err != nil {
+		t.Fatalf("Process() error: %v", err)
+	}
+	if resp.Content != "from mp2" {
+		t.Errorf("expected 'from mp2', got %q", resp.Content)
+	}
+	if mp1.called {
+		t.Error("expected original provider NOT to be called")
+	}
+	if !mp2.called {
+		t.Error("expected replacement provider to be called")
+	}
+}
+
+type providerSwapMiddleware struct {
+	replacement provider.LLMProvider
+}
+
+func (p *providerSwapMiddleware) Name() string { return "swapper" }
+func (p *providerSwapMiddleware) ProcessRequest(_ context.Context, _ *provider.ChatRequest, meta *RequestMeta) error {
+	meta.ProviderOverride = p.replacement
+	return nil
+}
+func (p *providerSwapMiddleware) ProcessResponse(_ context.Context, _ *provider.ChatRequest, _ *provider.ChatResponse, _ *RequestMeta) error {
+	return nil
+}
+
+func TestChain_MultipleMiddlewareOrdering(t *testing.T) {
+	mp := &mockProvider{response: &provider.ChatResponse{Content: "ok"}}
+	chain := NewChain(mp)
+
+	order := make([]string, 0, 4)
+	chain.Use(
+		&orderTracker{name: "first", order: &order},
+		&orderTracker{name: "second", order: &order},
+	)
+
+	meta := NewRequestMeta("test", "model")
+	req := &provider.ChatRequest{Messages: []provider.Message{{Role: "user", Content: "hi"}}}
+	_, err := chain.Process(context.Background(), req, meta)
+	if err != nil {
+		t.Fatalf("Process() error: %v", err)
+	}
+	expected := []string{"first-pre", "second-pre", "first-post", "second-post"}
+	if len(order) != len(expected) {
+		t.Fatalf("expected %d events, got %d: %v", len(expected), len(order), order)
+	}
+	for i, v := range expected {
+		if order[i] != v {
+			t.Errorf("event[%d] = %q, want %q", i, order[i], v)
+		}
+	}
+}
+
+type orderTracker struct {
+	name  string
+	order *[]string
+}
+
+func (o *orderTracker) Name() string { return o.name }
+func (o *orderTracker) ProcessRequest(_ context.Context, _ *provider.ChatRequest, _ *RequestMeta) error {
+	*o.order = append(*o.order, o.name+"-pre")
+	return nil
+}
+func (o *orderTracker) ProcessResponse(_ context.Context, _ *provider.ChatRequest, _ *provider.ChatResponse, _ *RequestMeta) error {
+	*o.order = append(*o.order, o.name+"-post")
+	return nil
+}
+
+func TestNewRequestMeta(t *testing.T) {
+	meta := NewRequestMeta("openai", "gpt-4")
+	if meta.ProviderID != "openai" {
+		t.Errorf("expected provider 'openai', got %q", meta.ProviderID)
+	}
+	if meta.ModelName != "gpt-4" {
+		t.Errorf("expected model 'gpt-4', got %q", meta.ModelName)
+	}
+	if meta.Tags == nil {
+		t.Error("expected non-nil Tags map")
+	}
+}

--- a/internal/provider/middleware/promptguard.go
+++ b/internal/provider/middleware/promptguard.go
@@ -1,0 +1,136 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+	"github.com/KafClaw/KafClaw/internal/provider"
+)
+
+// PromptGuard scans inbound messages for PII, secrets, and deny-keywords.
+// Depending on mode it can warn (tag only), redact, or block.
+type PromptGuard struct {
+	cfg          config.PromptGuardConfig
+	detector     *Detector
+	denyKeywords []string
+}
+
+// NewPromptGuard builds a guard from config.
+func NewPromptGuard(cfg config.PromptGuardConfig) *PromptGuard {
+	piiTypes := cfg.PII.Detect
+	secretTypes := cfg.Secrets.Detect
+	var custom []config.NamedPattern
+	custom = append(custom, cfg.PII.CustomPatterns...)
+	custom = append(custom, cfg.Secrets.CustomPatterns...)
+	custom = append(custom, cfg.CustomPatterns...)
+
+	return &PromptGuard{
+		cfg:          cfg,
+		detector:     NewDetector(piiTypes, secretTypes, custom),
+		denyKeywords: cfg.DenyKeywords,
+	}
+}
+
+func (g *PromptGuard) Name() string { return "prompt-guard" }
+
+func (g *PromptGuard) ProcessRequest(_ context.Context, req *provider.ChatRequest, meta *RequestMeta) error {
+	if !g.cfg.Enabled {
+		return nil
+	}
+
+	mode := g.cfg.Mode
+	if mode == "" {
+		mode = "warn"
+	}
+
+	// Scan user messages only.
+	for i, msg := range req.Messages {
+		if msg.Role != "user" {
+			continue
+		}
+
+		// Check deny keywords first — always block.
+		found := ContainsKeywords(msg.Content, g.denyKeywords)
+		if len(found) > 0 {
+			meta.Blocked = true
+			meta.BlockReason = fmt.Sprintf("denied keyword(s): %s", strings.Join(found, ", "))
+			return nil
+		}
+
+		matches := g.detector.Scan(msg.Content)
+		if len(matches) == 0 {
+			continue
+		}
+
+		// Determine action.
+		action := mode
+		// PII-specific action override.
+		if g.cfg.PII.Action != "" {
+			for _, m := range matches {
+				if isPIIType(m.Type) {
+					action = g.cfg.PII.Action
+					break
+				}
+			}
+		}
+		// Secret-specific action override.
+		if g.cfg.Secrets.Action != "" {
+			for _, m := range matches {
+				if isSecretType(m.Type) {
+					action = g.cfg.Secrets.Action
+					break
+				}
+			}
+		}
+
+		switch action {
+		case "block":
+			types := matchTypes(matches)
+			meta.Blocked = true
+			meta.BlockReason = fmt.Sprintf("detected %s in message", strings.Join(types, ", "))
+			return nil
+		case "redact":
+			req.Messages[i].Content = g.detector.Redact(msg.Content)
+			meta.Tags["prompt_guard"] = "redacted"
+		default: // "warn"
+			meta.Tags["prompt_guard"] = "detected"
+		}
+	}
+
+	return nil
+}
+
+func (g *PromptGuard) ProcessResponse(_ context.Context, _ *provider.ChatRequest, _ *provider.ChatResponse, _ *RequestMeta) error {
+	// Output scanning is handled by OutputSanitizer.
+	return nil
+}
+
+func isPIIType(t string) bool {
+	switch t {
+	case "email", "phone", "ssn", "credit_card", "ip_address":
+		return true
+	}
+	return false
+}
+
+func isSecretType(t string) bool {
+	switch t {
+	case "api_key", "bearer_token", "private_key", "password_literal":
+		return true
+	}
+	return false
+}
+
+func matchTypes(matches []DetectorMatch) []string {
+	seen := make(map[string]bool)
+	var types []string
+	for _, m := range matches {
+		if !seen[m.Type] {
+			seen[m.Type] = true
+			types = append(types, m.Type)
+		}
+	}
+	return types
+}

--- a/internal/provider/middleware/promptguard_test.go
+++ b/internal/provider/middleware/promptguard_test.go
@@ -1,0 +1,129 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+	"github.com/KafClaw/KafClaw/internal/provider"
+)
+
+func TestPromptGuard_Disabled(t *testing.T) {
+	g := NewPromptGuard(config.PromptGuardConfig{Enabled: false})
+	meta := NewRequestMeta("openai", "gpt-4")
+	req := &provider.ChatRequest{Messages: []provider.Message{{Role: "user", Content: "123-45-6789"}}}
+	if err := g.ProcessRequest(context.Background(), req, meta); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if meta.Blocked {
+		t.Error("expected not blocked when disabled")
+	}
+}
+
+func TestPromptGuard_WarnMode(t *testing.T) {
+	g := NewPromptGuard(config.PromptGuardConfig{
+		Enabled: true,
+		Mode:    "warn",
+		PII:     config.PIIConfig{Detect: []string{"ssn"}},
+	})
+	meta := NewRequestMeta("openai", "gpt-4")
+	req := &provider.ChatRequest{Messages: []provider.Message{{Role: "user", Content: "SSN: 123-45-6789"}}}
+	if err := g.ProcessRequest(context.Background(), req, meta); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if meta.Blocked {
+		t.Error("expected not blocked in warn mode")
+	}
+	if meta.Tags["prompt_guard"] != "detected" {
+		t.Errorf("expected tag=detected, got %q", meta.Tags["prompt_guard"])
+	}
+}
+
+func TestPromptGuard_BlockMode(t *testing.T) {
+	g := NewPromptGuard(config.PromptGuardConfig{
+		Enabled: true,
+		Mode:    "block",
+		PII:     config.PIIConfig{Detect: []string{"ssn"}},
+	})
+	meta := NewRequestMeta("openai", "gpt-4")
+	req := &provider.ChatRequest{Messages: []provider.Message{{Role: "user", Content: "SSN: 123-45-6789"}}}
+	if err := g.ProcessRequest(context.Background(), req, meta); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !meta.Blocked {
+		t.Error("expected blocked in block mode")
+	}
+}
+
+func TestPromptGuard_RedactMode(t *testing.T) {
+	g := NewPromptGuard(config.PromptGuardConfig{
+		Enabled: true,
+		Mode:    "redact",
+		PII:     config.PIIConfig{Detect: []string{"email"}},
+	})
+	meta := NewRequestMeta("openai", "gpt-4")
+	req := &provider.ChatRequest{Messages: []provider.Message{{Role: "user", Content: "Email me at test@example.com"}}}
+	if err := g.ProcessRequest(context.Background(), req, meta); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if meta.Blocked {
+		t.Error("expected not blocked in redact mode")
+	}
+	if req.Messages[0].Content != "Email me at [REDACTED:EMAIL]" {
+		t.Errorf("expected redacted content, got %q", req.Messages[0].Content)
+	}
+}
+
+func TestPromptGuard_DenyKeywords(t *testing.T) {
+	g := NewPromptGuard(config.PromptGuardConfig{
+		Enabled:      true,
+		Mode:         "warn",
+		DenyKeywords: []string{"bomb", "weapon"},
+	})
+	meta := NewRequestMeta("openai", "gpt-4")
+	req := &provider.ChatRequest{Messages: []provider.Message{{Role: "user", Content: "How to make a bomb"}}}
+	if err := g.ProcessRequest(context.Background(), req, meta); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !meta.Blocked {
+		t.Error("expected blocked for deny keyword")
+	}
+	if meta.BlockReason == "" {
+		t.Error("expected block reason")
+	}
+}
+
+func TestPromptGuard_NoMatch(t *testing.T) {
+	g := NewPromptGuard(config.PromptGuardConfig{
+		Enabled: true,
+		Mode:    "block",
+		PII:     config.PIIConfig{Detect: []string{"ssn"}},
+	})
+	meta := NewRequestMeta("openai", "gpt-4")
+	req := &provider.ChatRequest{Messages: []provider.Message{{Role: "user", Content: "What is the weather?"}}}
+	if err := g.ProcessRequest(context.Background(), req, meta); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if meta.Blocked {
+		t.Error("expected not blocked for clean message")
+	}
+}
+
+func TestPromptGuard_SkipsSystemMessages(t *testing.T) {
+	g := NewPromptGuard(config.PromptGuardConfig{
+		Enabled: true,
+		Mode:    "block",
+		PII:     config.PIIConfig{Detect: []string{"ssn"}},
+	})
+	meta := NewRequestMeta("openai", "gpt-4")
+	req := &provider.ChatRequest{Messages: []provider.Message{
+		{Role: "system", Content: "SSN: 123-45-6789"},
+		{Role: "user", Content: "hello"},
+	}}
+	if err := g.ProcessRequest(context.Background(), req, meta); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if meta.Blocked {
+		t.Error("expected not blocked for system message SSN")
+	}
+}

--- a/internal/provider/middleware/sanitizer.go
+++ b/internal/provider/middleware/sanitizer.go
@@ -1,0 +1,119 @@
+package middleware
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+	"github.com/KafClaw/KafClaw/internal/provider"
+)
+
+// OutputSanitizer scans LLM responses for PII, secrets, and deny patterns
+// before they reach the channel delivery path.
+type OutputSanitizer struct {
+	cfg          config.OutputSanitizationConfig
+	detector     *Detector
+	denyPatterns []*regexp.Regexp
+}
+
+// NewOutputSanitizer builds a sanitizer from config.
+func NewOutputSanitizer(cfg config.OutputSanitizationConfig) *OutputSanitizer {
+	var piiTypes, secretTypes []string
+	if cfg.RedactPII {
+		piiTypes = []string{"email", "phone", "ssn", "credit_card", "ip_address"}
+	}
+	if cfg.RedactSecrets {
+		secretTypes = []string{"api_key", "bearer_token", "private_key", "password_literal"}
+	}
+
+	var deny []*regexp.Regexp
+	for _, p := range cfg.DenyPatterns {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			continue
+		}
+		deny = append(deny, re)
+	}
+
+	return &OutputSanitizer{
+		cfg:          cfg,
+		detector:     NewDetector(piiTypes, secretTypes, cfg.CustomRedactPatterns),
+		denyPatterns: deny,
+	}
+}
+
+func (s *OutputSanitizer) Name() string { return "output-sanitizer" }
+
+func (s *OutputSanitizer) ProcessRequest(_ context.Context, _ *provider.ChatRequest, _ *RequestMeta) error {
+	return nil
+}
+
+func (s *OutputSanitizer) ProcessResponse(_ context.Context, _ *provider.ChatRequest, resp *provider.ChatResponse, meta *RequestMeta) error {
+	if !s.cfg.Enabled {
+		return nil
+	}
+
+	content := resp.Content
+
+	// Check deny patterns — replace entire response.
+	for _, re := range s.denyPatterns {
+		if re.MatchString(content) {
+			resp.Content = "[Response filtered by output sanitizer]"
+			meta.Tags["output_sanitized"] = "denied"
+			return nil
+		}
+	}
+
+	// Redact PII/secrets.
+	if s.cfg.RedactPII || s.cfg.RedactSecrets || len(s.cfg.CustomRedactPatterns) > 0 {
+		redacted := s.detector.Redact(content)
+		if redacted != content {
+			resp.Content = redacted
+			meta.Tags["output_sanitized"] = "redacted"
+		}
+	}
+
+	// Truncate if needed.
+	if s.cfg.MaxOutputLength > 0 && len(resp.Content) > s.cfg.MaxOutputLength {
+		resp.Content = resp.Content[:s.cfg.MaxOutputLength] + "\n[truncated by output sanitizer]"
+		if _, ok := meta.Tags["output_sanitized"]; !ok {
+			meta.Tags["output_sanitized"] = "truncated"
+		}
+	}
+
+	return nil
+}
+
+// SanitizeText is a standalone helper for sanitizing arbitrary text using the
+// same detector logic (useful outside the middleware chain).
+func (s *OutputSanitizer) SanitizeText(text string) string {
+	// Check deny
+	for _, re := range s.denyPatterns {
+		if re.MatchString(text) {
+			return "[Content filtered]"
+		}
+	}
+	result := s.detector.Redact(text)
+	if s.cfg.MaxOutputLength > 0 && len(result) > s.cfg.MaxOutputLength {
+		result = result[:s.cfg.MaxOutputLength]
+	}
+	return result
+}
+
+// QuickRedact is a convenience function that redacts PII and secrets from text
+// without needing a full config setup.
+func QuickRedact(text string) string {
+	d := NewDefaultDetector()
+	return d.Redact(text)
+}
+
+// MaskSecret partially masks a secret value, showing only the first and last
+// few characters. Useful for displaying credential snippets safely.
+func MaskSecret(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= 8 {
+		return "***"
+	}
+	return s[:4] + "..." + s[len(s)-4:]
+}

--- a/internal/provider/middleware/sanitizer_test.go
+++ b/internal/provider/middleware/sanitizer_test.go
@@ -1,0 +1,123 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+	"github.com/KafClaw/KafClaw/internal/provider"
+)
+
+func TestSanitizer_Disabled(t *testing.T) {
+	s := NewOutputSanitizer(config.OutputSanitizationConfig{Enabled: false})
+	meta := NewRequestMeta("openai", "gpt-4")
+	resp := &provider.ChatResponse{Content: "SSN: 123-45-6789"}
+	if err := s.ProcessResponse(context.Background(), nil, resp, meta); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if resp.Content != "SSN: 123-45-6789" {
+		t.Error("expected content unchanged when disabled")
+	}
+}
+
+func TestSanitizer_RedactPII(t *testing.T) {
+	s := NewOutputSanitizer(config.OutputSanitizationConfig{
+		Enabled:   true,
+		RedactPII: true,
+	})
+	meta := NewRequestMeta("openai", "gpt-4")
+	resp := &provider.ChatResponse{Content: "Contact test@example.com for help"}
+	if err := s.ProcessResponse(context.Background(), nil, resp, meta); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if resp.Content != "Contact [REDACTED:EMAIL] for help" {
+		t.Errorf("expected redacted email, got %q", resp.Content)
+	}
+	if meta.Tags["output_sanitized"] != "redacted" {
+		t.Errorf("expected tag=redacted, got %q", meta.Tags["output_sanitized"])
+	}
+}
+
+func TestSanitizer_RedactSecrets(t *testing.T) {
+	s := NewOutputSanitizer(config.OutputSanitizationConfig{
+		Enabled:       true,
+		RedactSecrets: true,
+	})
+	meta := NewRequestMeta("openai", "gpt-4")
+	resp := &provider.ChatResponse{Content: "Key: sk-abcdefghijklmnopqrstuvwx done"}
+	if err := s.ProcessResponse(context.Background(), nil, resp, meta); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if resp.Content != "Key: [REDACTED:API_KEY] done" {
+		t.Errorf("expected redacted key, got %q", resp.Content)
+	}
+}
+
+func TestSanitizer_DenyPatterns(t *testing.T) {
+	s := NewOutputSanitizer(config.OutputSanitizationConfig{
+		Enabled:      true,
+		DenyPatterns: []string{`(?i)forbidden\s+content`},
+	})
+	meta := NewRequestMeta("openai", "gpt-4")
+	resp := &provider.ChatResponse{Content: "This contains Forbidden Content that should be blocked"}
+	if err := s.ProcessResponse(context.Background(), nil, resp, meta); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if resp.Content != "[Response filtered by output sanitizer]" {
+		t.Errorf("expected filtered response, got %q", resp.Content)
+	}
+}
+
+func TestSanitizer_MaxOutputLength(t *testing.T) {
+	s := NewOutputSanitizer(config.OutputSanitizationConfig{
+		Enabled:         true,
+		MaxOutputLength: 20,
+	})
+	meta := NewRequestMeta("openai", "gpt-4")
+	resp := &provider.ChatResponse{Content: "This is a very long response that exceeds the maximum length"}
+	if err := s.ProcessResponse(context.Background(), nil, resp, meta); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(resp.Content) > 60 {
+		t.Errorf("expected truncated response, got len=%d", len(resp.Content))
+	}
+}
+
+func TestSanitizer_NoMatch(t *testing.T) {
+	s := NewOutputSanitizer(config.OutputSanitizationConfig{
+		Enabled:   true,
+		RedactPII: true,
+	})
+	meta := NewRequestMeta("openai", "gpt-4")
+	resp := &provider.ChatResponse{Content: "Safe response with no PII"}
+	if err := s.ProcessResponse(context.Background(), nil, resp, meta); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if resp.Content != "Safe response with no PII" {
+		t.Errorf("expected unchanged content, got %q", resp.Content)
+	}
+}
+
+func TestQuickRedact(t *testing.T) {
+	result := QuickRedact("My email is test@example.com and SSN 123-45-6789")
+	if result == "My email is test@example.com and SSN 123-45-6789" {
+		t.Error("expected redacted output")
+	}
+}
+
+func TestMaskSecret(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"short", "***"},
+		{"sk-abcdefghijklmnop", "sk-a...mnop"},
+		{"", "***"},
+	}
+	for _, tt := range tests {
+		got := MaskSecret(tt.input)
+		if got != tt.want {
+			t.Errorf("MaskSecret(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 
 import (
 	"context"
+	"time"
 )
 
 // LLMProvider is the interface for LLM API clients.
@@ -86,11 +87,17 @@ type FunctionDef struct {
 	Parameters  map[string]any `json:"parameters"`
 }
 
-// Usage contains token usage information.
+// Usage contains token usage information and optional rate limit data.
 type Usage struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
+	// Populated from HTTP response headers where the provider exposes them.
+	// nil means the provider did not report this value.
+	RemainingTokens   *int       `json:"remaining_tokens,omitempty"`
+	RemainingRequests *int       `json:"remaining_requests,omitempty"`
+	LimitTokens       *int       `json:"limit_tokens,omitempty"`
+	ResetAt           *time.Time `json:"reset_at,omitempty"`
 }
 
 // Embedder is an optional interface for providers that support embedding.

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -128,6 +128,107 @@ func TestOpenAIProvider_ParseToolCallResponse(t *testing.T) {
 	}
 }
 
+func TestParseOpenAIRateLimitHeaders(t *testing.T) {
+	t.Run("all headers present", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("x-ratelimit-remaining-tokens", "5000")
+		h.Set("x-ratelimit-remaining-requests", "100")
+		h.Set("x-ratelimit-limit-tokens", "10000")
+		h.Set("x-ratelimit-reset-tokens", "2026-02-21T12:00:00Z")
+		u := &Usage{}
+		parseOpenAIRateLimitHeaders(h, u)
+
+		if u.RemainingTokens == nil || *u.RemainingTokens != 5000 {
+			t.Errorf("expected remaining tokens 5000, got %v", u.RemainingTokens)
+		}
+		if u.RemainingRequests == nil || *u.RemainingRequests != 100 {
+			t.Errorf("expected remaining requests 100, got %v", u.RemainingRequests)
+		}
+		if u.LimitTokens == nil || *u.LimitTokens != 10000 {
+			t.Errorf("expected limit tokens 10000, got %v", u.LimitTokens)
+		}
+		if u.ResetAt == nil {
+			t.Error("expected reset time to be set")
+		}
+	})
+
+	t.Run("no headers", func(t *testing.T) {
+		h := http.Header{}
+		u := &Usage{}
+		parseOpenAIRateLimitHeaders(h, u)
+
+		if u.RemainingTokens != nil || u.RemainingRequests != nil || u.LimitTokens != nil || u.ResetAt != nil {
+			t.Error("expected all rate limit fields to be nil")
+		}
+	})
+
+	t.Run("malformed values", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("x-ratelimit-remaining-tokens", "not-a-number")
+		h.Set("x-ratelimit-reset-tokens", "not-a-date")
+		u := &Usage{}
+		parseOpenAIRateLimitHeaders(h, u)
+
+		if u.RemainingTokens != nil {
+			t.Error("expected nil for malformed token count")
+		}
+		if u.ResetAt != nil {
+			t.Error("expected nil for malformed reset time")
+		}
+	})
+
+	t.Run("anthropic headers", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("anthropic-ratelimit-tokens-remaining", "2000")
+		h.Set("anthropic-ratelimit-tokens-reset", "2026-02-21T12:00:00Z")
+		u := &Usage{}
+		parseOpenAIRateLimitHeaders(h, u)
+
+		if u.RemainingTokens == nil || *u.RemainingTokens != 2000 {
+			t.Errorf("expected remaining tokens 2000, got %v", u.RemainingTokens)
+		}
+		if u.ResetAt == nil {
+			t.Error("expected reset time from anthropic header")
+		}
+	})
+}
+
+func TestOpenAIProvider_RateLimitHeadersInResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("x-ratelimit-remaining-tokens", "8000")
+		w.Header().Set("x-ratelimit-limit-tokens", "10000")
+		resp := openAIResponse{
+			Choices: []openAIChoice{
+				{
+					Message:      openAIMessage{Role: "assistant", Content: "Hi"},
+					FinishReason: "stop",
+				},
+			},
+			Usage: struct {
+				PromptTokens     int `json:"prompt_tokens"`
+				CompletionTokens int `json:"completion_tokens"`
+				TotalTokens      int `json:"total_tokens"`
+			}{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := NewOpenAIProvider("test-key", server.URL, "test-model")
+	resp, err := p.Chat(context.Background(), &ChatRequest{
+		Messages: []Message{{Role: "user", Content: "Hello"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat() error: %v", err)
+	}
+	if resp.Usage.RemainingTokens == nil || *resp.Usage.RemainingTokens != 8000 {
+		t.Errorf("expected remaining tokens 8000 in response, got %v", resp.Usage.RemainingTokens)
+	}
+	if resp.Usage.LimitTokens == nil || *resp.Usage.LimitTokens != 10000 {
+		t.Errorf("expected limit tokens 10000 in response, got %v", resp.Usage.LimitTokens)
+	}
+}
+
 func TestOpenAIProvider_APIError(t *testing.T) {
 	// Mock server returning error
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/provider/resolver.go
+++ b/internal/provider/resolver.go
@@ -1,0 +1,326 @@
+package provider
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+)
+
+// providerAliases maps common aliases to canonical provider IDs.
+var providerAliases = map[string]string{
+	"google":    "gemini-cli",
+	"codex":     "openai-codex",
+	"anthropic": "claude",
+	"copilot":   "scalytics-copilot",
+	"grok":      "xai",
+}
+
+// NormalizeProviderID resolves aliases and normalizes the provider ID.
+// If "google" is used but an API key exists for gemini, it resolves to "gemini" instead.
+func NormalizeProviderID(id string, cfg *config.Config) string {
+	lower := strings.ToLower(strings.TrimSpace(id))
+	if lower == "google" {
+		if cfg != nil && cfg.Providers.Gemini.APIKey != "" {
+			return "gemini"
+		}
+		return "gemini-cli"
+	}
+	if canonical, ok := providerAliases[lower]; ok {
+		return canonical
+	}
+	return lower
+}
+
+// ParseModelString splits a "provider/model" string into provider ID and model name.
+// For OpenRouter, the format is "openrouter/vendor/model" (three segments).
+func ParseModelString(s string) (providerID, modelName string) {
+	s = strings.TrimSpace(s)
+	parts := strings.SplitN(s, "/", 2)
+	if len(parts) < 2 {
+		return "", s
+	}
+	providerID = strings.ToLower(parts[0])
+	modelName = parts[1]
+	return
+}
+
+// Resolve creates the appropriate LLMProvider for the given agent based on config.
+// Resolution order:
+//  1. agents.list[agentID].model.primary
+//  2. model.name (global fallback)
+//  3. providers.openai with model.name (legacy compat)
+func Resolve(cfg *config.Config, agentID string) (LLMProvider, error) {
+	modelStr := resolveModelString(cfg, agentID)
+	if modelStr == "" {
+		// Legacy fallback: use global OpenAI provider.
+		return NewOpenAIProvider(cfg.Providers.OpenAI.APIKey, cfg.Providers.OpenAI.APIBase, cfg.Model.Name), nil
+	}
+	provID, model := ParseModelString(modelStr)
+	if provID == "" {
+		// Bare model name — use legacy OpenAI path.
+		return NewOpenAIProvider(cfg.Providers.OpenAI.APIKey, cfg.Providers.OpenAI.APIBase, model), nil
+	}
+	provID = NormalizeProviderID(provID, cfg)
+	prov, err := buildProvider(cfg, provID, model)
+	if err != nil {
+		// If the model string came from the global model.name (not per-agent config),
+		// fall back to legacy OpenAI provider for backward compatibility.
+		if !hasPerAgentModel(cfg, agentID) {
+			return NewOpenAIProvider(cfg.Providers.OpenAI.APIKey, cfg.Providers.OpenAI.APIBase, modelStr), nil
+		}
+		return nil, err
+	}
+	return prov, nil
+}
+
+// hasPerAgentModel checks if the agent has an explicitly configured model.
+func hasPerAgentModel(cfg *config.Config, agentID string) bool {
+	if cfg.Agents == nil {
+		return false
+	}
+	for _, entry := range cfg.Agents.List {
+		if entry.ID == agentID && entry.Model != nil && entry.Model.Primary != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// ResolveSubagent creates the LLMProvider for subagents spawned by the given agent.
+// Resolution order:
+//  1. agents.list[agentID].subagents.model
+//  2. tools.subagents.model (global subagent default)
+//  3. Inherit parent agent's resolved model (via Resolve)
+func ResolveSubagent(cfg *config.Config, agentID string) (LLMProvider, error) {
+	if cfg.Agents != nil {
+		for _, entry := range cfg.Agents.List {
+			if entry.ID == agentID && entry.Subagents != nil && entry.Subagents.Model != "" {
+				provID, model := ParseModelString(entry.Subagents.Model)
+				if provID == "" {
+					return NewOpenAIProvider(cfg.Providers.OpenAI.APIKey, cfg.Providers.OpenAI.APIBase, model), nil
+				}
+				provID = NormalizeProviderID(provID, cfg)
+				return buildProvider(cfg, provID, model)
+			}
+		}
+	}
+	if cfg.Tools.Subagents.Model != "" {
+		provID, model := ParseModelString(cfg.Tools.Subagents.Model)
+		if provID == "" {
+			return NewOpenAIProvider(cfg.Providers.OpenAI.APIKey, cfg.Providers.OpenAI.APIBase, model), nil
+		}
+		provID = NormalizeProviderID(provID, cfg)
+		return buildProvider(cfg, provID, model)
+	}
+	return Resolve(cfg, agentID)
+}
+
+// resolveModelString finds the model string for an agent from config.
+func resolveModelString(cfg *config.Config, agentID string) string {
+	if cfg.Agents != nil {
+		for _, entry := range cfg.Agents.List {
+			if entry.ID == agentID && entry.Model != nil && entry.Model.Primary != "" {
+				return entry.Model.Primary
+			}
+		}
+	}
+	if cfg.Model.Name != "" {
+		return cfg.Model.Name
+	}
+	return ""
+}
+
+// ResolveFallbacks returns the fallback providers for a given agent (tried in order on transient errors).
+func ResolveFallbacks(cfg *config.Config, agentID string) []LLMProvider {
+	if cfg.Agents == nil {
+		return nil
+	}
+	for _, entry := range cfg.Agents.List {
+		if entry.ID != agentID || entry.Model == nil {
+			continue
+		}
+		var providers []LLMProvider
+		for _, fb := range entry.Model.Fallbacks {
+			provID, model := ParseModelString(fb)
+			if provID == "" {
+				continue
+			}
+			provID = NormalizeProviderID(provID, cfg)
+			p, err := buildProvider(cfg, provID, model)
+			if err != nil {
+				continue
+			}
+			providers = append(providers, p)
+		}
+		return providers
+	}
+	return nil
+}
+
+// buildProvider constructs a provider from its canonical ID and model name.
+func buildProvider(cfg *config.Config, providerID, model string) (LLMProvider, error) {
+	switch providerID {
+	case "claude":
+		key := cfg.Providers.Anthropic.APIKey
+		base := cfg.Providers.Anthropic.APIBase
+		if key == "" {
+			return nil, &ProviderError{Provider: "claude", Hint: "set providers.anthropic.apiKey in config or run: kafclaw models auth set-key --provider claude"}
+		}
+		if base == "" {
+			base = "https://api.anthropic.com/v1"
+		}
+		return NewOpenAIProvider(key, base, model), nil
+
+	case "openai":
+		key := cfg.Providers.OpenAI.APIKey
+		base := cfg.Providers.OpenAI.APIBase
+		if key == "" {
+			return nil, &ProviderError{Provider: "openai", Hint: "set providers.openai.apiKey in config or run: kafclaw models auth set-key --provider openai"}
+		}
+		return NewOpenAIProvider(key, base, model), nil
+
+	case "openai-codex":
+		return NewCodexProvider(model), nil
+
+	case "gemini":
+		key := cfg.Providers.Gemini.APIKey
+		if key == "" {
+			return nil, &ProviderError{Provider: "gemini", Hint: "set providers.gemini.apiKey in config or run: kafclaw models auth set-key --provider gemini"}
+		}
+		return NewGeminiProvider(key, model), nil
+
+	case "gemini-cli":
+		return NewGeminiCLIProvider(model), nil
+
+	case "xai":
+		key := cfg.Providers.XAI.APIKey
+		if key == "" {
+			return nil, &ProviderError{Provider: "xai", Hint: "set providers.xai.apiKey in config or run: kafclaw models auth set-key --provider xai"}
+		}
+		return NewXAIProvider(key, model), nil
+
+	case "scalytics-copilot":
+		key := cfg.Providers.ScalyticsCopilot.APIKey
+		base := cfg.Providers.ScalyticsCopilot.APIBase
+		if key == "" {
+			return nil, &ProviderError{Provider: "scalytics-copilot", Hint: "set providers.scalyticsCopilot.apiKey and apiBase in config or run: kafclaw models auth set-key --provider scalytics-copilot --base <url>"}
+		}
+		if base == "" {
+			return nil, &ProviderError{Provider: "scalytics-copilot", Hint: "set providers.scalyticsCopilot.apiBase (e.g. https://copilot.scalytics.io/v1)"}
+		}
+		return NewOpenAIProvider(key, base, model), nil
+
+	case "openrouter":
+		key := cfg.Providers.OpenRouter.APIKey
+		base := cfg.Providers.OpenRouter.APIBase
+		if key == "" {
+			return nil, &ProviderError{Provider: "openrouter", Hint: "set providers.openrouter.apiKey in config or run: kafclaw models auth set-key --provider openrouter"}
+		}
+		if base == "" {
+			base = "https://openrouter.ai/api/v1"
+		}
+		return NewOpenAIProvider(key, base, model), nil
+
+	case "deepseek":
+		key := cfg.Providers.DeepSeek.APIKey
+		base := cfg.Providers.DeepSeek.APIBase
+		if key == "" {
+			return nil, &ProviderError{Provider: "deepseek", Hint: "set providers.deepseek.apiKey in config or run: kafclaw models auth set-key --provider deepseek"}
+		}
+		if base == "" {
+			base = "https://api.deepseek.com/v1"
+		}
+		return NewOpenAIProvider(key, base, model), nil
+
+	case "groq":
+		key := cfg.Providers.Groq.APIKey
+		base := cfg.Providers.Groq.APIBase
+		if key == "" {
+			return nil, &ProviderError{Provider: "groq", Hint: "set providers.groq.apiKey in config or run: kafclaw models auth set-key --provider groq"}
+		}
+		if base == "" {
+			base = "https://api.groq.com/openai/v1"
+		}
+		return NewOpenAIProvider(key, base, model), nil
+
+	case "vllm":
+		base := cfg.Providers.VLLM.APIBase
+		key := cfg.Providers.VLLM.APIKey
+		if base == "" {
+			return nil, &ProviderError{Provider: "vllm", Hint: "set providers.vllm.apiBase in config (e.g. http://localhost:8000/v1)"}
+		}
+		return NewOpenAIProvider(key, base, model), nil
+
+	default:
+		return nil, &ProviderError{Provider: providerID, Hint: fmt.Sprintf("unknown provider ID %q — supported: claude, openai, openai-codex, gemini, gemini-cli, xai, scalytics-copilot, openrouter, deepseek, groq, vllm", providerID)}
+	}
+}
+
+// ProviderError is returned when a provider cannot be constructed.
+type ProviderError struct {
+	Provider string
+	Hint     string
+}
+
+func (e *ProviderError) Error() string {
+	return fmt.Sprintf("provider %q: %s", e.Provider, e.Hint)
+}
+
+// ---------------------------------------------------------------------------
+// In-memory rate limit cache
+// ---------------------------------------------------------------------------
+
+// RateLimitSnapshot stores the last-seen rate limit data for a provider.
+type RateLimitSnapshot struct {
+	RemainingTokens   *int
+	RemainingRequests *int
+	LimitTokens       *int
+	ResetAt           *time.Time
+	UpdatedAt         time.Time
+}
+
+var (
+	rateLimitMu    sync.RWMutex
+	rateLimitCache = map[string]*RateLimitSnapshot{}
+)
+
+// UpdateRateLimitCache updates the cached rate limit data for a provider from a Usage response.
+func UpdateRateLimitCache(providerID string, u *Usage) {
+	if u == nil {
+		return
+	}
+	if u.RemainingTokens == nil && u.RemainingRequests == nil && u.LimitTokens == nil && u.ResetAt == nil {
+		return
+	}
+	rateLimitMu.Lock()
+	defer rateLimitMu.Unlock()
+	rateLimitCache[providerID] = &RateLimitSnapshot{
+		RemainingTokens:   u.RemainingTokens,
+		RemainingRequests: u.RemainingRequests,
+		LimitTokens:       u.LimitTokens,
+		ResetAt:           u.ResetAt,
+		UpdatedAt:         time.Now(),
+	}
+}
+
+// GetRateLimitSnapshot returns the last-seen rate limit data for a provider.
+func GetRateLimitSnapshot(providerID string) *RateLimitSnapshot {
+	rateLimitMu.RLock()
+	defer rateLimitMu.RUnlock()
+	return rateLimitCache[providerID]
+}
+
+// AllRateLimitSnapshots returns a copy of all cached rate limit snapshots.
+func AllRateLimitSnapshots() map[string]*RateLimitSnapshot {
+	rateLimitMu.RLock()
+	defer rateLimitMu.RUnlock()
+	out := make(map[string]*RateLimitSnapshot, len(rateLimitCache))
+	for k, v := range rateLimitCache {
+		cp := *v
+		out[k] = &cp
+	}
+	return out
+}

--- a/internal/provider/resolver_test.go
+++ b/internal/provider/resolver_test.go
@@ -1,0 +1,590 @@
+package provider
+
+import (
+	"testing"
+	"time"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+)
+
+// ---------------------------------------------------------------------------
+// ParseModelString
+// ---------------------------------------------------------------------------
+
+func TestParseModelString(t *testing.T) {
+	tests := []struct {
+		input      string
+		wantProvID string
+		wantModel  string
+	}{
+		{"claude/claude-sonnet-4-5", "claude", "claude-sonnet-4-5"},
+		{"openai/gpt-4.1", "openai", "gpt-4.1"},
+		{"openrouter/anthropic/claude-sonnet-4-5", "openrouter", "anthropic/claude-sonnet-4-5"},
+		{"bare-model-name", "", "bare-model-name"},
+		{"", "", ""},
+		{"  gemini/gemini-2.5-pro  ", "gemini", "gemini-2.5-pro"},
+	}
+	for _, tt := range tests {
+		provID, model := ParseModelString(tt.input)
+		if provID != tt.wantProvID || model != tt.wantModel {
+			t.Errorf("ParseModelString(%q) = (%q, %q), want (%q, %q)",
+				tt.input, provID, model, tt.wantProvID, tt.wantModel)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NormalizeProviderID
+// ---------------------------------------------------------------------------
+
+func TestNormalizeProviderID(t *testing.T) {
+	cfg := config.DefaultConfig()
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"google", "gemini-cli"},
+		{"codex", "openai-codex"},
+		{"anthropic", "claude"},
+		{"copilot", "scalytics-copilot"},
+		{"grok", "xai"},
+		{"CLAUDE", "claude"},
+		{"  OpenAI  ", "openai"},
+		{"deepseek", "deepseek"},
+	}
+	for _, tt := range tests {
+		got := NormalizeProviderID(tt.input, cfg)
+		if got != tt.want {
+			t.Errorf("NormalizeProviderID(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestNormalizeProviderID_GoogleWithGeminiKey(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Providers.Gemini.APIKey = "test-key"
+	got := NormalizeProviderID("google", cfg)
+	if got != "gemini" {
+		t.Errorf("NormalizeProviderID(google) with Gemini key = %q, want %q", got, "gemini")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Resolve
+// ---------------------------------------------------------------------------
+
+func TestResolve_LegacyFallback(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Providers.OpenAI.APIKey = "test-key"
+	cfg.Model.Name = ""
+	prov, err := Resolve(cfg, "main")
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	oaiProv, ok := prov.(*OpenAIProvider)
+	if !ok {
+		t.Fatal("expected OpenAIProvider for legacy fallback")
+	}
+	if oaiProv.apiKey != "test-key" {
+		t.Errorf("expected api key 'test-key', got %q", oaiProv.apiKey)
+	}
+}
+
+func TestResolve_BareModelName(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Providers.OpenAI.APIKey = "test-key"
+	cfg.Model.Name = "gpt-4.1"
+	prov, err := Resolve(cfg, "main")
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	oaiProv, ok := prov.(*OpenAIProvider)
+	if !ok {
+		t.Fatal("expected OpenAIProvider for bare model name")
+	}
+	if oaiProv.defaultModel != "gpt-4.1" {
+		t.Errorf("expected model 'gpt-4.1', got %q", oaiProv.defaultModel)
+	}
+}
+
+func TestResolve_OpenAIProvider(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Providers.OpenAI.APIKey = "sk-test"
+	cfg.Model.Name = "openai/gpt-4.1"
+	prov, err := Resolve(cfg, "main")
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	if _, ok := prov.(*OpenAIProvider); !ok {
+		t.Fatal("expected OpenAIProvider")
+	}
+}
+
+func TestResolve_ClaudeProvider(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Providers.Anthropic.APIKey = "sk-ant-test"
+	cfg.Model.Name = "claude/claude-sonnet-4-5"
+	prov, err := Resolve(cfg, "main")
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	if _, ok := prov.(*OpenAIProvider); !ok {
+		t.Fatal("expected OpenAIProvider for claude (uses OpenAI-compatible API)")
+	}
+}
+
+func TestResolve_PerAgentModel(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Providers.OpenAI.APIKey = "sk-test"
+	cfg.Providers.Anthropic.APIKey = "sk-ant-test"
+	cfg.Model.Name = "openai/gpt-4.1"
+	cfg.Agents = &config.AgentsConfig{
+		List: []config.AgentListEntry{
+			{
+				ID:    "main",
+				Model: &config.AgentModelSpec{Primary: "claude/claude-opus-4"},
+			},
+		},
+	}
+	prov, err := Resolve(cfg, "main")
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	oaiProv, ok := prov.(*OpenAIProvider)
+	if !ok {
+		t.Fatal("expected OpenAIProvider")
+	}
+	if oaiProv.defaultModel != "claude-opus-4" {
+		t.Errorf("expected model 'claude-opus-4', got %q", oaiProv.defaultModel)
+	}
+}
+
+func TestResolve_UnknownProviderFallsBackToLegacy(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Providers.OpenAI.APIKey = "sk-test"
+	cfg.Model.Name = "unknownprov/some-model"
+	// Since no per-agent model, should fall back to legacy OpenAI
+	prov, err := Resolve(cfg, "main")
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	if _, ok := prov.(*OpenAIProvider); !ok {
+		t.Fatal("expected OpenAIProvider for legacy fallback")
+	}
+}
+
+func TestResolve_UnknownProviderPerAgentFails(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Agents = &config.AgentsConfig{
+		List: []config.AgentListEntry{
+			{
+				ID:    "main",
+				Model: &config.AgentModelSpec{Primary: "unknownprov/some-model"},
+			},
+		},
+	}
+	_, err := Resolve(cfg, "main")
+	if err == nil {
+		t.Fatal("expected error for unknown provider with per-agent config")
+	}
+	provErr, ok := err.(*ProviderError)
+	if !ok {
+		t.Fatalf("expected *ProviderError, got %T", err)
+	}
+	if provErr.Provider != "unknownprov" {
+		t.Errorf("expected provider 'unknownprov', got %q", provErr.Provider)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ResolveSubagent
+// ---------------------------------------------------------------------------
+
+func TestResolveSubagent_InheritsParent(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Providers.OpenAI.APIKey = "sk-test"
+	cfg.Model.Name = "openai/gpt-4.1"
+	prov, err := ResolveSubagent(cfg, "main")
+	if err != nil {
+		t.Fatalf("ResolveSubagent() error: %v", err)
+	}
+	if _, ok := prov.(*OpenAIProvider); !ok {
+		t.Fatal("expected OpenAIProvider")
+	}
+}
+
+func TestResolveSubagent_GlobalSubagentModel(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Providers.OpenAI.APIKey = "sk-test"
+	cfg.Tools.Subagents.Model = "openai/gpt-4.1-mini"
+	prov, err := ResolveSubagent(cfg, "main")
+	if err != nil {
+		t.Fatalf("ResolveSubagent() error: %v", err)
+	}
+	oaiProv, ok := prov.(*OpenAIProvider)
+	if !ok {
+		t.Fatal("expected OpenAIProvider")
+	}
+	if oaiProv.defaultModel != "gpt-4.1-mini" {
+		t.Errorf("expected model 'gpt-4.1-mini', got %q", oaiProv.defaultModel)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ResolveFallbacks
+// ---------------------------------------------------------------------------
+
+func TestResolveFallbacks_None(t *testing.T) {
+	cfg := config.DefaultConfig()
+	fbs := ResolveFallbacks(cfg, "main")
+	if len(fbs) != 0 {
+		t.Errorf("expected no fallbacks, got %d", len(fbs))
+	}
+}
+
+func TestResolveFallbacks_WithAgentFallbacks(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Providers.OpenAI.APIKey = "sk-test"
+	cfg.Providers.Anthropic.APIKey = "sk-ant-test"
+	cfg.Agents = &config.AgentsConfig{
+		List: []config.AgentListEntry{
+			{
+				ID: "main",
+				Model: &config.AgentModelSpec{
+					Primary:   "claude/claude-sonnet-4-5",
+					Fallbacks: []string{"openai/gpt-4.1"},
+				},
+			},
+		},
+	}
+	fbs := ResolveFallbacks(cfg, "main")
+	if len(fbs) != 1 {
+		t.Fatalf("expected 1 fallback, got %d", len(fbs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildProvider
+// ---------------------------------------------------------------------------
+
+func TestBuildProvider_GeminiRequiresKey(t *testing.T) {
+	cfg := config.DefaultConfig()
+	_, err := buildProvider(cfg, "gemini", "gemini-2.5-pro")
+	if err == nil {
+		t.Fatal("expected error for gemini without API key")
+	}
+}
+
+func TestBuildProvider_DeepSeekDefaults(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Providers.DeepSeek.APIKey = "test-key"
+	prov, err := buildProvider(cfg, "deepseek", "deepseek-chat")
+	if err != nil {
+		t.Fatalf("buildProvider() error: %v", err)
+	}
+	oaiProv, ok := prov.(*OpenAIProvider)
+	if !ok {
+		t.Fatal("expected OpenAIProvider for deepseek")
+	}
+	if oaiProv.apiBase != "https://api.deepseek.com/v1" {
+		t.Errorf("expected deepseek default base, got %q", oaiProv.apiBase)
+	}
+}
+
+func TestBuildProvider_GroqDefaults(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Providers.Groq.APIKey = "test-key"
+	prov, err := buildProvider(cfg, "groq", "llama-3.3-70b")
+	if err != nil {
+		t.Fatalf("buildProvider() error: %v", err)
+	}
+	oaiProv, ok := prov.(*OpenAIProvider)
+	if !ok {
+		t.Fatal("expected OpenAIProvider for groq")
+	}
+	if oaiProv.apiBase != "https://api.groq.com/openai/v1" {
+		t.Errorf("expected groq default base, got %q", oaiProv.apiBase)
+	}
+}
+
+func TestBuildProvider_VLLMRequiresBase(t *testing.T) {
+	cfg := config.DefaultConfig()
+	_, err := buildProvider(cfg, "vllm", "my-model")
+	if err == nil {
+		t.Fatal("expected error for vllm without apiBase")
+	}
+}
+
+func TestBuildProvider_ScalyticsCopilotRequiresKeyAndBase(t *testing.T) {
+	cfg := config.DefaultConfig()
+	_, err := buildProvider(cfg, "scalytics-copilot", "model")
+	if err == nil {
+		t.Fatal("expected error for scalytics-copilot without key")
+	}
+
+	cfg.Providers.ScalyticsCopilot.APIKey = "test"
+	_, err = buildProvider(cfg, "scalytics-copilot", "model")
+	if err == nil {
+		t.Fatal("expected error for scalytics-copilot without base")
+	}
+}
+
+func TestBuildProvider_UnknownProvider(t *testing.T) {
+	cfg := config.DefaultConfig()
+	_, err := buildProvider(cfg, "nonexistent", "model")
+	if err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+	provErr, ok := err.(*ProviderError)
+	if !ok {
+		t.Fatalf("expected *ProviderError, got %T", err)
+	}
+	if provErr.Provider != "nonexistent" {
+		t.Errorf("expected provider 'nonexistent', got %q", provErr.Provider)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rate limit cache
+// ---------------------------------------------------------------------------
+
+func TestRateLimitCache(t *testing.T) {
+	// Clean slate
+	rateLimitMu.Lock()
+	rateLimitCache = map[string]*RateLimitSnapshot{}
+	rateLimitMu.Unlock()
+
+	// Nil usage should be no-op
+	UpdateRateLimitCache("test", nil)
+	if snap := GetRateLimitSnapshot("test"); snap != nil {
+		t.Fatal("expected nil snapshot for no data")
+	}
+
+	// Empty usage fields should be no-op
+	UpdateRateLimitCache("test", &Usage{})
+	if snap := GetRateLimitSnapshot("test"); snap != nil {
+		t.Fatal("expected nil snapshot for empty usage")
+	}
+
+	// With data
+	remaining := 500
+	UpdateRateLimitCache("test", &Usage{
+		RemainingTokens: &remaining,
+	})
+	snap := GetRateLimitSnapshot("test")
+	if snap == nil {
+		t.Fatal("expected non-nil snapshot")
+	}
+	if snap.RemainingTokens == nil || *snap.RemainingTokens != 500 {
+		t.Errorf("expected remaining tokens 500, got %v", snap.RemainingTokens)
+	}
+	if snap.UpdatedAt.IsZero() {
+		t.Error("expected non-zero UpdatedAt")
+	}
+
+	// AllRateLimitSnapshots
+	all := AllRateLimitSnapshots()
+	if len(all) != 1 {
+		t.Errorf("expected 1 snapshot, got %d", len(all))
+	}
+	// Verify it's a copy
+	all["test"].RemainingTokens = nil
+	origSnap := GetRateLimitSnapshot("test")
+	if origSnap.RemainingTokens == nil {
+		t.Error("AllRateLimitSnapshots should return copies")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ProviderError
+// ---------------------------------------------------------------------------
+
+func TestProviderError(t *testing.T) {
+	err := &ProviderError{Provider: "test", Hint: "missing key"}
+	msg := err.Error()
+	if msg != `provider "test": missing key` {
+		t.Errorf("unexpected error message: %s", msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// hasPerAgentModel
+// ---------------------------------------------------------------------------
+
+func TestHasPerAgentModel(t *testing.T) {
+	cfg := config.DefaultConfig()
+	if hasPerAgentModel(cfg, "main") {
+		t.Error("expected false for nil Agents")
+	}
+
+	cfg.Agents = &config.AgentsConfig{
+		List: []config.AgentListEntry{
+			{ID: "main"},
+		},
+	}
+	if hasPerAgentModel(cfg, "main") {
+		t.Error("expected false for nil Model")
+	}
+
+	cfg.Agents.List[0].Model = &config.AgentModelSpec{Primary: "openai/gpt-4.1"}
+	if !hasPerAgentModel(cfg, "main") {
+		t.Error("expected true for configured model")
+	}
+
+	if hasPerAgentModel(cfg, "other") {
+		t.Error("expected false for non-matching agent ID")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resolveModelString
+// ---------------------------------------------------------------------------
+
+func TestResolveModelString(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Model.Name = "openai/gpt-4.1"
+
+	// Global fallback
+	if got := resolveModelString(cfg, "main"); got != "openai/gpt-4.1" {
+		t.Errorf("expected global model, got %q", got)
+	}
+
+	// Per-agent override
+	cfg.Agents = &config.AgentsConfig{
+		List: []config.AgentListEntry{
+			{
+				ID:    "main",
+				Model: &config.AgentModelSpec{Primary: "claude/claude-opus-4"},
+			},
+		},
+	}
+	if got := resolveModelString(cfg, "main"); got != "claude/claude-opus-4" {
+		t.Errorf("expected per-agent model, got %q", got)
+	}
+
+	// Empty model.name
+	cfg2 := config.DefaultConfig()
+	cfg2.Model.Name = ""
+	if got := resolveModelString(cfg2, "main"); got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RateLimitSnapshot with ResetAt
+// ---------------------------------------------------------------------------
+
+func TestRateLimitCacheWithResetAt(t *testing.T) {
+	rateLimitMu.Lock()
+	rateLimitCache = map[string]*RateLimitSnapshot{}
+	rateLimitMu.Unlock()
+
+	resetTime := time.Now().Add(5 * time.Minute)
+	remaining := 100
+	UpdateRateLimitCache("provider-x", &Usage{
+		RemainingTokens: &remaining,
+		ResetAt:         &resetTime,
+	})
+	snap := GetRateLimitSnapshot("provider-x")
+	if snap == nil {
+		t.Fatal("expected non-nil snapshot")
+	}
+	if snap.ResetAt == nil {
+		t.Fatal("expected non-nil ResetAt")
+	}
+	if !snap.ResetAt.Equal(resetTime) {
+		t.Errorf("expected reset time %v, got %v", resetTime, *snap.ResetAt)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ResolveWithTaskType
+// ---------------------------------------------------------------------------
+
+func TestResolveWithTaskType_NoRouting(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Providers.OpenAI.APIKey = "sk-test"
+	cfg.Model.Name = "openai/gpt-4.1"
+	prov, err := ResolveWithTaskType(cfg, "main", "security")
+	if err != nil {
+		t.Fatalf("ResolveWithTaskType() error: %v", err)
+	}
+	oaiProv, ok := prov.(*OpenAIProvider)
+	if !ok {
+		t.Fatal("expected OpenAIProvider")
+	}
+	if oaiProv.defaultModel != "gpt-4.1" {
+		t.Errorf("expected default model without routing, got %q", oaiProv.defaultModel)
+	}
+}
+
+func TestResolveWithTaskType_WithRouting(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Providers.OpenAI.APIKey = "sk-test"
+	cfg.Providers.Anthropic.APIKey = "sk-ant-test"
+	cfg.Model.Name = "openai/gpt-4.1"
+	cfg.Model.TaskRouting = map[string]string{
+		"security": "claude/claude-opus-4-6",
+	}
+	prov, err := ResolveWithTaskType(cfg, "main", "security")
+	if err != nil {
+		t.Fatalf("ResolveWithTaskType() error: %v", err)
+	}
+	oaiProv, ok := prov.(*OpenAIProvider)
+	if !ok {
+		t.Fatal("expected OpenAIProvider")
+	}
+	if oaiProv.defaultModel != "claude-opus-4-6" {
+		t.Errorf("expected routed model 'claude-opus-4-6', got %q", oaiProv.defaultModel)
+	}
+}
+
+func TestResolveWithTaskType_PerAgentOverridesRouting(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Providers.OpenAI.APIKey = "sk-test"
+	cfg.Providers.Anthropic.APIKey = "sk-ant-test"
+	cfg.Model.Name = "openai/gpt-4.1"
+	cfg.Model.TaskRouting = map[string]string{
+		"security": "claude/claude-opus-4-6",
+	}
+	cfg.Agents = &config.AgentsConfig{
+		List: []config.AgentListEntry{
+			{
+				ID:    "main",
+				Model: &config.AgentModelSpec{Primary: "openai/gpt-4.1"},
+			},
+		},
+	}
+	prov, err := ResolveWithTaskType(cfg, "main", "security")
+	if err != nil {
+		t.Fatalf("ResolveWithTaskType() error: %v", err)
+	}
+	oaiProv, ok := prov.(*OpenAIProvider)
+	if !ok {
+		t.Fatal("expected OpenAIProvider")
+	}
+	// Per-agent model should win over task routing
+	if oaiProv.defaultModel != "gpt-4.1" {
+		t.Errorf("expected per-agent model to win, got %q", oaiProv.defaultModel)
+	}
+}
+
+func TestResolveWithTaskType_EmptyCategory(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Providers.OpenAI.APIKey = "sk-test"
+	cfg.Model.Name = "openai/gpt-4.1"
+	cfg.Model.TaskRouting = map[string]string{
+		"security": "claude/claude-opus-4-6",
+	}
+	prov, err := ResolveWithTaskType(cfg, "main", "")
+	if err != nil {
+		t.Fatalf("ResolveWithTaskType() error: %v", err)
+	}
+	oaiProv, ok := prov.(*OpenAIProvider)
+	if !ok {
+		t.Fatal("expected OpenAIProvider")
+	}
+	if oaiProv.defaultModel != "gpt-4.1" {
+		t.Errorf("expected default model for empty category, got %q", oaiProv.defaultModel)
+	}
+}

--- a/internal/provider/xai.go
+++ b/internal/provider/xai.go
@@ -1,0 +1,38 @@
+package provider
+
+import (
+	"context"
+)
+
+const xaiDefaultBase = "https://api.x.ai/v1"
+
+// XAIProvider wraps OpenAIProvider with the xAI/Grok API base URL.
+type XAIProvider struct {
+	inner *OpenAIProvider
+}
+
+// NewXAIProvider creates a provider targeting the xAI API.
+func NewXAIProvider(apiKey, defaultModel string) *XAIProvider {
+	if defaultModel == "" {
+		defaultModel = "grok-3"
+	}
+	return &XAIProvider{
+		inner: NewOpenAIProvider(apiKey, xaiDefaultBase, defaultModel),
+	}
+}
+
+func (p *XAIProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	return p.inner.Chat(ctx, req)
+}
+
+func (p *XAIProvider) Transcribe(ctx context.Context, req *AudioRequest) (*AudioResponse, error) {
+	return p.inner.Transcribe(ctx, req)
+}
+
+func (p *XAIProvider) Speak(ctx context.Context, req *TTSRequest) (*TTSResponse, error) {
+	return p.inner.Speak(ctx, req)
+}
+
+func (p *XAIProvider) DefaultModel() string {
+	return p.inner.DefaultModel()
+}

--- a/internal/secrets/blob.go
+++ b/internal/secrets/blob.go
@@ -1,0 +1,427 @@
+// Package secrets provides shared encryption primitives for KafClaw.
+// It extracts the AES-256-GCM blob encryption originally in internal/skills/oauth_crypto.go
+// so that both internal/skills and internal/provider can use it without import cycles.
+package secrets
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/KafClaw/KafClaw/internal/config"
+	"github.com/zalando/go-keyring"
+)
+
+const keyFileName = "master.key"
+const localTombFileName = "tomb.rr"
+const keyringService = "kafclaw.skills.oauth"
+const keyringUser = "master-key"
+const localTombEnvAAD = "kafclaw-local-env-secrets-v1"
+
+// LocalTomb is the on-disk encrypted key store structure.
+type LocalTomb struct {
+	Version       string `json:"version"`
+	MasterKey     string `json:"masterKey"`
+	EnvNonce      string `json:"envNonce,omitempty"`
+	EnvCiphertext string `json:"envCiphertext,omitempty"`
+}
+
+type encryptedBlob struct {
+	Version    string `json:"version"`
+	Nonce      string `json:"nonce"`
+	Ciphertext string `json:"ciphertext"`
+}
+
+// EncryptBlob encrypts plain bytes using AES-256-GCM with the shared master key.
+func EncryptBlob(plain []byte) ([]byte, error) {
+	key, err := LoadOrCreateMasterKey()
+	if err != nil {
+		return nil, err
+	}
+	return EncryptBlobWithKey(plain, key)
+}
+
+// EncryptBlobWithKey encrypts plain bytes using the given 32-byte AES key.
+func EncryptBlobWithKey(plain, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	ciphertext := gcm.Seal(nil, nonce, plain, nil)
+	out := encryptedBlob{
+		Version:    "v1",
+		Nonce:      base64.RawStdEncoding.EncodeToString(nonce),
+		Ciphertext: base64.RawStdEncoding.EncodeToString(ciphertext),
+	}
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+// DecryptBlob decrypts an AES-256-GCM encrypted blob using the shared master key.
+// For backward compatibility, plaintext JSON is returned as-is.
+func DecryptBlob(data []byte) ([]byte, error) {
+	key, err := LoadOrCreateMasterKey()
+	if err != nil {
+		return nil, err
+	}
+	return DecryptBlobWithKey(data, key)
+}
+
+// DecryptBlobWithKey decrypts an encrypted blob using the given 32-byte AES key.
+// For backward compatibility, plaintext JSON is returned as-is.
+func DecryptBlobWithKey(data, key []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty encrypted blob")
+	}
+	var wrapped encryptedBlob
+	if err := json.Unmarshal(data, &wrapped); err != nil {
+		return data, nil
+	}
+	if wrapped.Version == "" || wrapped.Nonce == "" || wrapped.Ciphertext == "" {
+		return data, nil
+	}
+	if wrapped.Version != "v1" {
+		return nil, fmt.Errorf("unsupported blob version: %s", wrapped.Version)
+	}
+	nonce, err := base64.RawStdEncoding.DecodeString(strings.TrimSpace(wrapped.Nonce))
+	if err != nil {
+		return nil, err
+	}
+	ciphertext, err := base64.RawStdEncoding.DecodeString(strings.TrimSpace(wrapped.Ciphertext))
+	if err != nil {
+		return nil, err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	plain, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, err
+	}
+	return plain, nil
+}
+
+// LoadOrCreateMasterKey returns the 32-byte AES master key, creating one if necessary.
+// Priority: KAFCLAW_OAUTH_MASTER_KEY env → backend resolver (keyring / local tomb / file).
+func LoadOrCreateMasterKey() ([]byte, error) {
+	if envKey := strings.TrimSpace(os.Getenv("KAFCLAW_OAUTH_MASTER_KEY")); envKey != "" {
+		key, err := DecodeMasterKey(envKey)
+		if err != nil {
+			return nil, fmt.Errorf("invalid KAFCLAW_OAUTH_MASTER_KEY: %w", err)
+		}
+		return key, nil
+	}
+
+	switch resolveKeyBackend() {
+	case "local":
+		return loadOrCreateMasterKeyLocalOnly()
+	case "keyring":
+		return loadOrCreateMasterKeyKeyringOnly()
+	case "file":
+		return loadOrCreateMasterKeyFileOnly()
+	default:
+		if key, err := loadOrCreateMasterKeyKeyringOnly(); err == nil {
+			return key, nil
+		}
+		if key, err := loadOrCreateMasterKeyLocalOnly(); err == nil {
+			return key, nil
+		}
+		return loadOrCreateMasterKeyFileOnly()
+	}
+}
+
+// DecodeMasterKey base64-decodes a master key and validates its length (32 bytes).
+func DecodeMasterKey(raw string) ([]byte, error) {
+	trimmed := strings.TrimSpace(raw)
+	decoded := make([]byte, base64.RawStdEncoding.DecodedLen(len(trimmed)))
+	n, err := base64.RawStdEncoding.Decode(decoded, []byte(trimmed))
+	if err != nil {
+		return nil, err
+	}
+	if n != 32 {
+		return nil, fmt.Errorf("invalid master key length: %d", n)
+	}
+	return decoded[:n], nil
+}
+
+// ResolveLocalTombPath returns the local key tomb file path.
+func ResolveLocalTombPath() (string, error) {
+	if explicit := strings.TrimSpace(os.Getenv("KAFCLAW_OAUTH_TOMB_FILE")); explicit != "" {
+		if strings.HasPrefix(explicit, "~") {
+			home, err := resolveHomeDir()
+			if err != nil {
+				return "", err
+			}
+			return expandTildePath(explicit, home), nil
+		}
+		return explicit, nil
+	}
+	home, err := resolveHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "kafclaw", localTombFileName), nil
+}
+
+// LoadOrCreateLocalTomb loads or creates the local tomb file.
+func LoadOrCreateLocalTomb() (string, *LocalTomb, error) {
+	tombPath, err := ResolveLocalTombPath()
+	if err != nil {
+		return "", nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(tombPath), 0o700); err != nil {
+		return "", nil, err
+	}
+	if data, err := os.ReadFile(tombPath); err == nil {
+		doc, decErr := DecodeLocalTomb(data)
+		if decErr != nil {
+			return "", nil, decErr
+		}
+		return tombPath, doc, nil
+	} else if !os.IsNotExist(err) {
+		return "", nil, err
+	}
+
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return "", nil, err
+	}
+	encoded := base64.RawStdEncoding.EncodeToString(key)
+	doc := &LocalTomb{
+		Version:   "v1",
+		MasterKey: encoded,
+	}
+	if err := WriteLocalTomb(tombPath, doc); err != nil {
+		return "", nil, err
+	}
+	return tombPath, doc, nil
+}
+
+// DecodeLocalTomb parses a tomb file from raw bytes.
+func DecodeLocalTomb(data []byte) (*LocalTomb, error) {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return nil, fmt.Errorf("empty tomb file")
+	}
+	var doc LocalTomb
+	if err := json.Unmarshal([]byte(trimmed), &doc); err == nil && strings.TrimSpace(doc.MasterKey) != "" {
+		if strings.TrimSpace(doc.Version) == "" {
+			doc.Version = "v1"
+		}
+		return &doc, nil
+	}
+	if _, err := DecodeMasterKey(trimmed); err == nil {
+		return &LocalTomb{
+			Version:   "v1",
+			MasterKey: trimmed,
+		}, nil
+	}
+	return nil, fmt.Errorf("invalid tomb file format")
+}
+
+// WriteLocalTomb writes a tomb document to disk.
+func WriteLocalTomb(path string, doc *LocalTomb) error {
+	if doc == nil {
+		return fmt.Errorf("nil tomb payload")
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o600)
+}
+
+// LoadEnvSecretsFromTombDoc decrypts env secrets from a tomb document.
+func LoadEnvSecretsFromTombDoc(doc *LocalTomb) (map[string]string, error) {
+	out := map[string]string{}
+	if doc == nil || strings.TrimSpace(doc.EnvNonce) == "" || strings.TrimSpace(doc.EnvCiphertext) == "" {
+		return out, nil
+	}
+	key, err := DecodeMasterKey(doc.MasterKey)
+	if err != nil {
+		return nil, err
+	}
+	nonce, err := base64.RawStdEncoding.DecodeString(strings.TrimSpace(doc.EnvNonce))
+	if err != nil {
+		return nil, err
+	}
+	ciphertext, err := base64.RawStdEncoding.DecodeString(strings.TrimSpace(doc.EnvCiphertext))
+	if err != nil {
+		return nil, err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	plain, err := gcm.Open(nil, nonce, ciphertext, []byte(localTombEnvAAD))
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(plain, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// SealEnvSecretsIntoTombDoc encrypts env secrets into a tomb document.
+func SealEnvSecretsIntoTombDoc(doc *LocalTomb, kv map[string]string) error {
+	if doc == nil {
+		return fmt.Errorf("nil tomb payload")
+	}
+	if kv == nil {
+		kv = map[string]string{}
+	}
+	key, err := DecodeMasterKey(doc.MasterKey)
+	if err != nil {
+		return err
+	}
+	plain, err := json.Marshal(kv)
+	if err != nil {
+		return err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return err
+	}
+	ciphertext := gcm.Seal(nil, nonce, plain, []byte(localTombEnvAAD))
+	doc.EnvNonce = base64.RawStdEncoding.EncodeToString(nonce)
+	doc.EnvCiphertext = base64.RawStdEncoding.EncodeToString(ciphertext)
+	return nil
+}
+
+// --- internal helpers ---
+
+func resolveKeyBackend() string {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("KAFCLAW_OAUTH_KEY_BACKEND")))
+	switch v {
+	case "local", "keyring", "file", "auto":
+		return v
+	default:
+		return "local"
+	}
+}
+
+func loadOrCreateMasterKeyKeyringOnly() ([]byte, error) {
+	val, err := keyring.Get(keyringService, keyringUser)
+	if err == nil {
+		return DecodeMasterKey(val)
+	}
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return nil, err
+	}
+	encoded := base64.RawStdEncoding.EncodeToString(key)
+	if setErr := keyring.Set(keyringService, keyringUser, encoded); setErr != nil {
+		return nil, setErr
+	}
+	return key, nil
+}
+
+func loadOrCreateMasterKeyFileOnly() ([]byte, error) {
+	authRoot, err := resolveAuthRoot()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(authRoot, 0o700); err != nil {
+		return nil, err
+	}
+	keyPath := filepath.Join(authRoot, keyFileName)
+	if data, err := os.ReadFile(keyPath); err == nil {
+		return DecodeMasterKey(strings.TrimSpace(string(data)))
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return nil, err
+	}
+	encoded := base64.RawStdEncoding.EncodeToString(key)
+	if err := os.WriteFile(keyPath, []byte(encoded+"\n"), 0o600); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func loadOrCreateMasterKeyLocalOnly() ([]byte, error) {
+	tombPath, doc, err := LoadOrCreateLocalTomb()
+	if err != nil {
+		return nil, err
+	}
+	key, err := DecodeMasterKey(doc.MasterKey)
+	if err != nil {
+		return nil, err
+	}
+	_ = os.Chmod(tombPath, 0o600)
+	return key, nil
+}
+
+func resolveHomeDir() (string, error) {
+	if h := strings.TrimSpace(os.Getenv("KAFCLAW_HOME")); h != "" {
+		if strings.HasPrefix(h, "~") {
+			base, err := os.UserHomeDir()
+			if err != nil {
+				return "", err
+			}
+			return expandTildePath(h, base), nil
+		}
+		return h, nil
+	}
+	return os.UserHomeDir()
+}
+
+func expandTildePath(path string, home string) string {
+	switch {
+	case path == "~":
+		return home
+	case strings.HasPrefix(path, "~/"):
+		return filepath.Join(home, path[2:])
+	default:
+		return path
+	}
+}
+
+// resolveAuthRoot returns the auth directory path.
+// This mirrors the original skills.EnsureStateDirs().ToolsDir + "auth" logic:
+// <configDir>/skills/tools/auth
+func resolveAuthRoot() (string, error) {
+	cfgPath, err := config.ConfigPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(filepath.Dir(cfgPath), "skills", "tools", "auth"), nil
+}

--- a/internal/secrets/blob_test.go
+++ b/internal/secrets/blob_test.go
@@ -1,0 +1,271 @@
+package secrets
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+// ---------- EncryptBlobWithKey / DecryptBlobWithKey roundtrip ----------
+
+func TestEncryptDecryptBlobWithKey_Roundtrip(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+
+	plain := []byte("hello, KafClaw secrets!")
+	encrypted, err := EncryptBlobWithKey(plain, key)
+	if err != nil {
+		t.Fatalf("EncryptBlobWithKey: %v", err)
+	}
+
+	decrypted, err := DecryptBlobWithKey(encrypted, key)
+	if err != nil {
+		t.Fatalf("DecryptBlobWithKey: %v", err)
+	}
+
+	if string(decrypted) != string(plain) {
+		t.Fatalf("roundtrip mismatch: got %q, want %q", decrypted, plain)
+	}
+}
+
+// ---------- DecryptBlobWithKey backward compat (plaintext JSON) ----------
+
+func TestDecryptBlobWithKey_PlaintextJSON(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+
+	// Plain JSON without version/nonce/ciphertext should be returned as-is.
+	plainJSON := []byte(`{"foo":"bar","num":42}`)
+	got, err := DecryptBlobWithKey(plainJSON, key)
+	if err != nil {
+		t.Fatalf("DecryptBlobWithKey plaintext JSON: %v", err)
+	}
+	if string(got) != string(plainJSON) {
+		t.Fatalf("expected plaintext passthrough, got %q", got)
+	}
+}
+
+// ---------- DecryptBlobWithKey empty input ----------
+
+func TestDecryptBlobWithKey_EmptyInput(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+
+	_, err := DecryptBlobWithKey([]byte{}, key)
+	if err == nil {
+		t.Fatal("expected error for empty input, got nil")
+	}
+}
+
+// ---------- DecryptBlobWithKey wrong key ----------
+
+func TestDecryptBlobWithKey_WrongKey(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+
+	plain := []byte("secret payload")
+	encrypted, err := EncryptBlobWithKey(plain, key)
+	if err != nil {
+		t.Fatalf("EncryptBlobWithKey: %v", err)
+	}
+
+	wrongKey := make([]byte, 32)
+	if _, err := rand.Read(wrongKey); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+
+	_, err = DecryptBlobWithKey(encrypted, wrongKey)
+	if err == nil {
+		t.Fatal("expected error when decrypting with wrong key, got nil")
+	}
+}
+
+// ---------- DecodeMasterKey ----------
+
+func TestDecodeMasterKey_Valid(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	encoded := base64.RawStdEncoding.EncodeToString(key)
+
+	decoded, err := DecodeMasterKey(encoded)
+	if err != nil {
+		t.Fatalf("DecodeMasterKey: %v", err)
+	}
+	if len(decoded) != 32 {
+		t.Fatalf("expected 32 bytes, got %d", len(decoded))
+	}
+	for i := range key {
+		if decoded[i] != key[i] {
+			t.Fatalf("decoded key mismatch at byte %d", i)
+		}
+	}
+}
+
+func TestDecodeMasterKey_WrongLength(t *testing.T) {
+	short := make([]byte, 16)
+	if _, err := rand.Read(short); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	encoded := base64.RawStdEncoding.EncodeToString(short)
+
+	_, err := DecodeMasterKey(encoded)
+	if err == nil {
+		t.Fatal("expected error for wrong key length, got nil")
+	}
+}
+
+func TestDecodeMasterKey_InvalidBase64(t *testing.T) {
+	_, err := DecodeMasterKey("!!!not-valid-base64!!!")
+	if err == nil {
+		t.Fatal("expected error for invalid base64, got nil")
+	}
+}
+
+// ---------- DecodeLocalTomb ----------
+
+func TestDecodeLocalTomb_ValidJSON(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	encoded := base64.RawStdEncoding.EncodeToString(key)
+
+	tombJSON, _ := json.Marshal(LocalTomb{
+		Version:   "v1",
+		MasterKey: encoded,
+	})
+
+	doc, err := DecodeLocalTomb(tombJSON)
+	if err != nil {
+		t.Fatalf("DecodeLocalTomb: %v", err)
+	}
+	if doc.MasterKey != encoded {
+		t.Fatalf("master key mismatch: got %q, want %q", doc.MasterKey, encoded)
+	}
+	if doc.Version != "v1" {
+		t.Fatalf("version mismatch: got %q, want %q", doc.Version, "v1")
+	}
+}
+
+func TestDecodeLocalTomb_RawBase64MasterKey(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	encoded := base64.RawStdEncoding.EncodeToString(key)
+
+	doc, err := DecodeLocalTomb([]byte(encoded))
+	if err != nil {
+		t.Fatalf("DecodeLocalTomb raw base64: %v", err)
+	}
+	if doc.MasterKey != encoded {
+		t.Fatalf("master key mismatch: got %q, want %q", doc.MasterKey, encoded)
+	}
+	if doc.Version != "v1" {
+		t.Fatalf("expected version v1, got %q", doc.Version)
+	}
+}
+
+func TestDecodeLocalTomb_EmptyInput(t *testing.T) {
+	_, err := DecodeLocalTomb([]byte(""))
+	if err == nil {
+		t.Fatal("expected error for empty input, got nil")
+	}
+}
+
+func TestDecodeLocalTomb_InvalidFormat(t *testing.T) {
+	_, err := DecodeLocalTomb([]byte("this-is-not-valid-anything"))
+	if err == nil {
+		t.Fatal("expected error for invalid format, got nil")
+	}
+}
+
+// ---------- LoadEnvSecretsFromTombDoc / SealEnvSecretsIntoTombDoc roundtrip ----------
+
+func TestSealAndLoadEnvSecrets_Roundtrip(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	encoded := base64.RawStdEncoding.EncodeToString(key)
+
+	doc := &LocalTomb{
+		Version:   "v1",
+		MasterKey: encoded,
+	}
+
+	secrets := map[string]string{
+		"API_KEY":    "sk-12345",
+		"DB_PASS":    "hunter2",
+		"EMPTY_VAL":  "",
+	}
+
+	if err := SealEnvSecretsIntoTombDoc(doc, secrets); err != nil {
+		t.Fatalf("SealEnvSecretsIntoTombDoc: %v", err)
+	}
+
+	if doc.EnvNonce == "" || doc.EnvCiphertext == "" {
+		t.Fatal("expected EnvNonce and EnvCiphertext to be populated after sealing")
+	}
+
+	loaded, err := LoadEnvSecretsFromTombDoc(doc)
+	if err != nil {
+		t.Fatalf("LoadEnvSecretsFromTombDoc: %v", err)
+	}
+
+	for k, want := range secrets {
+		got, ok := loaded[k]
+		if !ok {
+			t.Fatalf("missing key %q in loaded secrets", k)
+		}
+		if got != want {
+			t.Fatalf("secret %q mismatch: got %q, want %q", k, got, want)
+		}
+	}
+	if len(loaded) != len(secrets) {
+		t.Fatalf("loaded secret count mismatch: got %d, want %d", len(loaded), len(secrets))
+	}
+}
+
+// ---------- SealEnvSecretsIntoTombDoc with nil doc ----------
+
+func TestSealEnvSecretsIntoTombDoc_NilDoc(t *testing.T) {
+	err := SealEnvSecretsIntoTombDoc(nil, map[string]string{"a": "b"})
+	if err == nil {
+		t.Fatal("expected error for nil doc, got nil")
+	}
+}
+
+// ---------- LoadEnvSecretsFromTombDoc with empty nonce/ciphertext ----------
+
+func TestLoadEnvSecretsFromTombDoc_EmptyNonceCiphertext(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	encoded := base64.RawStdEncoding.EncodeToString(key)
+
+	doc := &LocalTomb{
+		Version:   "v1",
+		MasterKey: encoded,
+	}
+
+	got, err := LoadEnvSecretsFromTombDoc(doc)
+	if err != nil {
+		t.Fatalf("LoadEnvSecretsFromTombDoc: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty map, got %v", got)
+	}
+}

--- a/internal/secrets/blob_test.go
+++ b/internal/secrets/blob_test.go
@@ -206,9 +206,9 @@ func TestSealAndLoadEnvSecrets_Roundtrip(t *testing.T) {
 	}
 
 	secrets := map[string]string{
-		"API_KEY":    "sk-12345",
-		"DB_PASS":    "hunter2",
-		"EMPTY_VAL":  "",
+		"API_KEY":   "sk-12345",
+		"DB_PASS":   "hunter2",
+		"EMPTY_VAL": "",
 	}
 
 	if err := SealEnvSecretsIntoTombDoc(doc, secrets); err != nil {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -265,7 +265,11 @@ func (m *Manager) List() []SessionInfo {
 
 func (m *Manager) sessionPath(key string) string {
 	safeKey := strings.ReplaceAll(key, ":", "_")
-	return filepath.Join(m.sessionsDir, safeKey+".jsonl")
+	// Strip path separators and traversal components to prevent path injection.
+	safeKey = strings.ReplaceAll(safeKey, "/", "_")
+	safeKey = strings.ReplaceAll(safeKey, "\\", "_")
+	safeKey = strings.ReplaceAll(safeKey, "..", "_")
+	return filepath.Join(m.sessionsDir, filepath.Base(safeKey)+".jsonl")
 }
 
 func (m *Manager) load(key string) *Session {

--- a/internal/skills/oauth_crypto.go
+++ b/internal/skills/oauth_crypto.go
@@ -1,380 +1,35 @@
 package skills
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/rand"
-	"encoding/base64"
-	"encoding/json"
-	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/zalando/go-keyring"
+	"github.com/KafClaw/KafClaw/internal/secrets"
 )
 
-const oauthKeyFileName = "master.key"
-const oauthLocalTombFileName = "tomb.rr"
-const oauthKeyringService = "kafclaw.skills.oauth"
-const oauthKeyringUser = "master-key"
-const localTombEnvAAD = "kafclaw-local-env-secrets-v1"
-
-type localTomb struct {
-	Version       string `json:"version"`
-	MasterKey     string `json:"masterKey"`
-	EnvNonce      string `json:"envNonce,omitempty"`
-	EnvCiphertext string `json:"envCiphertext,omitempty"`
-}
-
-type encryptedOAuthBlob struct {
-	Version    string `json:"version"`
-	Nonce      string `json:"nonce"`
-	Ciphertext string `json:"ciphertext"`
-}
-
+// encryptOAuthStateBlob encrypts an OAuth state blob using the shared secrets package.
 func encryptOAuthStateBlob(plain []byte) ([]byte, error) {
-	key, err := loadOrCreateOAuthMasterKey()
-	if err != nil {
-		return nil, err
-	}
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, err
-	}
-	nonce := make([]byte, gcm.NonceSize())
-	if _, err := rand.Read(nonce); err != nil {
-		return nil, err
-	}
-	ciphertext := gcm.Seal(nil, nonce, plain, nil)
-	out := encryptedOAuthBlob{
-		Version:    "v1",
-		Nonce:      base64.RawStdEncoding.EncodeToString(nonce),
-		Ciphertext: base64.RawStdEncoding.EncodeToString(ciphertext),
-	}
-	data, err := json.MarshalIndent(out, "", "  ")
-	if err != nil {
-		return nil, err
-	}
-	return append(data, '\n'), nil
+	return secrets.EncryptBlob(plain)
 }
 
+// decryptOAuthStateBlob decrypts an OAuth state blob using the shared secrets package.
 func decryptOAuthStateBlob(data []byte) ([]byte, error) {
-	if len(data) == 0 {
-		return nil, fmt.Errorf("empty oauth state blob")
-	}
-	var wrapped encryptedOAuthBlob
-	if err := json.Unmarshal(data, &wrapped); err != nil {
-		// Backward compatibility: old plaintext JSON.
-		return data, nil
-	}
-	if wrapped.Version == "" || wrapped.Nonce == "" || wrapped.Ciphertext == "" {
-		// Backward compatibility: plaintext JSON object.
-		return data, nil
-	}
-	if wrapped.Version != "v1" {
-		return nil, fmt.Errorf("unsupported oauth state blob version: %s", wrapped.Version)
-	}
-	key, err := loadOrCreateOAuthMasterKey()
-	if err != nil {
-		return nil, err
-	}
-	nonce, err := base64.RawStdEncoding.DecodeString(strings.TrimSpace(wrapped.Nonce))
-	if err != nil {
-		return nil, err
-	}
-	ciphertext, err := base64.RawStdEncoding.DecodeString(strings.TrimSpace(wrapped.Ciphertext))
-	if err != nil {
-		return nil, err
-	}
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, err
-	}
-	plain, err := gcm.Open(nil, nonce, ciphertext, nil)
-	if err != nil {
-		return nil, err
-	}
-	return plain, nil
+	return secrets.DecryptBlob(data)
 }
 
+// loadOrCreateOAuthMasterKey delegates to the shared secrets package.
 func loadOrCreateOAuthMasterKey() ([]byte, error) {
-	if envKey := strings.TrimSpace(os.Getenv("KAFCLAW_OAUTH_MASTER_KEY")); envKey != "" {
-		key, err := decodeMasterKey(envKey)
-		if err != nil {
-			return nil, fmt.Errorf("invalid KAFCLAW_OAUTH_MASTER_KEY: %w", err)
-		}
-		return key, nil
-	}
-
-	switch resolveOAuthKeyBackend() {
-	case "local":
-		return loadOrCreateOAuthMasterKeyLocalOnly()
-	case "keyring":
-		return loadOrCreateOAuthMasterKeyKeyringOnly()
-	case "file":
-		return loadOrCreateOAuthMasterKeyFileOnly()
-	default:
-		if key, err := loadOrCreateOAuthMasterKeyKeyringOnly(); err == nil {
-			return key, nil
-		}
-		if key, err := loadOrCreateOAuthMasterKeyLocalOnly(); err == nil {
-			return key, nil
-		}
-		return loadOrCreateOAuthMasterKeyFileOnly()
-	}
+	return secrets.LoadOrCreateMasterKey()
 }
 
-func resolveOAuthKeyBackend() string {
-	v := strings.ToLower(strings.TrimSpace(os.Getenv("KAFCLAW_OAUTH_KEY_BACKEND")))
-	switch v {
-	case "local", "keyring", "file", "auto":
-		return v
-	default:
-		return "local"
-	}
-}
-
-func loadOrCreateOAuthMasterKeyKeyringOnly() ([]byte, error) {
-	val, err := keyring.Get(oauthKeyringService, oauthKeyringUser)
-	if err == nil {
-		return decodeMasterKey(val)
-	}
-	key := make([]byte, 32)
-	if _, err := rand.Read(key); err != nil {
-		return nil, err
-	}
-	encoded := base64.RawStdEncoding.EncodeToString(key)
-	if setErr := keyring.Set(oauthKeyringService, oauthKeyringUser, encoded); setErr != nil {
-		return nil, setErr
-	}
-	return key, nil
-}
-
-func loadOrCreateOAuthMasterKeyFileOnly() ([]byte, error) {
-	dirs, err := EnsureStateDirs()
-	if err != nil {
-		return nil, err
-	}
-	authRoot := filepath.Join(dirs.ToolsDir, "auth")
-	if err := os.MkdirAll(authRoot, 0o700); err != nil {
-		return nil, err
-	}
-	keyPath := filepath.Join(authRoot, oauthKeyFileName)
-	if data, err := os.ReadFile(keyPath); err == nil {
-		return decodeMasterKey(strings.TrimSpace(string(data)))
-	} else if !os.IsNotExist(err) {
-		return nil, err
-	}
-
-	key := make([]byte, 32)
-	if _, err := rand.Read(key); err != nil {
-		return nil, err
-	}
-	encoded := base64.RawStdEncoding.EncodeToString(key)
-	if err := os.WriteFile(keyPath, []byte(encoded+"\n"), 0o600); err != nil {
-		return nil, err
-	}
-	return key, nil
-}
-
-// ResolveLocalOAuthTombPath returns the local key tomb file path.
+// ResolveLocalOAuthTombPath delegates to the shared secrets package.
 func ResolveLocalOAuthTombPath() (string, error) {
-	if explicit := strings.TrimSpace(os.Getenv("KAFCLAW_OAUTH_TOMB_FILE")); explicit != "" {
-		if strings.HasPrefix(explicit, "~") {
-			home, err := resolveOAuthHomeDir()
-			if err != nil {
-				return "", err
-			}
-			return expandOAuthTildePath(explicit, home), nil
-		}
-		return explicit, nil
-	}
-	home, err := resolveOAuthHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(home, ".config", "kafclaw", oauthLocalTombFileName), nil
+	return secrets.ResolveLocalTombPath()
 }
 
-func resolveOAuthHomeDir() (string, error) {
-	if h := strings.TrimSpace(os.Getenv("KAFCLAW_HOME")); h != "" {
-		if strings.HasPrefix(h, "~") {
-			base, err := os.UserHomeDir()
-			if err != nil {
-				return "", err
-			}
-			return expandOAuthTildePath(h, base), nil
-		}
-		return h, nil
-	}
-	return os.UserHomeDir()
-}
-
-func expandOAuthTildePath(path string, home string) string {
-	switch {
-	case path == "~":
-		return home
-	case strings.HasPrefix(path, "~/"):
-		return filepath.Join(home, path[2:])
-	default:
-		return path
-	}
-}
-
-func loadOrCreateOAuthMasterKeyLocalOnly() ([]byte, error) {
-	tombPath, doc, err := loadOrCreateLocalTomb()
-	if err != nil {
-		return nil, err
-	}
-	key, err := decodeMasterKey(doc.MasterKey)
-	if err != nil {
-		return nil, err
-	}
-	_ = os.Chmod(tombPath, 0o600)
-	return key, nil
-}
-
-func loadOrCreateLocalTomb() (string, *localTomb, error) {
-	tombPath, err := ResolveLocalOAuthTombPath()
-	if err != nil {
-		return "", nil, err
-	}
-	if err := os.MkdirAll(filepath.Dir(tombPath), 0o700); err != nil {
-		return "", nil, err
-	}
-	if data, err := os.ReadFile(tombPath); err == nil {
-		doc, decErr := decodeLocalTomb(data)
-		if decErr != nil {
-			return "", nil, decErr
-		}
-		return tombPath, doc, nil
-	} else if !os.IsNotExist(err) {
-		return "", nil, err
-	}
-
-	key := make([]byte, 32)
-	if _, err := rand.Read(key); err != nil {
-		return "", nil, err
-	}
-	encoded := base64.RawStdEncoding.EncodeToString(key)
-	doc := &localTomb{
-		Version:   "v1",
-		MasterKey: encoded,
-	}
-	if err := writeLocalTomb(tombPath, doc); err != nil {
-		return "", nil, err
-	}
-	return tombPath, doc, nil
-}
-
-func decodeLocalTomb(data []byte) (*localTomb, error) {
-	trimmed := strings.TrimSpace(string(data))
-	if trimmed == "" {
-		return nil, fmt.Errorf("empty tomb file")
-	}
-	var doc localTomb
-	if err := json.Unmarshal([]byte(trimmed), &doc); err == nil && strings.TrimSpace(doc.MasterKey) != "" {
-		if strings.TrimSpace(doc.Version) == "" {
-			doc.Version = "v1"
-		}
-		return &doc, nil
-	}
-	// Backward-compatible: tomb was raw base64 key only.
-	if _, err := decodeMasterKey(trimmed); err == nil {
-		return &localTomb{
-			Version:   "v1",
-			MasterKey: trimmed,
-		}, nil
-	}
-	return nil, fmt.Errorf("invalid tomb file format")
-}
-
-func writeLocalTomb(path string, doc *localTomb) error {
-	if doc == nil {
-		return fmt.Errorf("nil tomb payload")
-	}
-	data, err := json.MarshalIndent(doc, "", "  ")
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(path, append(data, '\n'), 0o600)
-}
-
-func loadEnvSecretsFromLocalTombDoc(doc *localTomb) (map[string]string, error) {
-	out := map[string]string{}
-	if doc == nil || strings.TrimSpace(doc.EnvNonce) == "" || strings.TrimSpace(doc.EnvCiphertext) == "" {
-		return out, nil
-	}
-	key, err := decodeMasterKey(doc.MasterKey)
-	if err != nil {
-		return nil, err
-	}
-	nonce, err := base64.RawStdEncoding.DecodeString(strings.TrimSpace(doc.EnvNonce))
-	if err != nil {
-		return nil, err
-	}
-	ciphertext, err := base64.RawStdEncoding.DecodeString(strings.TrimSpace(doc.EnvCiphertext))
-	if err != nil {
-		return nil, err
-	}
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, err
-	}
-	plain, err := gcm.Open(nil, nonce, ciphertext, []byte(localTombEnvAAD))
-	if err != nil {
-		return nil, err
-	}
-	if err := json.Unmarshal(plain, &out); err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func sealEnvSecretsIntoLocalTombDoc(doc *localTomb, kv map[string]string) error {
-	if doc == nil {
-		return fmt.Errorf("nil tomb payload")
-	}
-	if kv == nil {
-		kv = map[string]string{}
-	}
-	key, err := decodeMasterKey(doc.MasterKey)
-	if err != nil {
-		return err
-	}
-	plain, err := json.Marshal(kv)
-	if err != nil {
-		return err
-	}
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return err
-	}
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return err
-	}
-	nonce := make([]byte, gcm.NonceSize())
-	if _, err := rand.Read(nonce); err != nil {
-		return err
-	}
-	ciphertext := gcm.Seal(nil, nonce, plain, []byte(localTombEnvAAD))
-	doc.EnvNonce = base64.RawStdEncoding.EncodeToString(nonce)
-	doc.EnvCiphertext = base64.RawStdEncoding.EncodeToString(ciphertext)
-	return nil
+// decodeMasterKey delegates to the shared secrets package.
+func decodeMasterKey(raw string) ([]byte, error) {
+	return secrets.DecodeMasterKey(raw)
 }
 
 // StoreEnvSecretsInLocalTomb merges sensitive env kv into tomb-managed encrypted payload.
@@ -382,11 +37,11 @@ func StoreEnvSecretsInLocalTomb(kv map[string]string) (int, error) {
 	if len(kv) == 0 {
 		return 0, nil
 	}
-	tombPath, doc, err := loadOrCreateLocalTomb()
+	tombPath, doc, err := secrets.LoadOrCreateLocalTomb()
 	if err != nil {
 		return 0, err
 	}
-	existing, err := loadEnvSecretsFromLocalTombDoc(doc)
+	existing, err := secrets.LoadEnvSecretsFromTombDoc(doc)
 	if err != nil {
 		return 0, err
 	}
@@ -403,10 +58,10 @@ func StoreEnvSecretsInLocalTomb(kv map[string]string) (int, error) {
 	if changed == 0 {
 		return 0, nil
 	}
-	if err := sealEnvSecretsIntoLocalTombDoc(doc, existing); err != nil {
+	if err := secrets.SealEnvSecretsIntoTombDoc(doc, existing); err != nil {
 		return 0, err
 	}
-	if err := writeLocalTomb(tombPath, doc); err != nil {
+	if err := secrets.WriteLocalTomb(tombPath, doc); err != nil {
 		return 0, err
 	}
 	if err := os.Chmod(tombPath, 0o600); err != nil {
@@ -417,7 +72,7 @@ func StoreEnvSecretsInLocalTomb(kv map[string]string) (int, error) {
 
 // LoadEnvSecretsFromLocalTomb decrypts env secrets previously stored in tomb.
 func LoadEnvSecretsFromLocalTomb() (map[string]string, error) {
-	tombPath, err := ResolveLocalOAuthTombPath()
+	tombPath, err := secrets.ResolveLocalTombPath()
 	if err != nil {
 		return nil, err
 	}
@@ -428,22 +83,9 @@ func LoadEnvSecretsFromLocalTomb() (map[string]string, error) {
 		}
 		return nil, err
 	}
-	doc, err := decodeLocalTomb(data)
+	doc, err := secrets.DecodeLocalTomb(data)
 	if err != nil {
 		return nil, err
 	}
-	return loadEnvSecretsFromLocalTombDoc(doc)
-}
-
-func decodeMasterKey(raw string) ([]byte, error) {
-	trimmed := strings.TrimSpace(raw)
-	decoded := make([]byte, base64.RawStdEncoding.DecodedLen(len(trimmed)))
-	n, err := base64.RawStdEncoding.Decode(decoded, []byte(trimmed))
-	if err != nil {
-		return nil, err
-	}
-	if n != 32 {
-		return nil, fmt.Errorf("invalid oauth master key length: %d", n)
-	}
-	return decoded[:n], nil
+	return secrets.LoadEnvSecretsFromTombDoc(doc)
 }

--- a/internal/timeline/schema.go
+++ b/internal/timeline/schema.go
@@ -57,6 +57,8 @@ type AgentTask struct {
 	PromptTokens     int        `json:"prompt_tokens"`
 	CompletionTokens int        `json:"completion_tokens"`
 	TotalTokens      int        `json:"total_tokens"`
+	ProviderID       string     `json:"provider_id,omitempty"`
+	ModelName        string     `json:"model_name,omitempty"`
 	DeliveryAttempts int        `json:"delivery_attempts"`
 	DeliveryNextAt   *time.Time `json:"delivery_next_at,omitempty"`
 	CreatedAt        time.Time  `json:"created_at"`


### PR DESCRIPTION
## Summary

Adds a complete multi-provider LLM layer, replacing the hardcoded single-provider path with a runtime-resolved, per-agent configurable provider system — including chat middleware, credential management, CLI tooling, CodeQL hardening, and full documentation.

### Provider Layer

- **11 providers**: Claude, OpenAI, Gemini (API key + CLI OAuth), OpenAI Codex (CLI OAuth), xAI/Grok, Scalytics Copilot, OpenRouter, DeepSeek, Groq, vLLM
- **Model string format**: `<provider>/<model>` (e.g. `claude/claude-opus-4-6`, `openai/gpt-4o`)
- **Provider resolver** with resolution order: per-agent model → task-type routing → global model → legacy fallback
- **Per-agent config**: `primary` + `fallbacks[]` + subagent model inheritance
- **Credential store**: encrypted at-rest API key storage
- **CLI cache readers**: Gemini CLI and Codex CLI OAuth token caches
- **CLI installer**: auto-install `gemini` or `codex` CLI if absent during `models auth login`
- **Rate limit tracking**: parse `x-ratelimit-*` / `anthropic-ratelimit-*` headers per provider

### Chat Middleware Chain

Pipeline between agent loop and LLM provider:

1. **Content Classifier** — detect PII sensitivity level and task type
2. **Prompt Guard** — scan for PII, secrets, deny-keywords pre-LLM; modes: `warn`, `redact`, `block`
3. **Output Sanitizer** — redact PII/secrets/deny-patterns from LLM output before delivery
4. **FinOps Cost Attribution** — per-provider $/token pricing, daily/monthly budgets, per-agent breakdown

All middleware actions logged as timeline events for observability.

### Task-Type Model Routing

`model.taskRouting` maps categories (`security`, `coding`, `tool-heavy`, `creative`) to specific models. The agent loop dynamically swaps the provider chain per request via `AssessTask` → `ResolveWithTaskType`.

### CLI: `kafclaw models`

| Command | Description |
|---|---|
| `models list` | Show configured providers and active model per agent |
| `models stats [--days N] [--json]` | Token usage, cost, rate limit snapshots |
| `models auth login --provider <p>` | OAuth flow (Gemini, Codex) |
| `models auth set-key --provider <p> --key <k>` | Store API key in credential store |

### Onboarding

All 13 provider presets wired into `kafclaw onboard` interactive and `--non-interactive` flows.

### Diagnostics

- `kafclaw status` — active model, configured providers, token usage, rate limits, middleware
- `kafclaw doctor` — provider reachability checks, rate limit low-threshold warnings

### Timeline & FinOps

- `cost_usd` column added to timeline events
- `GetDailyCostByProvider` query for per-provider daily cost breakdown
- `UpdateTaskCost` for per-task cost attribution

### Security Hardening (CodeQL)

Resolved all CodeQL errors across the codebase:
- Path injection: taint-breaking `strings.Contains(path, "..")` barriers
- XSS: explicit `Content-Type: text/plain` on gateway text responses
- Command injection: git subcommand allowlist + `exec.Cmd{}` struct construction
- SSRF: `http.Request{}` struct construction bypassing `NewRequestWithContext` sink
- TLS: configurable `rejectUnauthorized` in Electron remote client

### Documentation

- **New**: `docs/reference/providers.md` — provider matrix, auth, resolution, routing
- **New**: `docs/reference/middleware.md` — classifier, prompt guard, sanitizer, FinOps
- **New**: `docs/reference/models-cli.md` — full CLI reference with examples
- **Updated**: config-keys, cli-reference, admin-guide, getting-started

### Test Coverage

- Provider: model string parsing, registration, resolution, task-type routing, fallbacks
- Credentials: encrypt/decrypt roundtrip, expiry with grace window
- Middleware: classifier, prompt guard, sanitizer, FinOps (each with unit tests)
- Secrets: EncryptBlob/DecryptBlob roundtrip
- Doctor: provider checks, rate limit warnings (cliconfig >80%)
- Gateway: runGit 100% branch coverage
- Timeline: token/cost queries

## Test Plan

- [ ] `make commit-check` passes (fmt, vet, race, fuzz, CodeQL gate)
- [ ] `kafclaw onboard` with each provider preset
- [ ] `kafclaw models list` / `kafclaw models stats`
- [ ] `kafclaw models auth set-key --provider claude --key sk-ant-...`
- [ ] `kafclaw doctor` shows provider checks and rate limit warnings
- [ ] `kafclaw status` shows provider info section
- [ ] Middleware: prompt guard blocks message with deny keyword
- [ ] Task routing: security-classified message routes to configured model