### PR TITLE
Fix docs 404: add permalink pretty

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -12,6 +12,7 @@ plugins:
   - jekyll-remote-theme
   - jekyll-seo-tag
   - jekyll-include-cache
+permalink: pretty
 markdown: kramdown
 kramdown:
   input: GFM


### PR DESCRIPTION
All doc links use trailing-slash URLs but Jekyll was generating .html files. Adds `permalink: pretty` to generate directory-based URLs matching the link format.