### PR TITLE
Agent thought process

### DIFF
--- a/docs/agent-concepts/CoT.md
+++ b/docs/agent-concepts/CoT.md
@@ -139,3 +139,40 @@ This should be enabled per agent only when the agent's workload is deterministic
 - Not recommended: general-purpose chat or exploratory analysis agents
 
 Use `kafclaw configure` to enable or disable cascade behavior at the agent level, and keep default behavior unchanged for agents that do not need gated execution.
+
+## Migration Guide for Existing Agent Configs
+
+Use this flow when upgrading an existing installation that already has `agents.list` entries.
+
+1. Inspect your current agents:
+
+```bash
+kafclaw config get agents.list
+```
+
+2. Enable cascade only for deterministic agents:
+
+```bash
+kafclaw configure --agent-id ops --agent-cascade-enabled-set --agent-cascade-enabled=true
+kafclaw configure --agent-id runbook --agent-cascade-enabled-set --agent-cascade-enabled=true
+```
+
+3. Keep exploratory or chat agents disabled:
+
+```bash
+kafclaw configure --agent-id main --agent-cascade-enabled-set --agent-cascade-enabled=false
+```
+
+4. Verify persisted config:
+
+```bash
+kafclaw config get agents.list
+```
+
+5. Validate runtime behavior on a trace:
+
+```bash
+kafclaw task status --trace <trace-id> --json
+```
+
+For failure triage, see the runbook snippet in [Memory Governance Operations](/memory-management/memory-governance-operations/#cascade-failure-triage-snippet).

--- a/docs/agent-concepts/CoT.md
+++ b/docs/agent-concepts/CoT.md
@@ -1,0 +1,141 @@
+---
+parent: Memory Management
+title: CoT Cascading Protocol
+nav_order: 2
+---
+
+# CoT Cascading Protocol
+
+The Cascading Protocol applies Chain-of-Thought style task decomposition with strict stage gates between subtasks.
+
+- Every subtask declares `required_input`, `produced_output`, and `validation_rules`.
+- `Task N+1` is blocked until `Task N` is committed with validated outputs.
+- Failures route back with deterministic reasons (`missing_input`, `missing_output`, `invalid_rules`) and retry controls.
+- State transitions are durable and idempotent.
+
+## State Machine Infographic
+
+<style>
+  .cot-wrap {
+    margin: 14px 0 6px;
+    color: #18263d;
+    font-family: "Avenir Next", "Segoe UI", "Helvetica Neue", sans-serif;
+  }
+  .cot-grid {
+    display: grid;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    gap: 12px;
+    margin-top: 14px;
+  }
+  .cot-card {
+    grid-column: span 12;
+    border: 1px solid #d4deef;
+    border-radius: 12px;
+    background: #ffffff;
+    padding: 12px;
+    box-shadow: 0 6px 18px rgba(24, 45, 84, 0.07);
+  }
+  .cot-card svg {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+</style>
+
+<div class="cot-wrap">
+  <section class="cot-grid">
+    <article class="cot-card">
+      <svg viewBox="0 0 1120 320" role="img" aria-label="Cascading protocol state machine">
+        <defs>
+          <marker id="cot-arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto">
+            <polygon points="0,0 10,4 0,8" fill="#24509c"></polygon>
+          </marker>
+          <marker id="cot-arrow-fail" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto">
+            <polygon points="0,0 10,4 0,8" fill="#b11f2f"></polygon>
+          </marker>
+        </defs>
+
+        <rect x="30" y="44" width="140" height="58" rx="10" fill="#eef4ff" stroke="#9bb5e6"></rect>
+        <text x="100" y="78" text-anchor="middle" font-size="14" font-weight="700" fill="#1a4288">pending</text>
+
+        <rect x="200" y="44" width="140" height="58" rx="10" fill="#eef4ff" stroke="#9bb5e6"></rect>
+        <text x="270" y="78" text-anchor="middle" font-size="14" font-weight="700" fill="#1a4288">running</text>
+
+        <rect x="370" y="44" width="140" height="58" rx="10" fill="#eef4ff" stroke="#9bb5e6"></rect>
+        <text x="440" y="78" text-anchor="middle" font-size="14" font-weight="700" fill="#1a4288">self_test</text>
+
+        <rect x="540" y="44" width="140" height="58" rx="10" fill="#eef4ff" stroke="#9bb5e6"></rect>
+        <text x="610" y="78" text-anchor="middle" font-size="14" font-weight="700" fill="#1a4288">validated</text>
+
+        <rect x="710" y="44" width="140" height="58" rx="10" fill="#eaf8f3" stroke="#9ad8c4"></rect>
+        <text x="780" y="78" text-anchor="middle" font-size="14" font-weight="700" fill="#17634d">committed</text>
+
+        <rect x="880" y="44" width="170" height="58" rx="10" fill="#eaf8f3" stroke="#9ad8c4"></rect>
+        <text x="965" y="78" text-anchor="middle" font-size="14" font-weight="700" fill="#17634d">released_next</text>
+
+        <rect x="760" y="212" width="150" height="58" rx="10" fill="#ffeef0" stroke="#de9aa1"></rect>
+        <text x="835" y="246" text-anchor="middle" font-size="14" font-weight="700" fill="#8e1f2a">failed</text>
+
+        <rect x="930" y="212" width="170" height="58" rx="10" fill="#fff8ea" stroke="#e3c995"></rect>
+        <text x="1015" y="238" text-anchor="middle" font-size="14" font-weight="700" fill="#84511b">Task N+1</text>
+        <text x="1015" y="256" text-anchor="middle" font-size="11" fill="#8f6933">can start</text>
+
+        <line x1="170" y1="73" x2="198" y2="73" stroke="#24509c" stroke-width="2.4" marker-end="url(#cot-arrow)"></line>
+        <line x1="340" y1="73" x2="368" y2="73" stroke="#24509c" stroke-width="2.4" marker-end="url(#cot-arrow)"></line>
+        <line x1="510" y1="73" x2="538" y2="73" stroke="#24509c" stroke-width="2.4" marker-end="url(#cot-arrow)"></line>
+        <line x1="680" y1="73" x2="708" y2="73" stroke="#24509c" stroke-width="2.4" marker-end="url(#cot-arrow)"></line>
+        <line x1="850" y1="73" x2="878" y2="73" stroke="#24509c" stroke-width="2.4" marker-end="url(#cot-arrow)"></line>
+
+        <path d="M 440 104 C 440 150, 100 150, 100 104" fill="none" stroke="#996221" stroke-width="2.2" marker-end="url(#cot-arrow)"></path>
+        <text x="230" y="165" text-anchor="middle" font-size="11" fill="#8f6933">validation failed + retries left</text>
+
+        <line x1="100" y1="104" x2="760" y2="212" stroke="#b11f2f" stroke-width="2" marker-end="url(#cot-arrow-fail)"></line>
+        <text x="318" y="186" text-anchor="middle" font-size="11" fill="#8e1f2a">retry budget exhausted</text>
+
+        <line x1="270" y1="104" x2="790" y2="212" stroke="#b11f2f" stroke-width="2" marker-end="url(#cot-arrow-fail)"></line>
+        <text x="468" y="205" text-anchor="middle" font-size="11" fill="#8e1f2a">runtime error</text>
+
+        <line x1="610" y1="104" x2="820" y2="212" stroke="#b11f2f" stroke-width="2" marker-end="url(#cot-arrow-fail)"></line>
+        <text x="672" y="186" text-anchor="middle" font-size="11" fill="#8e1f2a">commit error</text>
+
+        <line x1="800" y1="104" x2="985" y2="212" stroke="#996221" stroke-width="2" stroke-dasharray="6,5" marker-end="url(#cot-arrow)"></line>
+        <text x="905" y="164" text-anchor="middle" font-size="11" fill="#8f6933">unlock Task N+1</text>
+      </svg>
+    </article>
+  </section>
+</div>
+
+## When To Use
+
+Use this mode for deterministic, verifiable work where output shape and validation are clear.
+
+- Runbooks and operations workflows
+- Config generation and structured updates
+- Code mod pipelines and migration steps
+- Multi-stage tasks where each step has hard contracts
+
+## When Not To Use
+
+Avoid this mode for open-ended and high-ambiguity work.
+
+- Creative generation and brainstorming
+- Exploratory research without stable validation criteria
+- Low-latency conversational tasks
+- Tasks where strict sequencing blocks useful parallelism
+
+## Implications and Tradeoffs
+
+- Improves reliability by preventing context drift between subtasks.
+- Reduces copy-of-copy distortion via explicit output validation.
+- Adds latency and compute cost due to retries and gate checks.
+- Can stall throughput if contracts are underspecified.
+- Requires better task design (`required_input`, `produced_output`, and validation rules must be explicit).
+
+## Configuration Guidance
+
+This should be enabled per agent only when the agent's workload is deterministic and auditable.
+
+- Recommended: ops/runbook/config/code-mod agents
+- Not recommended: general-purpose chat or exploratory analysis agents
+
+Use `kafclaw configure` to enable or disable cascade behavior at the agent level, and keep default behavior unchanged for agents that do not need gated execution.

--- a/docs/agent-concepts/CoT.md
+++ b/docs/agent-concepts/CoT.md
@@ -130,6 +130,7 @@ Avoid this mode for open-ended and high-ambiguity work.
 - Adds latency and compute cost due to retries and gate checks.
 - Can stall throughput if contracts are underspecified.
 - Requires better task design (`required_input`, `produced_output`, and validation rules must be explicit).
+- On retry-threshold exceed, failed transitions now trigger deterministic escalation hints for fallback model and tooling.
 
 ## Configuration Guidance
 

--- a/docs/agent-concepts/how-agents-work.md
+++ b/docs/agent-concepts/how-agents-work.md
@@ -1,6 +1,7 @@
 ---
 parent: Agent Concepts
 title: How Agents Work
+nav_order: 1
 ---
 
 # How Agents Work

--- a/docs/agent-concepts/index.md
+++ b/docs/agent-concepts/index.md
@@ -1,8 +1,13 @@
 ---
 title: Agent Concepts
-parent: Memory Management
-nav_order: 1
+nav_order: 5
 has_children: true
 ---
 
-Core concepts behind KafClaw agents, including identity, runtime behavior, tool boundaries, and memory.
+Core runtime concepts behind KafClaw agents, including identity, lifecycle, tool boundaries, and execution behavior.
+
+## Core Pages
+
+- [How Agents Work](/agent-concepts/how-agents-work/)
+- [Soul and Identity Files](/agent-concepts/soul-identity-tools/)
+- [Runtime Tools and Capabilities](/agent-concepts/runtime-tools/)

--- a/docs/agent-concepts/memory-notes.md
+++ b/docs/agent-concepts/memory-notes.md
@@ -1,7 +1,7 @@
 ---
 parent: Memory Management
 title: Memory Architecture and Notes
-nav_order: 2
+nav_order: 1
 ---
 
 # Memory Architecture and Notes
@@ -179,6 +179,10 @@ Private memory lanes, restart durability, model-switch behavior, and distributed
 <div class="km-callout">
   Model switch rule: if a previously used embedding model changes, memory vectors are wiped before reindex. Adding the first embedding model later does not wipe existing text records.
 </div>
+
+## Cascading Protocol (Gated Subtasks)
+
+Full protocol details, state machine infographic, and operational guidance are documented in [CoT Cascading Protocol](/agent-concepts/CoT/).
 
 ## Kafka Knowledge Pool: How It Works
 

--- a/docs/agent-concepts/runtime-tools.md
+++ b/docs/agent-concepts/runtime-tools.md
@@ -1,6 +1,7 @@
 ---
 parent: Agent Concepts
 title: Runtime Tools and Capabilities
+nav_order: 3
 ---
 
 # Runtime Tools and Capabilities

--- a/docs/agent-concepts/soul-identity-tools.md
+++ b/docs/agent-concepts/soul-identity-tools.md
@@ -1,6 +1,7 @@
 ---
 parent: Agent Concepts
 title: Soul and Identity Files
+nav_order: 2
 ---
 
 # Soul and Identity Files

--- a/docs/architecture-security/architecture-timeline.md
+++ b/docs/architecture-security/architecture-timeline.md
@@ -1,7 +1,7 @@
 ---
-parent: Memory Management
+parent: Architecture and Security
 title: "Architecture: Timeline and Memory"
-nav_order: 3
+nav_order: 4
 ---
 
 # Architecture: Timeline and Memory

--- a/docs/architecture-security/index.md
+++ b/docs/architecture-security/index.md
@@ -1,6 +1,6 @@
 ---
 title: Architecture and Security
-nav_order: 7
+nav_order: 9
 has_children: true
 ---
 

--- a/docs/collaboration/index.md
+++ b/docs/collaboration/index.md
@@ -1,6 +1,6 @@
 ---
 title: Communication and Channels
-nav_order: 5
+nav_order: 6
 has_children: true
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,12 +34,18 @@ KafClaw is a Go-based agent runtime with three practical deployment modes:
 - [WhatsApp Onboarding](./integrations/whatsapp-onboarding/)
 - [WhatsApp Setup](./integrations/whatsapp-setup/)
 
+## Agent Concepts
+
+- [Agent Concepts](./agent-concepts/)
+- [How Agents Work](./agent-concepts/how-agents-work/)
+- [Soul and Identity Files](./agent-concepts/soul-identity-tools/)
+- [Runtime Tools and Capabilities](./agent-concepts/runtime-tools/)
+
 ## Memory Management
 
 - [Memory Management](./memory-management/)
 - [Memory Architecture and Notes](./agent-concepts/memory-notes/)
-- [Timeline and Memory Architecture](./architecture-security/architecture-timeline/)
-- [Knowledge Contracts](./reference/knowledge-contracts/)
+- [CoT Cascading Protocol](./agent-concepts/CoT/)
 - [Memory Governance Operations](./memory-management/memory-governance-operations/)
 
 ## Communication and Channels
@@ -76,3 +82,4 @@ KafClaw is a Go-based agent runtime with three practical deployment modes:
 - [CLI Reference](./reference/cli-reference/)
 - [API Endpoints](./reference/api-endpoints/)
 - [Configuration Keys](./reference/config-keys/)
+- [Knowledge Contracts](./reference/knowledge-contracts/)

--- a/docs/memory-management/index.md
+++ b/docs/memory-management/index.md
@@ -1,6 +1,6 @@
 ---
 title: Memory Management
-nav_order: 4
+nav_order: 7
 has_children: true
 ---
 
@@ -17,11 +17,15 @@ Private memory, durability, embeddings, and shared knowledge governance in one p
 ## Core Pages
 
 - [Memory Architecture and Notes](/agent-concepts/memory-notes/)
+- [CoT Cascading Protocol](/agent-concepts/CoT/)
 - [Durable Memory Concept (Runbook)](/memory-management/memory-governance-operations/#durable-memory-concept)
-- [Architecture: Timeline and Memory](/architecture-security/architecture-timeline/)
-- [Knowledge Contracts](/reference/knowledge-contracts/)
 - [Memory Governance Operations](/memory-management/memory-governance-operations/)
+
+## Related References
+
+- [Knowledge Contracts](/reference/knowledge-contracts/)
 - [Configuration Keys](/reference/config-keys/)
+- [Architecture: Timeline and Memory](/architecture-security/architecture-timeline/)
 
 ## Operational Endpoints
 

--- a/docs/memory-management/memory-governance-operations.md
+++ b/docs/memory-management/memory-governance-operations.md
@@ -1,7 +1,7 @@
 ---
 title: Memory Governance Operations
 parent: Memory Management
-nav_order: 5
+nav_order: 3
 ---
 
 # Memory Governance Operations

--- a/docs/memory-management/memory-governance-operations.md
+++ b/docs/memory-management/memory-governance-operations.md
@@ -114,3 +114,35 @@ Governance behavior:
 - Quorum policy is controlled by `knowledge.voting.*`.
 - Shared facts apply sequential version policy (`accepted|stale|conflict`).
 - Apply paths are feature-gated by `knowledge.governanceEnabled`.
+
+## Cascade Failure Triage Snippet
+
+Use this quick flow when a cascading task is stuck or failed.
+
+1. Pull the full state machine for the trace:
+
+```bash
+kafclaw task status --trace <trace-id> --json
+```
+
+2. Check transition order for the failing task:
+- expected happy path: `pending -> running -> self_test -> validated -> committed -> released_next`
+- expected retry path: `self_test -> pending` when retries remain
+- terminal paths: `failed` on runtime, validation budget, or commit errors
+
+3. Identify deterministic failure reason in JSON:
+- `missing_input`
+- `missing_output`
+- `invalid_rules`
+- runtime or commit error metadata
+
+4. Apply targeted fix:
+- contract issue: update `required_input` or `produced_output`
+- validation issue: tighten or correct `validation_rules`
+- runtime issue: fix tool or execution precondition
+
+5. Re-run task and verify transition recovery:
+
+```bash
+kafclaw task status --trace <trace-id> --json
+```

--- a/docs/memory-management/memory-governance-operations.md
+++ b/docs/memory-management/memory-governance-operations.md
@@ -135,6 +135,7 @@ kafclaw task status --trace <trace-id> --json
 - `missing_output`
 - `invalid_rules`
 - runtime or commit error metadata
+- escalation marker (when retry threshold exceeded): `artifact.escalation` with fallback model/tooling hints
 
 4. Apply targeted fix:
 - contract issue: update `required_input` or `produced_output`

--- a/docs/operations-admin/index.md
+++ b/docs/operations-admin/index.md
@@ -1,6 +1,6 @@
 ---
 title: Operations and Admin
-nav_order: 6
+nav_order: 8
 has_children: true
 ---
 

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -23,6 +23,7 @@ Primary command groups:
 - `kafclaw pairing` - Slack/Teams pairing approvals
 - `kafclaw group` - group communication controls
 - `kafclaw knowledge` - shared knowledge governance (`status|propose|vote|decisions|facts`)
+- `kafclaw task` - cascading task protocol visibility (`status --trace <id>`)
 - `kafclaw kshark` - Kafka diagnostics
 - `kafclaw version` - print build version
 
@@ -45,11 +46,20 @@ Memory safety flags:
 - `kafclaw doctor --fix` repairs missing memory embedding defaults.
 - `kafclaw configure --memory-embedding-enabled-set --memory-embedding-enabled=true --memory-embedding-provider local-hf --memory-embedding-model BAAI/bge-small-en-v1.5 --memory-embedding-dimension 384`
 - `kafclaw configure --memory-embedding-model <new-model> --confirm-memory-wipe` when switching an already-used embedding.
+- `kafclaw configure --agent-id <agent-id> --agent-cascade-enabled-set --agent-cascade-enabled=<true|false>`
+
+Cascade safety note:
+- Enabling per-agent cascade is recommended only for deterministic workflows (ops/runbook/config/code-mod).
+- For ambiguous or creative tasks, keep it disabled to avoid extra latency and retry churn.
 
 Knowledge governance notes:
 - Knowledge envelopes require `schemaVersion`, `traceId`, `idempotencyKey`, `clawId`, and `instanceId`.
 - Duplicate knowledge envelopes (same `idempotencyKey`) are ignored after first apply.
 - Voting outcomes follow quorum policy (`approved|rejected|expired|pending`) from `knowledge.voting.*`.
+
+Cascading protocol visibility:
+- `kafclaw task status --trace <trace-id> --json`
+- Returns ordered cascade task states plus transition audit events for restart-safe debugging.
 
 Skills execution example:
 - `kafclaw skills exec <skill-id> --input '{"text":"..."}'`

--- a/docs/reference/config-keys.md
+++ b/docs/reference/config-keys.md
@@ -240,6 +240,11 @@ Each provider entry accepts `apiKey` and `apiBase`. See [LLM Providers](/referen
 | `agents.list[].model.primary` | string | Primary model for this agent |
 | `agents.list[].model.fallbacks` | []string | Fallback models tried on transient errors |
 | `agents.list[].subagents.model` | string | Model for subagents spawned by this agent |
+| `agents.list[].cascade.enabled` | bool | Enable cascading protocol gates for this agent (recommended only for deterministic tasks) |
+
+Cascade usage warning:
+- Enable for deterministic workflows (ops/runbook/config/code-mod).
+- Keep disabled for ambiguous/creative tasks to reduce latency and retry-loop risk.
 
 ## Subagent Memory Share Mode
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,6 +1,6 @@
 ---
 title: Reference
-nav_order: 8
+nav_order: 10
 has_children: true
 ---
 

--- a/docs/reference/knowledge-contracts.md
+++ b/docs/reference/knowledge-contracts.md
@@ -1,7 +1,7 @@
 ---
 title: Knowledge Contracts
-parent: Memory Management
-nav_order: 4
+parent: Reference
+nav_order: 7
 ---
 
 # Knowledge Contracts

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -1,6 +1,6 @@
 ---
 title: Skills
-nav_order: 9
+nav_order: 11
 has_children: true
 ---
 

--- a/internal/cascade/protocol.go
+++ b/internal/cascade/protocol.go
@@ -1,0 +1,163 @@
+package cascade
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	StatePending      = "pending"
+	StateRunning      = "running"
+	StateSelfTest     = "self_test"
+	StateValidated    = "validated"
+	StateCommitted    = "committed"
+	StateReleasedNext = "released_next"
+	StateFailed       = "failed"
+)
+
+// TaskContract defines explicit IO boundaries for one cascade step.
+type TaskContract struct {
+	TaskID          string
+	Sequence        int
+	RequiredInput   []string
+	ProducedOutput  []string
+	ValidationRules []string // supported: non_empty:<field>, equals:<field>:<value>
+}
+
+// TaskSnapshot is the runtime state used by orchestration gates.
+type TaskSnapshot struct {
+	TaskID          string
+	Sequence        int
+	State           string
+	RetryCount      int
+	MaxRetries      int
+	BlockedByTaskID string
+}
+
+// ValidationResult is the output of self-test and manager-side validation.
+type ValidationResult struct {
+	OK             bool
+	MissingInput   []string
+	MissingOutput  []string
+	InvalidRules   []string
+	RemediationMsg string
+}
+
+func ValidateContract(c TaskContract) error {
+	if strings.TrimSpace(c.TaskID) == "" {
+		return fmt.Errorf("task_id is required")
+	}
+	if c.Sequence <= 0 {
+		return fmt.Errorf("sequence must be > 0")
+	}
+	return nil
+}
+
+func CanTransition(fromState, toState string) bool {
+	switch fromState {
+	case StatePending:
+		return toState == StateRunning || toState == StateFailed
+	case StateRunning:
+		return toState == StateSelfTest || toState == StateFailed
+	case StateSelfTest:
+		return toState == StateValidated || toState == StatePending || toState == StateFailed
+	case StateValidated:
+		return toState == StateCommitted || toState == StateFailed
+	case StateCommitted:
+		return toState == StateReleasedNext || toState == StateFailed
+	case StateReleasedNext, StateFailed:
+		return false
+	default:
+		return false
+	}
+}
+
+func CanStart(task TaskSnapshot, predecessor *TaskSnapshot) (bool, string) {
+	if task.State != StatePending {
+		return false, "task must be pending"
+	}
+	if task.MaxRetries > 0 && task.RetryCount >= task.MaxRetries {
+		return false, "retry budget exhausted"
+	}
+
+	requiresPredecessor := task.Sequence > 1 || strings.TrimSpace(task.BlockedByTaskID) != ""
+	if !requiresPredecessor {
+		return true, ""
+	}
+	if predecessor == nil {
+		return false, "predecessor not found"
+	}
+	if predecessor.State != StateCommitted && predecessor.State != StateReleasedNext {
+		return false, "predecessor output not committed"
+	}
+	return true, ""
+}
+
+func ValidateIO(contract TaskContract, input map[string]string, output map[string]string) ValidationResult {
+	res := ValidationResult{OK: true}
+	for _, key := range contract.RequiredInput {
+		if strings.TrimSpace(input[strings.TrimSpace(key)]) == "" {
+			res.MissingInput = append(res.MissingInput, strings.TrimSpace(key))
+		}
+	}
+	for _, key := range contract.ProducedOutput {
+		if strings.TrimSpace(output[strings.TrimSpace(key)]) == "" {
+			res.MissingOutput = append(res.MissingOutput, strings.TrimSpace(key))
+		}
+	}
+	for _, rule := range contract.ValidationRules {
+		if !applyRule(strings.TrimSpace(rule), output) {
+			res.InvalidRules = append(res.InvalidRules, strings.TrimSpace(rule))
+		}
+	}
+	if len(res.MissingInput) > 0 || len(res.MissingOutput) > 0 || len(res.InvalidRules) > 0 {
+		res.OK = false
+		res.RemediationMsg = buildRemediation(res)
+	}
+	return res
+}
+
+func NextStateAfterValidation(task TaskSnapshot, validation ValidationResult) string {
+	if validation.OK {
+		return StateValidated
+	}
+	if task.MaxRetries > 0 && task.RetryCount+1 >= task.MaxRetries {
+		return StateFailed
+	}
+	return StatePending
+}
+
+func applyRule(rule string, output map[string]string) bool {
+	if rule == "" {
+		return true
+	}
+	switch {
+	case strings.HasPrefix(rule, "non_empty:"):
+		key := strings.TrimSpace(strings.TrimPrefix(rule, "non_empty:"))
+		return strings.TrimSpace(output[key]) != ""
+	case strings.HasPrefix(rule, "equals:"):
+		parts := strings.SplitN(strings.TrimPrefix(rule, "equals:"), ":", 2)
+		if len(parts) != 2 {
+			return false
+		}
+		key := strings.TrimSpace(parts[0])
+		want := strings.TrimSpace(parts[1])
+		return strings.TrimSpace(output[key]) == want
+	default:
+		return false
+	}
+}
+
+func buildRemediation(res ValidationResult) string {
+	parts := make([]string, 0, 3)
+	if len(res.MissingInput) > 0 {
+		parts = append(parts, "missing_input="+strings.Join(res.MissingInput, ","))
+	}
+	if len(res.MissingOutput) > 0 {
+		parts = append(parts, "missing_output="+strings.Join(res.MissingOutput, ","))
+	}
+	if len(res.InvalidRules) > 0 {
+		parts = append(parts, "invalid_rules="+strings.Join(res.InvalidRules, ","))
+	}
+	return strings.Join(parts, "; ")
+}

--- a/internal/cascade/protocol_test.go
+++ b/internal/cascade/protocol_test.go
@@ -1,0 +1,151 @@
+package cascade
+
+import "testing"
+
+func TestValidateContract(t *testing.T) {
+	if err := ValidateContract(TaskContract{TaskID: "t1", Sequence: 1}); err != nil {
+		t.Fatalf("expected valid contract, got %v", err)
+	}
+	if err := ValidateContract(TaskContract{TaskID: "", Sequence: 1}); err == nil {
+		t.Fatal("expected error for empty task_id")
+	}
+	if err := ValidateContract(TaskContract{TaskID: "t1", Sequence: 0}); err == nil {
+		t.Fatal("expected error for sequence<=0")
+	}
+}
+
+func TestCanTransition(t *testing.T) {
+	if !CanTransition(StatePending, StateRunning) {
+		t.Fatal("pending->running should be valid")
+	}
+	if !CanTransition(StateSelfTest, StatePending) {
+		t.Fatal("self_test->pending should be valid")
+	}
+	if CanTransition(StateCommitted, StateValidated) {
+		t.Fatal("committed->validated should be invalid")
+	}
+	if CanTransition(StateFailed, StatePending) {
+		t.Fatal("failed should be terminal")
+	}
+}
+
+func TestCanStart(t *testing.T) {
+	start, reason := CanStart(TaskSnapshot{
+		TaskID:     "t1",
+		Sequence:   1,
+		State:      StatePending,
+		RetryCount: 0,
+		MaxRetries: 2,
+	}, nil)
+	if !start || reason != "" {
+		t.Fatalf("expected start allowed, got start=%v reason=%q", start, reason)
+	}
+
+	start, reason = CanStart(TaskSnapshot{
+		TaskID:     "t2",
+		Sequence:   2,
+		State:      StatePending,
+		RetryCount: 0,
+		MaxRetries: 2,
+	}, &TaskSnapshot{TaskID: "t1", State: StateValidated})
+	if start || reason == "" {
+		t.Fatalf("expected block until predecessor committed, got start=%v reason=%q", start, reason)
+	}
+
+	start, reason = CanStart(TaskSnapshot{
+		TaskID:     "t2",
+		Sequence:   2,
+		State:      StatePending,
+		RetryCount: 1,
+		MaxRetries: 2,
+	}, &TaskSnapshot{TaskID: "t1", State: StateCommitted})
+	if !start || reason != "" {
+		t.Fatalf("expected start allowed after predecessor commit, got start=%v reason=%q", start, reason)
+	}
+}
+
+func TestCanStartRetryBudgetAndState(t *testing.T) {
+	start, reason := CanStart(TaskSnapshot{
+		TaskID:     "t1",
+		Sequence:   1,
+		State:      StateRunning,
+		RetryCount: 0,
+		MaxRetries: 1,
+	}, nil)
+	if start || reason == "" {
+		t.Fatalf("expected block when not pending, got start=%v reason=%q", start, reason)
+	}
+
+	start, reason = CanStart(TaskSnapshot{
+		TaskID:     "t1",
+		Sequence:   1,
+		State:      StatePending,
+		RetryCount: 1,
+		MaxRetries: 1,
+	}, nil)
+	if start || reason == "" {
+		t.Fatalf("expected retry budget exhaustion, got start=%v reason=%q", start, reason)
+	}
+}
+
+func TestValidateIO(t *testing.T) {
+	contract := TaskContract{
+		TaskID:          "t1",
+		Sequence:        1,
+		RequiredInput:   []string{"source_doc", "ticket_id"},
+		ProducedOutput:  []string{"summary", "risk_level"},
+		ValidationRules: []string{"non_empty:summary", "equals:risk_level:low"},
+	}
+	ok := ValidateIO(contract,
+		map[string]string{"source_doc": "doc", "ticket_id": "T-1"},
+		map[string]string{"summary": "all good", "risk_level": "low"},
+	)
+	if !ok.OK {
+		t.Fatalf("expected valid io, got %+v", ok)
+	}
+
+	bad := ValidateIO(contract,
+		map[string]string{"source_doc": "doc"},
+		map[string]string{"summary": "", "risk_level": "high"},
+	)
+	if bad.OK {
+		t.Fatalf("expected invalid io, got %+v", bad)
+	}
+	if len(bad.MissingInput) != 1 || bad.MissingInput[0] != "ticket_id" {
+		t.Fatalf("unexpected missing input: %+v", bad.MissingInput)
+	}
+	if len(bad.MissingOutput) != 1 || bad.MissingOutput[0] != "summary" {
+		t.Fatalf("unexpected missing output: %+v", bad.MissingOutput)
+	}
+	if len(bad.InvalidRules) != 2 {
+		t.Fatalf("expected two invalid rules, got %+v", bad.InvalidRules)
+	}
+	if bad.RemediationMsg == "" {
+		t.Fatal("expected remediation message")
+	}
+}
+
+func TestValidateIOUnknownRule(t *testing.T) {
+	contract := TaskContract{
+		TaskID:          "t1",
+		Sequence:        1,
+		ValidationRules: []string{"unknown_rule"},
+	}
+	res := ValidateIO(contract, nil, map[string]string{})
+	if res.OK {
+		t.Fatalf("expected invalid result for unknown rule, got %+v", res)
+	}
+}
+
+func TestNextStateAfterValidation(t *testing.T) {
+	task := TaskSnapshot{TaskID: "t1", RetryCount: 0, MaxRetries: 2}
+	if got := NextStateAfterValidation(task, ValidationResult{OK: true}); got != StateValidated {
+		t.Fatalf("expected validated, got %s", got)
+	}
+	if got := NextStateAfterValidation(task, ValidationResult{OK: false}); got != StatePending {
+		t.Fatalf("expected pending for retry, got %s", got)
+	}
+	if got := NextStateAfterValidation(TaskSnapshot{TaskID: "t1", RetryCount: 1, MaxRetries: 2}, ValidationResult{OK: false}); got != StateFailed {
+		t.Fatalf("expected failed when retry budget reached, got %s", got)
+	}
+}

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	taskCmd = &cobra.Command{
+		Use:   "task",
+		Short: "Task workflow utilities",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	taskStatusCmd = &cobra.Command{
+		Use:   "status",
+		Short: "Show cascading protocol status for a trace",
+		RunE:  runTaskStatus,
+	}
+)
+
+func init() {
+	taskStatusCmd.Flags().String("trace", "", "Trace ID")
+	taskStatusCmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	taskCmd.AddCommand(taskStatusCmd)
+	rootCmd.AddCommand(taskCmd)
+}
+
+func runTaskStatus(cmd *cobra.Command, args []string) error {
+	traceID, _ := cmd.Flags().GetString("trace")
+	asJSON, _ := cmd.Flags().GetBool("json")
+	traceID = strings.TrimSpace(traceID)
+	if traceID == "" {
+		return fmt.Errorf("--trace is required")
+	}
+	timeSvc, err := loadGroupTimeline()
+	if err != nil {
+		return err
+	}
+	defer timeSvc.Close()
+
+	tasks, err := timeSvc.ListCascadeTasks(traceID)
+	if err != nil {
+		return err
+	}
+	transitions, err := timeSvc.ListCascadeTransitions(traceID, "", 500)
+	if err != nil {
+		return err
+	}
+	out := map[string]any{
+		"traceId":            traceID,
+		"taskCount":          len(tasks),
+		"transitionCount":    len(transitions),
+		"tasks":              tasks,
+		"transitionsPreview": transitions,
+	}
+	return printTaskOutput(cmd.OutOrStdout(), out, asJSON)
+}
+
+func printTaskOutput(w io.Writer, payload any, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(payload)
+	}
+	m, ok := payload.(map[string]any)
+	if !ok {
+		_, err := fmt.Fprintln(w, payload)
+		return err
+	}
+	_, _ = fmt.Fprintf(w, "Trace: %v\n", m["traceId"])
+	_, _ = fmt.Fprintf(w, "Cascade tasks: %v\n", m["taskCount"])
+	_, _ = fmt.Fprintf(w, "Transitions: %v\n", m["transitionCount"])
+	tasks, _ := m["tasks"].([]any)
+	if len(tasks) == 0 {
+		_, _ = fmt.Fprintln(w, "No cascading tasks recorded.")
+		return nil
+	}
+	_, _ = fmt.Fprintln(w, "Tasks:")
+	for i, item := range tasks {
+		_, _ = fmt.Fprintf(w, "  %d. %v\n", i+1, item)
+	}
+	return nil
+}

--- a/internal/cli/task_test.go
+++ b/internal/cli/task_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/KafClaw/KafClaw/internal/timeline"
+)
+
+func TestTaskStatusCLI(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgDir := filepath.Join(tmpDir, ".kafclaw")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(`{"node":{"clawId":"c1","instanceId":"i1"}}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	tl, err := timeline.NewTimelineService(filepath.Join(cfgDir, "timeline.db"))
+	if err != nil {
+		t.Fatalf("open timeline: %v", err)
+	}
+	if err := tl.CreateCascadeTask(&timeline.CascadeTaskRecord{
+		TaskID:   "t1",
+		TraceID:  "trace-xyz",
+		Sequence: 1,
+		Title:    "Collect inputs",
+	}); err != nil {
+		t.Fatalf("create cascade task: %v", err)
+	}
+	if _, err := tl.AdvanceCascadeTask("trace-xyz", "t1", "pending", "running", "manager", "start", `{}`, "idem-x1"); err != nil {
+		t.Fatalf("advance cascade task: %v", err)
+	}
+	_ = tl.Close()
+
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	_ = os.Setenv("HOME", tmpDir)
+
+	out, err := runRootCommand(t, "task", "status", "--trace=trace-xyz", "--json")
+	if err != nil {
+		t.Fatalf("task status json: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal json output: %v\nout=%s", err, out)
+	}
+	if payload["traceId"] != "trace-xyz" {
+		t.Fatalf("expected traceId trace-xyz, got %+v", payload["traceId"])
+	}
+	if payload["taskCount"] == nil || payload["transitionCount"] == nil {
+		t.Fatalf("expected task/transition counts in output, got %v", payload)
+	}
+
+	plain, err := runRootCommand(t, "task", "status", "--trace=trace-xyz", "--json=false")
+	if err != nil {
+		t.Fatalf("task status text: %v", err)
+	}
+	if !strings.Contains(plain, "Trace: trace-xyz") {
+		t.Fatalf("unexpected text output: %s", plain)
+	}
+}
+
+func TestTaskStatusRequiresTrace(t *testing.T) {
+	if _, err := runRootCommand(t, "task", "status", "--trace="); err == nil {
+		t.Fatal("expected --trace required error")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -392,6 +392,11 @@ type AgentSubagentSpec struct {
 	Model string `json:"model"`
 }
 
+// AgentCascadeSpec configures cascading protocol behavior for an agent.
+type AgentCascadeSpec struct {
+	Enabled bool `json:"enabled"`
+}
+
 // AgentListEntry describes a configured agent identity.
 type AgentListEntry struct {
 	ID        string             `json:"id"`
@@ -399,6 +404,7 @@ type AgentListEntry struct {
 	Default   bool               `json:"default,omitempty"`
 	Model     *AgentModelSpec    `json:"model,omitempty"`
 	Subagents *AgentSubagentSpec `json:"subagents,omitempty"`
+	Cascade   *AgentCascadeSpec  `json:"cascade,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -556,7 +556,7 @@ func cleanEmptyAgents(cfg *Config) {
 	if cfg == nil || cfg.Agents == nil {
 		return
 	}
-	if isZeroSubagentsToolConfig(cfg.Agents.Defaults.Subagents) {
+	if isZeroSubagentsToolConfig(cfg.Agents.Defaults.Subagents) && len(cfg.Agents.List) == 0 {
 		cfg.Agents = nil
 	}
 }

--- a/internal/tools/shell_fuzz_test.go
+++ b/internal/tools/shell_fuzz_test.go
@@ -24,7 +24,7 @@ func FuzzGuardCommand_NoPanicAndTraversalBlocked(f *testing.F) {
 				t.Fatalf("expected traversal-like command to be blocked: %q", command)
 			}
 		}
-		if strings.Contains(lc, "rm -rf /") && err == nil {
+		if destructiveRMRootRegex.MatchString(lc) && err == nil {
 			t.Fatalf("expected destructive rm pattern blocked: %q", command)
 		}
 	})


### PR DESCRIPTION
## Summary

This PR adds the Cascading Protocol implementation in three clean layers:

1. Core gated task lifecycle and persistence engine
2. Per-agent cascade configuration and guided CLI enablement
3. Documentation split and navigation reorganization for clarity

## What Changed

### 1. Cascading Protocol Runtime

- Added cascade protocol core in:
  - `internal/cascade/protocol.go`
  - `internal/cascade/protocol_test.go`
- Added task CLI/runtime wiring:
  - `internal/cli/task.go`
  - `internal/cli/task_test.go`
- Added durable task transition schema/service support:
  - `internal/timeline/schema.go`
  - `internal/timeline/service.go`
  - `internal/timeline/service_task_test.go`

Behavior:
- Enforces gated subtask progression
- Validates required outputs before release of next stage
- Supports deterministic retry and failure paths
- Persists transitions for auditability and idempotent replay

### 2. Per-Agent Configure Gating

- Added per-agent cascade config model:
  - `internal/config/config.go`
- Preserved non-empty `agents.list` during loader cleanup:
  - `internal/config/loader.go`
- Added config test coverage:
  - `internal/config/config_test.go`
- Added guided configure flow with explicit enable/disable and warning copy:
  - `internal/cli/configure.go`
  - `internal/cli/configure_test.go`
- Updated docs:
  - `docs/reference/cli-reference.md`
  - `docs/reference/config-keys.md`

Behavior:
- Cascade is configured per agent
- Configure flow explicitly warns this is best for deterministic workloads
- Default behavior remains unchanged unless enabled

### 3. Docs 

- Added dedicated CoT page with explanation, use cases, non-use cases, implications, and infographic:
  - `docs/agent-concepts/CoT.md`
- Kept memory notes concise and linked to the dedicated CoT page:
  - `docs/agent-concepts/memory-notes.md`
- Reorganized docs ownership:
  - Agent Concepts promoted to top-level section
  - Timeline architecture moved under Architecture and Security
  - Knowledge Contracts moved under Reference
  - Memory Management index now focuses on memory-owned content with related links
- Updated navigation and landing pages:
  - `docs/index.md`
  - `docs/agent-concepts/index.md`
  - `docs/memory-management/index.md`
  - `docs/architecture-security/architecture-timeline.md`
  - `docs/reference/knowledge-contracts.md`
  - plus top-level nav order normalization across section indexes

## Why

- Prevent context drift and copy-of-copy degradation in multi-step agent tasks
- Make deterministic, validated workflows first class
- Keep risky behavior opt-in and scoped per agent
- Reduce documentation confusion by aligning content with clear domain ownership

## Testing and Quality

Executed and passing before merge:
- `make fmt-check`
- `go test ./...`
- `go test -race ./...`
- `make test-critical`

Coverage targets addressed:
- Critical components: targeted at 100%
- Overall components: targeted at >80%

## Rollout Notes

- Enable cascade only on deterministic agents (ops/runbook/config/code-mod).
- Keep cascade disabled for exploratory or conversational agents.
- Use `kafclaw configure` to set per-agent enablement safely.

## Risks

- Additional latency and compute cost from stage gating and validation
- Possible throughput reduction when contracts are underspecified
- Misconfiguration risk if enabled broadly for non-deterministic workloads
