### PR TITLE
fix broken doc links for pretty permalinks

### DIFF
--- a/docs/architecture-security/architecture-detailed.md
+++ b/docs/architecture-security/architecture-detailed.md
@@ -5,7 +5,7 @@ title: KafClaw System Architecture — Detailed Reference
 
 # KafClaw System Architecture — Detailed Reference
 
-> For the quick overview, see [architecture.md](./architecture/).
+> For the quick overview, see [Architecture Overview](/architecture-security/architecture/).
 
 ---
 
@@ -576,7 +576,7 @@ Renderer (Vue 3 SPA)
 
 ## 9. Security Model
 
-> See also: [admin-guide.md](./admin-guide.md#2-security-model) for the comprehensive security reference, [security-risks.md](./security-risks/) for threat model
+> See also: [Administration Guide](/operations-admin/admin-guide/#2-security-model) for the comprehensive security reference, [Security Risks](/architecture-security/security-risks/) for threat model
 
 ### 9.1 Tool Authorization (3-Tier)
 
@@ -608,7 +608,7 @@ Destructive deletion, VCS deletion, disk destruction, device redirection, permis
 
 ## 10. Deployment Modes
 
-> See also: [operations-guide.md](./operations-guide.md#3-deployment) for full deployment instructions
+> See also: [Operations Guide](/operations-admin/operations-guide/#3-deployment) for full deployment instructions
 
 | Mode | Command | Description |
 |------|---------|-------------|
@@ -642,7 +642,7 @@ KAFCLAW_GATEWAY_HOST=192.168.0.199 make run      # bind to specific IP
 
 ## 11. Build and Release
 
-> See also: [release.md](./release/), [operations-guide.md](./operations-guide.md#2-build-and-release)
+> See also: [Release Process](/operations-admin/release/), [Operations Guide](/operations-admin/operations-guide/#2-build-and-release)
 
 ### Key Makefile Targets
 
@@ -746,7 +746,7 @@ ContextBuilder.BuildSystemPrompt()
 
 ## 13. Extension Points
 
-> See also: [admin-guide.md](./admin-guide.md#6-extending-kafclaw) for detailed extension instructions with code examples
+> See also: [Administration Guide](/operations-admin/admin-guide/#6-extending-kafclaw) for detailed extension instructions with code examples
 
 ### Adding a New Tool
 

--- a/docs/architecture-security/architecture.md
+++ b/docs/architecture-security/architecture.md
@@ -5,7 +5,7 @@ title: KafClaw Architecture — Overview
 
 # KafClaw Architecture — Overview
 
-A quick reference for the KafClaw system architecture. For the comprehensive deep-dive, see [architecture-detailed.md](./architecture-detailed/).
+A quick reference for the KafClaw system architecture. For the comprehensive deep-dive, see [Detailed Architecture](/architecture-security/architecture-detailed/).
 
 ---
 

--- a/docs/architecture-security/security-for-ops.md
+++ b/docs/architecture-security/security-for-ops.md
@@ -110,5 +110,5 @@ Use these as part of daily operations and after any security-relevant change.
 - `doctor --fix` moves sensitive env keys into tomb-managed encrypted storage and scrubs them from `~/.config/kafclaw/env`.
 - Security events and install decisions are chained into immutable-style audit logs under `~/.kafclaw/skills/audit/`.
 - For deployment-specific skill operations and remediations, refer to:
-  - [Skills](../skills/index.md)
-  - [KafClaw Management Guide](../operations-admin/manage-kafclaw.md)
+  - [Skills](/skills/)
+  - [KafClaw Management Guide](/operations-admin/manage-kafclaw/)

--- a/docs/integrations/whatsapp-onboarding.md
+++ b/docs/integrations/whatsapp-onboarding.md
@@ -7,7 +7,7 @@ title: WhatsApp Onboarding — Buddy Access
 
 End-to-end guide for connecting a buddy to your KafClaw instance via WhatsApp.
 
-> See also: [WhatsApp Setup (Default Deny)](whatsapp-setup/) for CLI reference.
+> See also: [WhatsApp Setup (Default Deny)](/integrations/whatsapp-setup/) for CLI reference.
 
 ## Overview
 
@@ -81,7 +81,7 @@ Once setup is verified and the buddy is approved:
 
 For channel parity status versus OpenClaw (what WhatsApp can do today in KafClaw, and what remains limited), see:
 
-- [WhatsApp Setup (Default Deny)](whatsapp-setup/) -> **Parity snapshot (OpenClaw vs KafClaw)**
+- [WhatsApp Setup (Default Deny)](/integrations/whatsapp-setup/) -> **Parity snapshot (OpenClaw vs KafClaw)**
 
 ## CLI Quick Reference
 

--- a/docs/operations-admin/admin-guide.md
+++ b/docs/operations-admin/admin-guide.md
@@ -64,7 +64,7 @@ type Config struct {
 }
 ```
 
-New sections added in this release: `Model`, `Paths`, `ContentClassification`, `PromptGuard`, `OutputSanitization`, `FinOps`. See [Configuration Keys](../reference/config-keys/) for details.
+New sections added in this release: `Model`, `Paths`, `ContentClassification`, `PromptGuard`, `OutputSanitization`, `FinOps`. See [Configuration Keys](/reference/config-keys/) for details.
 
 ### Agent Configuration
 
@@ -389,7 +389,7 @@ type LLMProvider interface {
 | `groq` | API key | `https://api.groq.com/openai/v1` |
 | `vllm` | optional key + base | _(configured)_ |
 
-For full provider setup, see [LLM Providers Reference](../reference/providers/).
+For full provider setup, see [LLM Providers Reference](/reference/providers/).
 
 ### Provider Resolution Order
 
@@ -408,7 +408,7 @@ kafclaw models auth set-key --provider claude --key sk-ant-...
 kafclaw models auth login --provider gemini
 ```
 
-See [Models CLI Reference](../reference/models-cli/) for all auth commands.
+See [Models CLI Reference](/reference/models-cli/) for all auth commands.
 
 ### Middleware Chain
 
@@ -419,7 +419,7 @@ A configurable middleware chain runs between the agent loop and the LLM provider
 - **Output Sanitizer** — response redaction and deny pattern filtering
 - **FinOps Recorder** — per-request cost calculation and budget warnings
 
-See [Chat Middleware Reference](../reference/middleware/) for configuration.
+See [Chat Middleware Reference](/reference/middleware/) for configuration.
 
 ### Token & Cost Tracking
 

--- a/docs/operations-admin/maintenance.md
+++ b/docs/operations-admin/maintenance.md
@@ -158,6 +158,6 @@ Use trace views in dashboard to inspect these lifecycle events.
 
 ## Deep References
 
-- [Operations Guide](./operations-guide/)
-- [Admin Guide](./admin-guide/)
-- [Security Risks](../architecture-security/security-risks/)
+- [Operations Guide](/operations-admin/operations-guide/)
+- [Admin Guide](/operations-admin/admin-guide/)
+- [Security Risks](/architecture-security/security-risks/)

--- a/docs/operations-admin/manage-kafclaw.md
+++ b/docs/operations-admin/manage-kafclaw.md
@@ -281,7 +281,7 @@ Skills policy defaults:
 - `skills.scope=selected` (least-privilege, recommended)
 - `skills.runtimeIsolation=auto` (use strict if container runtime is mandatory in your environment)
 
-See [Skills](../skills/index.md) for full skill policy details.
+See [Skills](/skills/) for full skill policy details.
 
 ### LLM provider and token management
 
@@ -488,8 +488,8 @@ Recommended usage:
 - `security fix --yes`: apply safe remediations; re-run check after changes.
 - `doctor --fix`: merges env files, syncs sensitive env keys into tomb-managed encrypted storage, then scrubs those sensitive keys from `~/.config/kafclaw/env`.
 
-For security posture details, see [Security for Operators](../architecture-security/security-for-ops.md).
-For skills policy, OAuth keying, and source pinning syntax, see [Skills](../skills/index.md).
+For security posture details, see [Security for Operators](/architecture-security/security-for-ops/).
+For skills policy, OAuth keying, and source pinning syntax, see [Skills](/skills/).
 
 Recommended CI gate:
 

--- a/docs/operations-admin/operations-guide.md
+++ b/docs/operations-admin/operations-guide.md
@@ -69,7 +69,7 @@ WhatsApp/CLI/Web/Scheduler --> Message Bus --> Agent Loop --> LLM Provider
 
 ## 2. Build and Release
 
-> See also: [release.md](./release/) for versioning details
+> See also: [Release Process](/operations-admin/release/) for versioning details
 
 ### Prerequisites
 
@@ -147,7 +147,7 @@ Container mounts:
 kafclaw install      # root: /usr/local/bin, non-root: ~/.local/bin
 ```
 
-For release-binary install flows (`--latest`, `--version`, `--list-releases`, unattended, signature verification), see [KafClaw Management Guide](../operations-admin/manage-kafclaw/).
+For release-binary install flows (`--latest`, `--version`, `--list-releases`, unattended, signature verification), see [KafClaw Management Guide](/operations-admin/manage-kafclaw/).
 
 ### Deployment Modes
 

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -18,6 +18,6 @@ Runtime HTTP surfaces:
   - repo/orchestrator/group endpoints under `/api/v1/*`
 
 Detailed API docs:
-- [KafClaw Operations Guide](../operations-admin/operations-guide/)
-- [KafClaw Administration Guide](../operations-admin/admin-guide/)
-- [Detailed Architecture](../architecture-security/architecture-detailed/)
+- [KafClaw Operations Guide](/operations-admin/operations-guide/)
+- [KafClaw Administration Guide](/operations-admin/admin-guide/)
+- [Detailed Architecture](/architecture-security/architecture-detailed/)

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -35,10 +35,10 @@ Automation-friendly lifecycle output:
 - `kafclaw daemon <install|uninstall|start|stop|restart|status> --json`
 
 Detailed command examples:
-- [Getting Started](../start-here/getting-started/)
-- [User Manual - CLI Reference section](../start-here/user-manual/#3-cli-reference)
-- [Manage KafClaw](../operations-admin/manage-kafclaw/)
-- [Models CLI Reference](models-cli/) - provider management, auth, usage stats
+- [Getting Started](/start-here/getting-started/)
+- [User Manual - CLI Reference section](/start-here/user-manual/#3-cli-reference)
+- [Manage KafClaw](/operations-admin/manage-kafclaw/)
+- [Models CLI Reference](/reference/models-cli/) - provider management, auth, usage stats
 
 Skills execution example:
 - `kafclaw skills exec <skill-id> --input '{"text":"..."}'`

--- a/docs/reference/config-keys.md
+++ b/docs/reference/config-keys.md
@@ -104,7 +104,7 @@ kafclaw doctor
 }
 ```
 
-Each provider entry accepts `apiKey` and `apiBase`. See [LLM Providers](providers/) for details.
+Each provider entry accepts `apiKey` and `apiBase`. See [LLM Providers](/reference/providers/) for details.
 
 ## Per-Agent Model Configuration
 
@@ -137,10 +137,10 @@ Each provider entry accepts `apiKey` and `apiBase`. See [LLM Providers](provider
 
 | Section | Reference |
 |---------|-----------|
-| `contentClassification` | [Content Classification](middleware/#content-classification) |
-| `promptGuard` | [Prompt Guard](middleware/#prompt-guard) |
-| `outputSanitization` | [Output Sanitizer](middleware/#output-sanitizer) |
-| `finops` | [FinOps Cost Attribution](middleware/#finops-cost-attribution) |
+| `contentClassification` | [Content Classification](/reference/middleware/#content-classification) |
+| `promptGuard` | [Prompt Guard](/reference/middleware/#prompt-guard) |
+| `outputSanitization` | [Output Sanitizer](/reference/middleware/#output-sanitizer) |
+| `finops` | [FinOps Cost Attribution](/reference/middleware/#finops-cost-attribution) |
 
 ## Common Environment Variables
 
@@ -163,9 +163,9 @@ Each provider entry accepts `apiKey` and `apiBase`. See [LLM Providers](provider
 
 ## Related Docs
 
-- [LLM Providers](providers/)
-- [Models CLI](models-cli/)
-- [Chat Middleware](middleware/)
-- [Getting Started Guide](../start-here/getting-started/)
-- [KafClaw Administration Guide](../operations-admin/admin-guide/)
-- [Workspace Policy](../architecture-security/workspace-policy/)
+- [LLM Providers](/reference/providers/)
+- [Models CLI](/reference/models-cli/)
+- [Chat Middleware](/reference/middleware/)
+- [Getting Started Guide](/start-here/getting-started/)
+- [KafClaw Administration Guide](/operations-admin/admin-guide/)
+- [Workspace Policy](/architecture-security/workspace-policy/)

--- a/docs/reference/middleware.md
+++ b/docs/reference/middleware.md
@@ -240,6 +240,6 @@ kafclaw status
 
 ## Related Docs
 
-- [LLM Providers](providers/)
-- [Models CLI Reference](models-cli/)
-- [Configuration Keys](config-keys/)
+- [LLM Providers](/reference/providers/)
+- [Models CLI Reference](/reference/models-cli/)
+- [Configuration Keys](/reference/config-keys/)

--- a/docs/reference/models-cli.md
+++ b/docs/reference/models-cli.md
@@ -158,6 +158,6 @@ kafclaw models auth set-key --provider scalytics-copilot --key <bearer-token> --
 
 ## Related Docs
 
-- [LLM Providers](providers/)
-- [Chat Middleware](middleware/)
-- [Configuration Keys](config-keys/)
+- [LLM Providers](/reference/providers/)
+- [Chat Middleware](/reference/middleware/)
+- [Configuration Keys](/reference/config-keys/)

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -195,6 +195,6 @@ kafclaw models stats --days 7
 
 ## Related Docs
 
-- [Models CLI Reference](models-cli/)
-- [Middleware Configuration](middleware/)
-- [Configuration Keys](config-keys/)
+- [Models CLI Reference](/reference/models-cli/)
+- [Middleware Configuration](/reference/middleware/)
+- [Configuration Keys](/reference/config-keys/)

--- a/docs/skills/google-workspace.md
+++ b/docs/skills/google-workspace.md
@@ -19,7 +19,7 @@ Headless OAuth flow for Google Workspace integrations.
 - Stores token state securely for runtime use by the local agent.
 - Enables policy-gated Google Workspace operations after enrollment.
 
-For key backend options and storage/security posture, see [Skills](./index.md).
+For key backend options and storage/security posture, see [Skills](/skills/).
 
 ## Install / Enable
 
@@ -50,7 +50,7 @@ kafclaw skills auth complete google-workspace \
 
 - Start flow, open returned URL in a browser, approve scopes, and paste callback URL.
 - Keep scopes minimal and aligned with tenant policy.
-- OAuth flow start/complete events are recorded in chained security audit logs (see [Skills](./index.md)).
+- OAuth flow start/complete events are recorded in chained security audit logs (see [Skills](/skills/)).
 - Agent read-only tool:
   - `google_workspace_read` with `operation=gmail_list_messages|calendar_list_events|drive_list_files`
   - include Gmail/Calendar/Drive read scopes during `auth start` for the operation you need.

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -10,8 +10,8 @@ Operator and security notes for bundled and external skills.
 
 For deep security posture and operational commands, see:
 
-- [Security for Operators](../architecture-security/security-for-ops.md)
-- [KafClaw Management Guide](../operations-admin/manage-kafclaw.md)
+- [Security for Operators](/architecture-security/security-for-ops/)
+- [KafClaw Management Guide](/operations-admin/manage-kafclaw/)
 
 ## Bundled Skills
 
@@ -144,8 +144,8 @@ Agent tool names for OAuth-enrolled read-only access:
 - `kafclaw doctor --fix` also syncs sensitive env keys into tomb-managed encrypted storage (`env_tomb_sync` check).
 - After successful tomb sync, `doctor --fix` scrubs sensitive keys from `~/.config/kafclaw/env` (`env_sensitive_scrub` check). Runtime then loads them from tomb into process env.
 - For provider-specific enrollment flows, use:
-  - [google-workspace](./google-workspace.md)
-  - [m365](./m365.md)
+  - [google-workspace](/skills/google-workspace/)
+  - [m365](/skills/m365/)
 
 ## External Source Pinning
 
@@ -159,4 +159,4 @@ Agent tool names for OAuth-enrolled read-only access:
 - `clawhub:<slug>` installs are staged in quarantine, verified, then installed.
 - ClawHub state/metadata is synchronized under skills runtime tools state.
 - Security events and install decisions are recorded as chained JSONL audit logs in `~/.kafclaw/skills/audit/`.
-- See [KafClaw Management Guide](../operations-admin/manage-kafclaw.md) for operations workflow.
+- See [KafClaw Management Guide](/operations-admin/manage-kafclaw/) for operations workflow.

--- a/docs/skills/m365.md
+++ b/docs/skills/m365.md
@@ -19,7 +19,7 @@ Headless OAuth flow for Microsoft 365 integrations.
 - Stores token state securely for runtime use by the local agent.
 - Enables policy-gated Outlook/Calendar/Drive/Teams operations.
 
-For key backend options and storage/security posture, see [Skills](./index.md).
+For key backend options and storage/security posture, see [Skills](/skills/).
 
 ## Install / Enable
 
@@ -51,7 +51,7 @@ kafclaw skills auth complete m365 \
 
 - Start flow, sign in, approve scopes, then paste callback URL to complete enrollment.
 - Prefer tenant-specific app registration and least-privilege scopes.
-- OAuth flow start/complete events are recorded in chained security audit logs (see [Skills](./index.md)).
+- OAuth flow start/complete events are recorded in chained security audit logs (see [Skills](/skills/)).
 - Agent read-only tool:
   - `m365_read` with `operation=mail_list_messages|calendar_list_events|onedrive_list_children`
   - include `Mail.Read` / `Calendars.Read` / `Files.Read` scopes during `auth start` for the operation you need.

--- a/docs/start-here/getting-started.md
+++ b/docs/start-here/getting-started.md
@@ -54,7 +54,7 @@ curl --fail --show-error --silent --location \
   | bash -s -- --list-releases
 ```
 
-For full install flags and operator-focused behavior (root handling, signature controls, unattended modes), see [KafClaw Management Guide](../operations-admin/manage-kafclaw/).
+For full install flags and operator-focused behavior (root handling, signature controls, unattended modes), see [KafClaw Management Guide](/operations-admin/manage-kafclaw/).
 
 Desktop app distribution:
 
@@ -206,7 +206,7 @@ kafclaw models auth login --provider gemini
 kafclaw models stats
 ```
 
-See [LLM Providers](../reference/providers/) and [Models CLI](../reference/models-cli/) for full details.
+See [LLM Providers](/reference/providers/) and [Models CLI](/reference/models-cli/) for full details.
 
 To reconfigure provider/token later, run onboarding again (interactive) or use:
 
@@ -382,9 +382,9 @@ Join and verify:
 
 ## Next
 
-- [Manage KafClaw](../operations-admin/manage-kafclaw/)
-- [Operations and Maintenance](../operations-admin/maintenance/)
-- [How Agents Work](../agent-concepts/how-agents-work/)
-- [Soul and Identity Files](../agent-concepts/soul-identity-tools/)
-- [User Manual](./user-manual/)
-- [Admin Guide](../operations-admin/admin-guide/)
+- [Manage KafClaw](/operations-admin/manage-kafclaw/)
+- [Operations and Maintenance](/operations-admin/maintenance/)
+- [How Agents Work](/agent-concepts/how-agents-work/)
+- [Soul and Identity Files](/agent-concepts/soul-identity-tools/)
+- [User Manual](/start-here/user-manual/)
+- [Admin Guide](/operations-admin/admin-guide/)

--- a/docs/start-here/user-manual.md
+++ b/docs/start-here/user-manual.md
@@ -65,7 +65,7 @@ cd KafClaw
 make build
 ```
 
-For complete install options (`--list-releases`, signature verification defaults, root/runtime behavior), see [KafClaw Management Guide](../operations-admin/manage-kafclaw/).
+For complete install options (`--list-releases`, signature verification defaults, root/runtime behavior), see [KafClaw Management Guide](/operations-admin/manage-kafclaw/).
 
 ### First-Time Setup
 
@@ -346,7 +346,7 @@ Header status indicators: mode badge, memory LED, sidecar/connection status.
 
 ## 5. WhatsApp, Slack, and Teams Integration
 
-> See also: [whatsapp-setup.md](./whatsapp-setup/) for full details
+> See also: [WhatsApp Setup](/integrations/whatsapp-setup/) for full details
 
 KafClaw uses `whatsmeow` for native Go WhatsApp connectivity. No Node.js bridge required.
 
@@ -410,7 +410,7 @@ Known limits:
 
 ## 6. Memory System
 
-> See also: [architecture-timeline.md](./architecture-timeline/) for the full memory architecture
+> See also: [Timeline Architecture](/architecture-security/architecture-timeline/) for the full memory architecture
 
 ### Overview
 


### PR DESCRIPTION
## Summary
- Convert all relative links (`../`, `./`, bare) to absolute paths across 19 doc files
- With `permalink: pretty`, each page URL gains a directory level, breaking cross-section relative links

## Test plan
- [ ] Verify previously-404 links from getting-started Next section resolve correctly
- [ ] Spot-check reference, operations, skills cross-links