### PR TITLE
Release v2.7.0

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kafclaw-desktop",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "description": "KafClaw Desktop - AI Assistant with three operation modes",
   "main": "dist/main/index.js",
   "scripts": {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,7 +8,7 @@ import (
 var (
 	// version can be overridden at build time via:
 	// go build -ldflags "-X github.com/KafClaw/KafClaw/internal/cli.version=1.2.3"
-	version = "2.6.3"
+	version = "2.7.0"
 	logo    = "\n" +
 		"  _  __       __  ____ _\n" +
 		" | |/ / __ _ / _|/ ___| | __ ___      __\n" +


### PR DESCRIPTION
## Release v2.7.0

Version bump `2.6.3` → `2.7.0` in `internal/cli/root.go` and `electron/package.json`.

Once merged, push tag `v2.7.0` to trigger the release workflow.

**Full Changelog**: https://github.com/KafClaw/KafClaw/compare/v2.6.3...release-v2.7.0