### PR TITLE
Fix Pages deploy: allow workflow_dispatch trigger

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Pages
-        if: github.repository == 'KafClaw/KafClaw' && github.event_name == 'push'
+        if: github.repository == 'KafClaw/KafClaw' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: actions/configure-pages@v5
         with:
           enablement: true
@@ -47,7 +47,7 @@ jobs:
           path: ./_site
 
   deploy:
-    if: github.repository == 'KafClaw/KafClaw' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.repository == 'KafClaw/KafClaw' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Deploy job was skipped on manual triggers because the condition only matched `push` events. Also switched Pages source from legacy to workflow build type to prevent the legacy builder from overriding Actions-based deploys.